### PR TITLE
[KernelGen][Nvidia] Fix top_k_per_row_prefill standards compliance

### DIFF
--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -8,9 +8,8 @@ Shapes match DeepSeek V4 production config:
     - num_rows=64: larger prefill batch
     - num_rows=2048: max prefill sequence length
 
-The torch reference uses torch.topk directly (no masking), representing the
-theoretical minimum for selection-only. The Triton kernel additionally handles
-masking and index adjustment.
+The baseline uses vLLM's persistent_topk CUDA kernel when available,
+falling back to torch.topk for the selection-only theoretical minimum.
 """
 
 import pytest
@@ -28,16 +27,38 @@ pytestmark = pytest.mark.skipif(
     reason="CUDA device required",
 )
 
+# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
+
+
+def _torch_topk_ref(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+):
+    """Pure-PyTorch fallback: torch.topk on full vocab (no masking)."""
+    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
+    indices.copy_(top_idx.to(torch.int32))
+
+
+_baseline_op = _vllm_top_k_per_row_prefill if HAS_VLLM else _torch_topk_ref
+
 
 class TopKPerRowPrefillBenchmark(base.Benchmark):
     DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k"
 
     def set_shapes(self, shape_file_path=None):
-        # DeepSeek V4 production shapes:
-        # - (1, 129280, 1024): decode path, single token, latency-critical
-        # - (32, 129280, 1024): typical prefill micro-batch
-        # - (64, 129280, 1024): larger prefill batch
-        # - (2048, 129280, 1024): max sequence length prefill
         self.shapes = [
             (1, 129280, 1024),
             (32, 129280, 1024),
@@ -50,31 +71,22 @@ class TopKPerRowPrefillBenchmark(base.Benchmark):
             logits = torch.randn(
                 num_rows, vocab_size, device=device, dtype=torch.float32
             )
-            # Full vocab range: row_starts=0, row_ends=vocab_size (common case)
             row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
             row_ends = torch.full(
                 (num_rows,), vocab_size, dtype=torch.int32, device=device
             )
-            # Pre-allocated output buffer (matches vLLM calling convention)
             indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-            stride0 = logits.stride(0)  # = vocab_size for contiguous
-            stride1 = logits.stride(1)  # = 1 for contiguous
+            stride0 = logits.stride(0)
+            stride1 = logits.stride(1)
 
             yield logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-
-
-def _torch_topk_ref(
-    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-):
-    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
 
 
 @pytest.mark.top_k_per_row_prefill
 def test_top_k_per_row_prefill():
     bench = TopKPerRowPrefillBenchmark(
         op_name="top_k_per_row_prefill",
-        torch_op=_torch_topk_ref,
+        torch_op=_baseline_op,
         gems_op=top_k_per_row_prefill,
         dtypes=[torch.float32],
     )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5931,6 +5931,7 @@ ops:
       - None
     labels:
       - fused
+      - KernelGen
     kind:
       - NeuralNetwork
     stages:

--- a/src/flag_gems/fused/top_k_per_row_prefill.py
+++ b/src/flag_gems/fused/top_k_per_row_prefill.py
@@ -25,19 +25,33 @@ Performance (DeepSeek V4 config, vocab=129280, top_k=1024):
     - num_rows=32: 0.38x vs vLLM CUDA (bounded by torch.topk on large vocab)
 """
 
+import logging
+
 import torch
 import triton
 import triton.language as tl
 
+logger = logging.getLogger(__name__)
 
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 16384}, num_warps=4),
+    ],
+    key=["vocab_size"],
+)
 @triton.jit
 def _mask_invalid_kernel(
     logits_ptr,
     row_starts_ptr,
     row_ends_ptr,
-    stride0,  # logits row stride (= vocab_size for contiguous tensor)
-    BLOCK_SIZE: tl.constexpr,  # 8192: tuned for 129280 vocab (16 blocks/row)
-    VOCAB_SIZE: tl.constexpr,  # total vocabulary size (e.g. 129280)
+    stride0,
+    num_rows,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
 ):
     """Mask logits outside [row_starts[i], row_ends[i]) to -inf, in-place.
 
@@ -46,7 +60,7 @@ def _mask_invalid_kernel(
     Early exits when the row uses full vocab to avoid unnecessary stores.
     """
     pid = tl.program_id(0)
-    num_blocks_per_row = tl.cdiv(VOCAB_SIZE, BLOCK_SIZE)
+    num_blocks_per_row = tl.cdiv(vocab_size, BLOCK_SIZE)
     row_id = pid // num_blocks_per_row
     block_id = pid % num_blocks_per_row
 
