### PR TITLE
[Feat] Enable `triton_tvm_ffi` Wrappers for `w8a8_block_fp8_matmul`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ nvidia = [
     "torchvision==0.24.0+cu128",
     "torchaudio==2.9.0+cu128",
     "flagtree==0.5.0+3.5",
+    "triton-tvm-ffi @ git+https://github.com/sgjzfzzf/triton-tvm-ffi.git",
 ]
 
 tsingmicro = [

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_matmul.cc
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_matmul.cc
@@ -1,0 +1,61 @@
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/tvm_ffi.h>
+#include <cstdint>
+
+#ifndef W8A8_BLOCK_FP8_MATMUL_KERNEL_GENERAL_STUB
+#define W8A8_BLOCK_FP8_MATMUL_KERNEL_GENERAL_STUB(grid, device, stream, args, kwargs)
+#endif
+
+#ifndef W8A8_BLOCK_FP8_MATMUL_GENERAL_TVM_FFI_NAME
+#define W8A8_BLOCK_FP8_MATMUL_GENERAL_TVM_FFI_NAME ""
+#endif
+
+tvm::ffi::Tensor W8A8BlockFp8MatmulGeneral(tvm::ffi::Tensor a,
+                                           tvm::ffi::Tensor b,
+                                           tvm::ffi::Tensor c,
+                                           tvm::ffi::Tensor as,
+                                           tvm::ffi::Tensor bs,
+                                           int32_t m,
+                                           int32_t n,
+                                           int32_t k,
+                                           int32_t group_n,
+                                           int32_t group_k,
+                                           int32_t stride_am,
+                                           int32_t stride_ak,
+                                           int32_t stride_bk,
+                                           int32_t stride_bn,
+                                           int32_t stride_cm,
+                                           int32_t stride_cn,
+                                           int32_t stride_as_m,
+                                           int32_t stride_as_k,
+                                           int32_t stride_bs_k,
+                                           int32_t stride_bs_n) {
+  tvm::ffi::Function grid =
+      tvm::ffi::Function::FromTyped([m, n](const tvm::ffi::Map<tvm::ffi::String, tvm::ffi::Any>& meta)
+                                        -> tvm::ffi::Tuple<int32_t, int32_t, int32_t> {
+        const int32_t block_m = meta["BLOCK_M"].cast<int32_t>();
+        const int32_t block_n = meta["BLOCK_N"].cast<int32_t>();
+        const int32_t grid_m = (m + block_m - 1) / block_m;
+        const int32_t grid_n = (n + block_n - 1) / block_n;
+        return tvm::ffi::Tuple(grid_m * grid_n, 1, 1);
+      });
+
+  DLDevice device = a.device();
+  void* stream = TVMFFIEnvGetStream(device.device_type, device.device_id);
+
+  tvm::ffi::Array<tvm::ffi::Any> args = {
+      a,         b,         c,           as,          bs,          m,           n,
+      k,         group_n,   group_k,     stride_am,   stride_ak,   stride_bk,   stride_bn,
+      stride_cm, stride_cn, stride_as_m, stride_as_k, stride_bs_k, stride_bs_n,
+  };
+  tvm::ffi::Map<tvm::ffi::String, tvm::ffi::Any> kwargs = {};
+
+  W8A8_BLOCK_FP8_MATMUL_KERNEL_GENERAL_STUB(grid, device.device_id, stream, args, kwargs);
+  return c;
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def(W8A8_BLOCK_FP8_MATMUL_GENERAL_TVM_FFI_NAME, W8A8BlockFp8MatmulGeneral);
+}

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_matmul.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_matmul.py
@@ -1,11 +1,13 @@
 import functools
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import torch
 import triton
 import triton.language as tl
+import triton_tvm_ffi
 import yaml
 
 from flag_gems import runtime
@@ -155,7 +157,7 @@ def matmul_tma_set_block_size_hook(nargs):
     nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
 
 
-@libentry()
+@triton_tvm_ffi.jit
 @libtuner(
     configs=runtime.ops_get_configs(
         "w8a8_block_fp8_general",
@@ -173,7 +175,25 @@ def matmul_tma_set_block_size_hook(nargs):
     warmup=5,
     rep=5,
 )
-@triton.jit
+@triton.jit(
+    do_not_specialize=[
+        "M",
+        "N",
+        "K",
+        "group_n",
+        "group_k",
+        "stride_am",
+        "stride_ak",
+        "stride_bk",
+        "stride_bn",
+        "stride_cm",
+        "stride_cn",
+        "stride_As_m",
+        "stride_As_k",
+        "stride_Bs_k",
+        "stride_Bs_n",
+    ]
+)
 def w8a8_block_fp8_matmul_kernel_general(
     A,
     B,
@@ -345,6 +365,38 @@ def w8a8_block_fp8_matmul_kernel_host_tma(
     c_desc.store([offset_am, offset_bn], acc.to(c_desc.dtype))
 
 
+@triton_tvm_ffi.torch_wrap(
+    [w8a8_block_fp8_matmul_kernel_general],
+    Path(__file__).with_suffix(".cc"),
+    extra_include_paths=[
+        str(Path(triton_tvm_ffi.__file__).resolve().parents[2] / "include")
+    ],
+)
+def w8a8_block_fp8_matmul_general_tvm_ffi(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    As: torch.Tensor,
+    Bs: torch.Tensor,
+    M: int,
+    N: int,
+    K: int,
+    group_n: int,
+    group_k: int,
+    stride_am: int,
+    stride_ak: int,
+    stride_bk: int,
+    stride_bn: int,
+    stride_cm: int,
+    stride_cn: int,
+    stride_As_m: int,
+    stride_As_k: int,
+    stride_Bs_k: int,
+    stride_Bs_n: int,
+) -> torch.Tensor:
+    ...
+
+
 def general_w8a8_block_fp8_matmul(a, b, c, a_s, b_s, M, N, K, group_n, group_k):
     logger.debug(
         "GEMS w8a8_block_fp8_matmul-hopper, [scenario]: general, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
@@ -355,19 +407,18 @@ def general_w8a8_block_fp8_matmul(a, b, c, a_s, b_s, M, N, K, group_n, group_k):
         a.stride(0) == 1,
         b.stride(0) == 1,
     )
-    grid = lambda meta: (
-        triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
-    )
-    use_flagtune = os.environ.get("USE_FLAGTUNE") == "1"
-    fixed_meta = (
-        None
-        if use_flagtune
-        else _get_fixed_matmul_meta(M, N, K, block_n=group_n, block_k=group_k)
-    )
-
     if hasattr(
         triton.tools.tensor_descriptor, "TensorDescriptor"
     ) and is_tma_compatible(a, b, N, K):
+        grid = lambda meta: (
+            triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
+        )
+        use_flagtune = os.environ.get("USE_FLAGTUNE") == "1"
+        fixed_meta = (
+            None
+            if use_flagtune
+            else _get_fixed_matmul_meta(M, N, K, block_n=group_n, block_k=group_k)
+        )
         a_row_major = a.stride(1) == 1
         b_row_major = b.stride(1) == 1
         dummy_block = [1, 1]
@@ -457,61 +508,29 @@ def general_w8a8_block_fp8_matmul(a, b, c, a_s, b_s, M, N, K, group_n, group_k):
         with torch_device_fn.device(a.device):
             launch()
     else:
-
-        def alloc_fn(size: int, align: int, stream: Optional[int]):
-            return torch.empty(size, dtype=torch.int8, device=a.device)
-
-        triton.set_allocator(alloc_fn)
-        if use_flagtune:
-            launch = lambda: w8a8_block_fp8_matmul_kernel_general[grid](
-                a,
-                b,
-                c,
-                a_s,
-                b_s,
-                M,
-                N,
-                K,
-                group_n,
-                group_k,
-                a.stride(0),
-                a.stride(1),
-                b.stride(1),
-                b.stride(0),
-                c.stride(0),
-                c.stride(1),
-                a_s.stride(0),
-                a_s.stride(1),
-                b_s.stride(1),
-                b_s.stride(0),
-            )
-        else:
-            launch = lambda: w8a8_block_fp8_matmul_kernel_general.fn.fn[grid](
-                a,
-                b,
-                c,
-                a_s,
-                b_s,
-                M,
-                N,
-                K,
-                group_n,
-                group_k,
-                a.stride(0),
-                a.stride(1),
-                b.stride(1),
-                b.stride(0),
-                c.stride(0),
-                c.stride(1),
-                a_s.stride(0),
-                a_s.stride(1),
-                b_s.stride(1),
-                b_s.stride(0),
-                **fixed_meta,
-            )
-
         with torch_device_fn.device(a.device):
-            launch()
+            w8a8_block_fp8_matmul_general_tvm_ffi(
+                a,
+                b,
+                c,
+                a_s,
+                b_s,
+                M,
+                N,
+                K,
+                group_n,
+                group_k,
+                a.stride(0),
+                a.stride(1),
+                b.stride(1),
+                b.stride(0),
+                c.stride(0),
+                c.stride(1),
+                a_s.stride(0),
+                a_s.stride(1),
+                b_s.stride(1),
+                b_s.stride(0),
+            )
     return c
 
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR introduces `triton_tvm_ffi` to enable autotuning for C++ runtime.

To compatible `triton_tvm_ffi`, `libentry` is disabled and all parameters should be "not specialized".

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

```bash
# default
Operator: w8a8_block_fp8_matmul  Performance Test (dtype=fp8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               0.007200            0.006496               1.108               0.323          [torch.Size([64, 128]), torch.Size([128, 128]), torch.Size([64, 1]), torch.Size([1, 1]), [128, 128], torch.float16]
SUCCESS               0.010400            0.007680               1.354               4.369          [torch.Size([128, 512]), torch.Size([256, 512]), torch.Size([128, 4]), torch.Size([2, 4]), [128, 128], torch.float16]
SUCCESS               0.074816            0.030784               2.430               1.907          [torch.Size([1, 7168]), torch.Size([4096, 7168]), torch.Size([1, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.073968            0.028640               2.583              32.805          [torch.Size([16, 7168]), torch.Size([4096, 7168]), torch.Size([16, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.074080            0.032064               2.310             117.206          [torch.Size([64, 7168]), torch.Size([4096, 7168]), torch.Size([64, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.938800            0.170176               5.517              29.355          [torch.Size([83, 3884]), torch.Size([7748, 3884]), torch.Size([83, 31]), torch.Size([61, 31]), [128, 128], torch.float16]
SUCCESS               0.984864            0.204576               4.814              22.863          [torch.Size([84, 3884]), torch.Size([7168, 3884]), torch.Size([84, 31]), torch.Size([56, 31]), [128, 128], torch.float16]
```

```bash
# triton-tvm-ffi
Operator: w8a8_block_fp8_matmul  Performance Test (dtype=fp8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               0.007072            0.048128               0.147               0.044          [torch.Size([64, 128]), torch.Size([128, 128]), torch.Size([64, 1]), torch.Size([1, 1]), [128, 128], torch.float16]
SUCCESS               0.010432            0.014144               0.738               2.372          [torch.Size([128, 512]), torch.Size([256, 512]), torch.Size([128, 4]), torch.Size([2, 4]), [128, 128], torch.float16]
SUCCESS               0.074816            0.086272               0.867               0.681          [torch.Size([1, 7168]), torch.Size([4096, 7168]), torch.Size([1, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.073376            0.121984               0.602               7.702          [torch.Size([16, 7168]), torch.Size([4096, 7168]), torch.Size([16, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.073984            0.258080               0.287              14.562          [torch.Size([64, 7168]), torch.Size([4096, 7168]), torch.Size([64, 56]), torch.Size([32, 56]), [128, 128], torch.float16]
SUCCESS               0.931968            0.316160               2.948              15.800          [torch.Size([83, 3884]), torch.Size([7748, 3884]), torch.Size([83, 31]), torch.Size([61, 31]), [128, 128], torch.float16]
SUCCESS               0.972112            0.308832               3.148              15.145          [torch.Size([84, 3884]), torch.Size([7168, 3884]), torch.Size([84, 31]), torch.Size([56, 31]), [128, 128], torch.float16]
```