### PR TITLE
[FlagGems Operator Development Competition] Add upsample_nearest2d_backward operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -525,6 +525,7 @@ _FULL_CONFIG = (
     ("upsample_linear1d", upsample_linear1d),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("upsample_nearest2d_backward", upsample_nearest2d_backward),
     ("upsample_nearest3d", upsample_nearest3d),
     ("var_mean.correction", var_mean),
     ("var", var),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -368,7 +368,7 @@ from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
 from flag_gems.ops.upsample_bicubic2d_aa_backward import _upsample_bicubic2d_aa_backward
 from flag_gems.ops.upsample_linear1d import upsample_linear1d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
-from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.upsample_nearest2d import upsample_nearest2d, upsample_nearest2d_backward
 from flag_gems.ops.upsample_nearest3d import upsample_nearest3d
 from flag_gems.ops.var import var, var_correction, var_dim
 from flag_gems.ops.var_mean import var_mean
@@ -862,6 +862,7 @@ __all__ = [
     "upsample_linear1d",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "upsample_nearest2d_backward",
     "upsample_nearest3d",
     "var_mean",
     "var",

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -66,6 +66,89 @@ def upsample_nearest2d_kernel(
         nc_iter += nc_stride
 
 
+@triton.jit
+def upsample_nearest2d_backward_kernel(
+    ptr_go,
+    ptr_gi,
+    n_elements_grad_out,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < n_elements_grad_out
+
+    # Decode flat index into (n, c, oh, ow)
+    ow = idx % OW
+    tmp = idx // OW
+    oh = tmp % OH
+    tmp2 = tmp // OH
+    nc = tmp2
+
+    # Map output position to input position (nearest neighbor)
+    ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
+    iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+
+    # Input flat index
+    offset_gi = (nc * IH + ih) * IW + iw
+
+    grad = tl.load(ptr_go + idx, mask=mask)
+    tl.atomic_add(ptr_gi + offset_gi, grad, mask=mask)
+
+
+def upsample_nearest2d_backward(
+    grad_output: torch.Tensor,
+    output_size: Tuple[int],
+    input_size: Tuple[int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE NEAREST2D BACKWARD")
+    assert grad_output.ndim == 4
+    assert len(output_size) == 2
+    assert len(input_size) == 4
+    OH, OW = output_size
+    N, C, IH, IW = input_size
+    if scales_h is not None:
+        reciprocal_scale_h = 1 / scales_h
+    else:
+        reciprocal_scale_h = IH / OH
+    if scales_w is not None:
+        reciprocal_scale_w = 1 / scales_w
+    else:
+        reciprocal_scale_w = IW / OW
+
+    grad_output = grad_output.contiguous()
+    grad_input = torch.zeros(
+        (N, C, IH, IW), device=grad_output.device, dtype=grad_output.dtype
+    )
+    n_elements = grad_output.numel()
+    if n_elements == 0:
+        return grad_input
+
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    with torch_device_fn.device(grad_output.device):
+        upsample_nearest2d_backward_kernel[grid](
+            grad_output,
+            grad_input,
+            n_elements,
+            OH,
+            OW,
+            IH,
+            IW,
+            reciprocal_scale_h,
+            reciprocal_scale_w,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+    return grad_input
+
+
 def upsample_nearest2d(
     input: torch.Tensor,
     output_size: Tuple[int],


### PR DESCRIPTION
## Summary

- Add Triton backward kernel for `upsample_nearest2d` using `atomic_add` for gradient scatter
- Register as `aten::upsample_nearest2d_backward` matching the ATen schema
- Support float32 and float16

## Implementation Details

Nearest neighbor upsampling backward is a scatter-sum operation:
- Forward: each input pixel is copied to a block of output pixels
- Backward: gradients from output pixels are accumulated (via atomic_add) to the corresponding input pixel

The kernel decodes the flat gradient output index into `(n, c, oh, ow)`, computes the corresponding input position `(ih, iw)` using the same nearest-neighbor mapping, and atomically adds the gradient.

## Testing

- All 60 existing `test_upsample_nearest2d.py` tests pass (forward unchanged)
- Backward correctness verified with `torch.allclose` against PyTorch reference for float32 and float16, with 2x and 3x upscale factors
- Tested on NVIDIA RTX PRO 6000 Blackwell (CUDA 13.2, PyTorch 2.11, Triton 3.6)