@@ -55,27 +69,27 @@ def _mask_invalid_kernel(
 
     # Early exit: most rows in inference use full vocab (start=0, end=vocab_size).
     # Skipping these avoids ~90% of memory writes in typical workloads.
-    if start == 0 and end >= VOCAB_SIZE:
+    if start == 0 and end >= vocab_size:
         return
 
     # Compute which positions in this block are outside the valid range
     offs = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     out_of_range = (offs < start) | (offs >= end)
     # Only write to positions that are both within vocab bounds AND out of valid range
-    mask = (offs < VOCAB_SIZE) & out_of_range
+    mask = (offs < vocab_size) & out_of_range
 
     tl.store(logits_ptr + row_id * stride0 + offs, float("-inf"), mask=mask)
 
 
 @triton.jit
 def _fused_postprocess_kernel(
-    src_ptr,  # source indices (from argsort or topk)
-    dst_ptr,  # destination: output indices buffer [num_rows, top_k]
-    row_starts_ptr,  # per-row start offsets for index adjustment
+    src_ptr,
+    dst_ptr,
+    row_starts_ptr,
     num_rows: tl.constexpr,
-    top_k: tl.constexpr,  # 1024 in DeepSeek V4
-    src_stride0: tl.constexpr,  # row stride of src (vocab_size for argsort, top_k for topk)
-    BLOCK_SIZE: tl.constexpr,  # next_power_of_2(top_k), e.g. 1024
+    top_k: tl.constexpr,
+    src_stride0: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
     """Fused slice + cast + subtract: convert absolute indices to row-relative.
 
@@ -122,31 +136,28 @@ def top_k_per_row_prefill(
         stride1: logits.stride(1), typically == 1 for contiguous tensor.
         top_k: number of top elements per row (1024 in DeepSeek V4).
     """
+    logger.debug("GEMS TOP_K_PER_ROW_PREFILL")
+
     vocab_size = logits.shape[1]
 
     if top_k > vocab_size:
         raise ValueError(f"top_k ({top_k}) must not exceed vocab_size ({vocab_size})")
 
     # --- Phase 1: Mask invalid ranges to -inf ---
-    # BLOCK_SIZE=8192 chosen to balance occupancy vs. grid size:
-    # For vocab=129280, this gives ceil(129280/8192)=16 blocks per row.
-    # num_warps=2 is sufficient since masking is memory-bound (simple store).
-    MASK_BS = 8192
-    num_mask_blocks = (vocab_size + MASK_BS - 1) // MASK_BS
-    _mask_invalid_kernel[(num_rows * num_mask_blocks,)](
+    grid = lambda META: (num_rows * triton.cdiv(vocab_size, META["BLOCK_SIZE"]),)
+    _mask_invalid_kernel[grid](
         logits,
         row_starts,
         row_ends,
         stride0,
-        BLOCK_SIZE=MASK_BS,
-        VOCAB_SIZE=vocab_size,
-        num_warps=2,
+        num_rows,
+        vocab_size,
     )
 
     # --- Phase 2: Select top-K indices ---
     # POSTPROC_BLOCK must be power-of-2 >= top_k for tl.arange.
-    # For top_k=1024, this is exactly 1024 (no waste).
     POSTPROC_BLOCK = triton.next_power_of_2(top_k)
+    num_warps_post = min(max(POSTPROC_BLOCK // 256, 1), 8)
 
     if num_rows == 1:
         # Single row path: torch.argsort uses CUB radix sort under the hood.
@@ -154,7 +165,6 @@ def top_k_per_row_prefill(
         # than torch.topk's heap-based O(N log k) because it fully utilizes GPU
         # parallelism without the sequential heap maintenance bottleneck.
         sorted_idx = torch.argsort(logits, dim=1, descending=True, stable=False)
-        # src_stride0=vocab_size because argsort returns full-width sorted indices
         _fused_postprocess_kernel[(1,)](
             sorted_idx,
             indices,
@@ -163,7 +173,7 @@ def top_k_per_row_prefill(
             top_k=top_k,
             src_stride0=vocab_size,
             BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=4,
+            num_warps=num_warps_post,
         )
     else:
         # Multi-row path: torch.topk with sorted=False.
@@ -171,7 +181,6 @@ def top_k_per_row_prefill(
         # than argsort (which serializes the full sort per row).
         # sorted=False avoids an unnecessary final sort pass.
         _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-        # src_stride0=top_k because topk output shape is [num_rows, top_k]
         _fused_postprocess_kernel[(num_rows,)](
             top_idx,
             indices,
@@ -180,5 +189,5 @@ def top_k_per_row_prefill(
             top_k=top_k,
             src_stride0=top_k,
             BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=4,
+            num_warps=num_warps_post,
         )

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn.functional as F
 
 import flag_gems
-from flag_gems.fused import top_k_per_row_prefill
 from flag_gems.patches.patch_util import patch_module_method, patch_vllm_lib
 
 
@@ -440,14 +439,6 @@ def custom_cutlass_scaled_mm(
     return flag_gems.cutlass_scaled_mm(output, input, weight, scale_a, scale_b, bias)
 
 
-def custom_top_k_per_row_prefill(
-    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-):
-    top_k_per_row_prefill(
-        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-    )
-
-
 def custom_concat_and_cache_mla(
     kv_c: torch.Tensor,
     k_pe: torch.Tensor,
@@ -637,7 +628,6 @@ def apply_gems_patches_to_vllm(verbose=True):
         ("_moe_C", "grouped_topk", custom_moe_grouped_topk),
         ("_C", "per_token_group_fp8_quant", custom_per_token_group_fp8_quant),
         ("_C", "apply_repetition_penalties_", custom_apply_repetition_penalties),
-        ("_C", "top_k_per_row_prefill", custom_top_k_per_row_prefill),
         ("_C_cache_ops", "concat_and_cache_mla", custom_concat_and_cache_mla),
     ]
     for lib_name, fn_name, fn in lib_patches:

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -1,7 +1,8 @@
 """Accuracy tests for top_k_per_row_prefill (DeepSeek V4 sparse attention).
 
-Tests the Triton kernel against a pure-PyTorch reference implementation.
-Verifies that the selected top-K values match (set comparison, order-independent).
+Tests the Triton kernel against vLLM CUDA reference (when available) and a
+pure-PyTorch fallback. Verifies that the selected top-K values match
+(set comparison, order-independent).
 
 Test shapes match DeepSeek V4 production config:
     - vocab_size=129280: DeepSeek V4 vocabulary size
@@ -16,12 +17,40 @@ import torch
 import flag_gems
 from flag_gems.fused import top_k_per_row_prefill
 
+from . import conftest as cfg
+
 device = flag_gems.device
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA device required",
 )
+
+# --- Shape configuration with QUICK_MODE support ---
+if cfg.QUICK_MODE:
+    NUM_ROWS_LIST = [1, 32]
+    VOCAB_SIZE_LIST = [129280]
+    TOP_K_LIST = [1024]
+else:
+    NUM_ROWS_LIST = [1, 32, 64, 2048]
+    VOCAB_SIZE_LIST = [20000, 129280]
+    TOP_K_LIST = [1024, 2048]
+
+# --- vLLM CUDA reference (optional) ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
 
 
 def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
@@ -39,7 +68,6 @@ def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
         row_slice = logits[i, start:end]
         k = min(top_k, end - start)
         _, topk_idx = torch.topk(row_slice, k, largest=True, sorted=False)
-        # topk_idx is already 0-based relative to start (since we sliced)
         indices[i, :k] = topk_idx.to(torch.int32)
         if k < top_k:
             indices[i, k:] = -1
@@ -51,26 +79,21 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
     """Value-based set comparison: verify that the actual logit values selected
     by test indices match those selected by reference indices.
 
-    This is order-independent — we only care that the same top-K values are found,
-    not that they appear in the same order. This is important because argsort and
-    topk may break ties differently.
+    Order-independent — we only care that the same top-K values are found,
+    not that they appear in the same order (argsort and topk break ties differently).
     """
     num_rows = logits.shape[0]
     for i in range(num_rows):
         offset = row_starts[i].item()
-        # Convert 0-based row-relative indices back to absolute vocab indices
         abs_test = indices_test[i].long() + offset
         abs_ref = indices_ref[i].long() + offset
 
-        # Filter out padding (-1 + offset could be invalid)
         valid_test = abs_test[abs_test >= offset]
         valid_ref = abs_ref[abs_ref >= offset]
 
         vals_test = logits[i].gather(0, valid_test)
         vals_ref = logits[i].gather(0, valid_ref)
 
-        # Sort values descending and compare — if same top-K values are selected,
-        # sorted arrays must match regardless of index order
         vals_test_sorted, _ = vals_test.sort(descending=True)
         vals_ref_sorted, _ = vals_ref.sort(descending=True)
 
@@ -80,15 +103,18 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.parametrize("num_rows", [1, 32, 64, 2048])
-@pytest.mark.parametrize("vocab_size", [129280])  # DeepSeek V4 vocab size
-@pytest.mark.parametrize("top_k", [1024])  # DeepSeek V4 KV cache topk
+@pytest.mark.parametrize("num_rows", NUM_ROWS_LIST)
+@pytest.mark.parametrize("vocab_size", VOCAB_SIZE_LIST)
+@pytest.mark.parametrize("top_k", TOP_K_LIST)
 def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     """Test with full vocab range (row_starts=0, row_ends=vocab_size).
 
     This is the most common case in inference: every token sees the full vocabulary.
     The masking kernel should early-exit for all rows.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(42)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
@@ -97,7 +123,6 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
 
-    # Reference uses a clone because the Triton kernel modifies logits in-place
     indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
 
     indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
@@ -111,13 +136,9 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.parametrize("num_rows", [1, 32])
-@pytest.mark.parametrize(
-    "vocab_size", [20000, 129280]  # 20000: smaller vocab for edge case coverage
-)
-@pytest.mark.parametrize(
-    "top_k", [1024, 2048]  # 2048: tests larger top_k (used in some configs)
-)
+@pytest.mark.parametrize("num_rows", NUM_ROWS_LIST[:2])
+@pytest.mark.parametrize("vocab_size", VOCAB_SIZE_LIST)
+@pytest.mark.parametrize("top_k", TOP_K_LIST)
 def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     """Test with variable row lengths (partial vocab per row).
 
@@ -125,11 +146,13 @@ def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     KV ranges (e.g., due to causal masking or sequence packing).
     row_ends is randomized in [top_k, vocab_size] to ensure enough valid elements.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(123)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
     row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
-    # Ensure row_ends >= top_k so there are enough valid elements to select
     row_ends = torch.randint(
         top_k, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
@@ -154,17 +177,14 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     """Test with non-zero row_starts.
 
     Verifies the index subtraction logic: output indices must be 0-based relative
-    to row_starts[i], not absolute vocab positions. This catches off-by-one errors
-    in the _fused_postprocess_kernel.
+    to row_starts[i], not absolute vocab positions.
     """
     torch.manual_seed(456)
     vocab_size = 50000
     top_k = 1024
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
-    # row_starts in [0, 1000): simulates offset within a packed sequence
     row_starts = torch.randint(0, 1000, (num_rows,), dtype=torch.int32, device=device)
-    # row_ends in [top_k+1000, vocab_size]: ensures enough valid range after start
     row_ends = torch.randint(
         top_k + 1000, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
@@ -181,3 +201,43 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     assert check_topk_values_match(
         logits, indices_test, indices_ref, row_starts, top_k
     ), f"FAIL: num_rows={num_rows}, nonzero starts"
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("num_rows", [1, 32, 64])
+def test_top_k_per_row_prefill_vs_vllm(num_rows):
+    """Test against vLLM CUDA kernel (persistent_topk)."""
+    torch.manual_seed(789)
+    vocab_size = 129280
+    top_k = 1024
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    # vLLM CUDA reference
+    logits_vllm = logits.clone()
+    indices_vllm = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    _vllm_top_k_per_row_prefill(
+        logits_vllm,
+        row_starts,
+        row_ends,
+        indices_vllm,
+        num_rows,
+        stride0,
+        stride1,
+        top_k,
+    )
+
+    # FlagGems Triton kernel
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_vllm, row_starts, top_k
+    ), f"FAIL vs vLLM: num_rows={num_rows}"


### PR DESCRIPTION
## Summary

Fix top_k_per_row_prefill (#3279) to meet code standards:
- Add `logger.debug("GEMS TOP_K_PER_ROW_PREFILL")` per FlagGems convention
- Replace hardcoded `BLOCK_SIZE=8192`/`num_warps=2/4` with `@triton.autotune` for mask kernel
- Use dynamic `num_warps` calculation for postprocess kernel
- Add `QUICK_MODE` support in tests (from conftest)
- Add vLLM CUDA reference (`torch.ops._C.top_k_per_row_prefill`) in test and benchmark with graceful fallback
- Add `KernelGen` label in `operators.yaml`
- Revert `patch_vllm_all.py` changes (separate concern)

## Correctness

Verified against torch.topk reference (atol=1e-6, rtol=1e-6):
- Shapes: vocab_size=[20000, 129280], top_k=[1024, 2048], num_rows=[1, 32, 64, 2048]
- Tests: full vocab, variable row lengths, non-zero row_starts
- Additional vs-vLLM test when vLLM is installed

## Performance (DeepSeek V4: vocab=129280, top_k=1024, H20 GPU)

| num_rows | Triton (us) | vLLM CUDA (us) | Speedup |
|----------|-------------|----------------|---------|
| 1        | 56.7        | 50.8           | 0.90x   |
| 32       | 127.8       | 52.6           | 0.41x   |
| 64       | 184.2       | 53.0           | 0.29x   |
| 2048     | 4822.6      | 851.4          | 0.18x   |

## Files Changed

- `src/flag_gems/fused/top_k_per_row_prefill.py` — add logger, @triton.autotune, dynamic num_warps
- `tests/test_top_k_per_row_prefill.py` — QUICK_MODE, vLLM reference, module-level shape lists
- `benchmark/test_top_k_per_row_prefill.py` — vLLM reference with PyTorch fallback
- `conf/operators.yaml` — add KernelGen label
- `src/flag_gems/patches/patch_vllm_all.py` — revert extra change from #3279