### PR TITLE
[FlagGems Operator Development Competition] Add mse_loss_backward

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -355,6 +355,7 @@ _FULL_CONFIG = (
     ("mm", mm),
     ("mm.out", mm_out),
     ("mse_loss", mse_loss),
+    ("mse_loss_backward", mse_loss_backward),
     ("mul.Tensor", mul),
     ("mul_.Tensor", mul_),
     ("multinomial", multinomial),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -234,7 +234,7 @@ from flag_gems.ops.median import median, median_dim, median_dim_values, median_o
 from flag_gems.ops.min import min, min_dim
 from flag_gems.ops.minimum import minimum
 from flag_gems.ops.mm import mm, mm_out, router_gemm
-from flag_gems.ops.mse_loss import mse_loss
+from flag_gems.ops.mse_loss import mse_loss, mse_loss_backward
 from flag_gems.ops.mul import mul, mul_
 from flag_gems.ops.multinomial import multinomial
 from flag_gems.ops.mv import mv
@@ -692,6 +692,7 @@ __all__ = [
     "mm",
     "mm_out",
     "mse_loss",
+    "mse_loss_backward",
     "mul",
     "mul_",
     "multinomial",

--- a/src/flag_gems/ops/mse_loss.py
+++ b/src/flag_gems/ops/mse_loss.py
@@ -79,3 +79,15 @@ def mse_loss(inp, target, reduction=Reduction.MEAN.value):
         kernel_1[(mid_size, 1, 1)](inp, target, mid, M, block_size, reduction)
         kernel_2[(1, 1, 1)](mid, out, mid_size, block_mid)
     return out
+
+
+def mse_loss_backward(grad_output, input, target, reduction=Reduction.MEAN.value):
+    logger.debug("GEMS MSE LOSS BACKWARD")
+    # d/dx mse_loss = 2 * (input - target) * grad_output
+    # For mean: divide by n_elements
+    diff = input - target
+    grad_input = 2 * grad_output * diff
+    if reduction == Reduction.MEAN.value:
+        n_elements = input.numel()
+        grad_input = grad_input / n_elements
+    return grad_input


### PR DESCRIPTION
## Summary
- Add `mse_loss_backward` with ATen dispatch registration
- Supports all three reduction modes: none, mean, sum

## Implementation Details
Formula: `grad_input = 2 * (input - target) * grad_output`
- For mean reduction: additionally divides by number of elements
- Uses standard PyTorch tensor operations for element-wise computation

## Testing
All tests passed on NVIDIA RTX PRO 6000 Blackwell:
```
none match: True
mean match: True  
sum match: True
random grad none match: True
```

## Hardware Environment
- GPU: NVIDIA RTX PRO 6000 Blackwell
- PyTorch: 2.11+cu128
- Triton: 3.6