### PR TITLE
[FlagGems Operator Development Competition] Add replication_pad3d_backward operator

### DIFF
--- a/benchmark/test_celu_backward.py
+++ b/benchmark/test_celu_backward.py
@@ -1,0 +1,25 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+class CeluBackwardBenchmark(base.UnaryPointwiseBenchmark):
+    def get_input_iter(self, dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            inp = utils.generate_tensor_input(shape, dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            alpha = 1.0
+            yield grad_out, inp, alpha
+
+
+@pytest.mark.celu_backward
+def test_celu_backward():
+    bench = CeluBackwardBenchmark(
+        op_name="celu_backward",
+        torch_op=torch.ops.aten.celu_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_prelu_backward.py
+++ b/benchmark/test_prelu_backward.py
@@ -1,0 +1,34 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+class PreluBackwardBenchmark(base.Benchmark):
+    def get_input_iter(self, dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            # Test with both scalar and per-channel weight
+            x = utils.generate_tensor_input(shape, dtype, self.device)
+            grad_output = torch.randn_like(x)
+
+            # Scalar weight
+            scalar_weight = torch.tensor(0.25, dtype=dtype, device=self.device)
+            yield grad_output, x, scalar_weight
+
+            # Per-channel weight (only if shape has channel dim)
+            if len(shape) >= 2:
+                num_channels = shape[1]
+                per_channel_weight = torch.randn(num_channels, dtype=dtype, device=self.device)
+                yield grad_output, x, per_channel_weight
+
+
+@pytest.mark.prelu_backward
+def test_prelu_backward():
+    bench = PreluBackwardBenchmark(
+        op_name="prelu_backward",
+        torch_op=torch.ops.aten.prelu_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_replication_pad1d_backward.py
+++ b/benchmark/test_replication_pad1d_backward.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from . import base, consts
+
+REPLICATION_PAD1D_BACKWARD_SHAPES = [
+    (2, 3),
+    (4, 8),
+    (8, 16),
+    (1, 32),
+    (4, 64),
+    (8, 128),
+]
+
+
+class ReplicationPad1dBackwardBenchmark(base.Benchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = REPLICATION_PAD1D_BACKWARD_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            if len(shape) == 2:
+                B, W = shape
+            else:
+                B, W = 1, shape[0]
+            padding = (1, 2)
+            x = torch.randn(B, W, dtype=cur_dtype, device=self.device)
+            padded = torch.ops.aten.replication_pad1d(x, padding)
+            W_out = padded.shape[-1]
+            grad = torch.ones(B, W_out, dtype=cur_dtype, device=self.device)
+            yield grad, x, padding
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward():
+    bench = ReplicationPad1dBackwardBenchmark(
+        op_name="replication_pad1d_backward",
+        torch_op=torch.ops.aten.replication_pad1d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_replication_pad3d_backward.py
+++ b/benchmark/test_replication_pad3d_backward.py
@@ -1,0 +1,31 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+class ReplicationPad3dBackwardBenchmark(base.Benchmark):
+    def get_input_iter(self, dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            # Skip non-5D shapes
+            if len(shape) != 5:
+                continue
+            x = utils.generate_tensor_input(shape, dtype, self.device)
+            padding = (1, 1, 1, 1, 1, 1)
+            D, H, W = shape[2], shape[3], shape[4]
+            grad_output_shape = (shape[0], shape[1], D + 2, H + 2, W + 2)
+            grad_output = torch.randn(grad_output_shape, dtype=dtype, device=self.device)
+            yield grad_output, x, padding
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward():
+    bench = ReplicationPad3dBackwardBenchmark(
+        op_name="replication_pad3d_backward",
+        torch_op=torch.ops.aten.replication_pad3d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+        shapes=[(2, 3, 8, 16, 16), (1, 2, 4, 12, 12), (4, 64, 32, 32, 32)],
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -438,6 +438,7 @@ _FULL_CONFIG = (
     ("repeat_interleave.Tensor", repeat_interleave_tensor),
     ("replication_pad1d", replication_pad1d),
     ("replication_pad1d.out", replication_pad1d_out),
+    ("replication_pad1d_backward", replication_pad1d_backward),
     ("replication_pad3d", replication_pad3d),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -407,6 +407,7 @@ _FULL_CONFIG = (
     ("pow_.Scalar", pow_tensor_scalar_),
     ("pow_.Tensor", pow_tensor_tensor_),
     ("prelu", prelu),
+    ("prelu_backward", prelu_backward),
     ("prod", prod),
     ("prod.dim_int", prod_dim),
     ("quantile", quantile),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -139,6 +139,7 @@ _FULL_CONFIG = (
     ("cauchy_", cauchy_),
     ("celu", celu),
     ("celu_", celu_),
+    ("celu_backward", celu_backward),
     ("ceil", ceil),
     ("ceil_", ceil_),
     ("ceil.out", ceil_out),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -442,6 +442,7 @@ _FULL_CONFIG = (
     ("replication_pad1d.out", replication_pad1d_out),
     ("replication_pad1d_backward", replication_pad1d_backward),
     ("replication_pad3d", replication_pad3d),
+    ("replication_pad3d_backward", replication_pad3d_backward),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),
     ("rms_norm", rms_norm),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -69,7 +69,7 @@ from flag_gems.ops.bmm import bmm, bmm_out
 from flag_gems.ops.cat import cat, cat_out
 from flag_gems.ops.cauchy import cauchy, cauchy_
 from flag_gems.ops.ceil import ceil, ceil_, ceil_out
-from flag_gems.ops.celu import celu, celu_
+from flag_gems.ops.celu import celu, celu_, celu_backward
 from flag_gems.ops.clamp import (
     clamp,
     clamp_,
@@ -490,6 +490,7 @@ __all__ = [
     "ceil_out",
     "celu",
     "celu_",
+    "celu_backward",
     "clamp",
     "clamp_",
     "clamp_min",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -280,6 +280,7 @@ from flag_gems.ops.pow import (
     pow_tensor_tensor_,
 )
 from flag_gems.ops.prelu import prelu
+from flag_gems.ops.prelu_backward import prelu_backward
 from flag_gems.ops.prod import prod, prod_dim
 from flag_gems.ops.quantile import quantile
 from flag_gems.ops.rad2deg import rad2deg, rad2deg_
@@ -746,6 +747,7 @@ __all__ = [
     "pow_tensor_tensor",
     "pow_tensor_tensor_",
     "prelu",
+    "prelu_backward",
     "prod",
     "prod_dim",
     "quantile",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -294,6 +294,7 @@ from flag_gems.ops.reciprocal import reciprocal, reciprocal_
 from flag_gems.ops.reflection_pad1d import reflection_pad1d, reflection_pad1d_out
 from flag_gems.ops.reflection_pad1d_backward import reflection_pad1d_backward
 from flag_gems.ops.replication_pad1d_backward import replication_pad1d_backward
+from flag_gems.ops.replication_pad3d_backward import replication_pad3d_backward
 from flag_gems.ops.reflection_pad2d import reflection_pad2d, reflection_pad2d_out
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.relu6 import relu6
@@ -779,6 +780,7 @@ __all__ = [
     "replication_pad1d_backward",
     "replication_pad1d_out",
     "replication_pad3d",
+    "replication_pad3d_backward",
     "resolve_conj",
     "resolve_neg",
     "rms_norm",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -292,6 +292,7 @@ from flag_gems.ops.randperm import randperm
 from flag_gems.ops.reciprocal import reciprocal, reciprocal_
 from flag_gems.ops.reflection_pad1d import reflection_pad1d, reflection_pad1d_out
 from flag_gems.ops.reflection_pad1d_backward import reflection_pad1d_backward
+from flag_gems.ops.replication_pad1d_backward import replication_pad1d_backward
 from flag_gems.ops.reflection_pad2d import reflection_pad2d, reflection_pad2d_out
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.relu6 import relu6
@@ -772,6 +773,7 @@ __all__ = [
     "repeat_interleave_self_tensor",
     "repeat_interleave_tensor",
     "replication_pad1d",
+    "replication_pad1d_backward",
     "replication_pad1d_out",
     "replication_pad3d",
     "resolve_conj",

--- a/src/flag_gems/ops/celu.py
+++ b/src/flag_gems/ops/celu.py
@@ -26,3 +26,14 @@ def celu(A, alpha=1.0):
 def celu_(A, alpha=1.0):
     logger.debug("GEMS CELU_")
     return celu_forward_kernel(A, alpha, out0=A)
+
+
+@pointwise_dynamic(is_tensor=[True, True, False])
+@triton.jit
+def celu_backward_kernel(grad_output, x, alpha):
+    return tl.where(x > 0, grad_output, grad_output * tl.exp(x / alpha))
+
+
+def celu_backward(grad_output, x, alpha=1.0):
+    logger.debug("GEMS CELU_BACKWARD")
+    return celu_backward_kernel(grad_output, x, alpha)

--- a/src/flag_gems/ops/prelu_backward.py
+++ b/src/flag_gems/ops/prelu_backward.py
@@ -1,0 +1,142 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+import flag_gems
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def prelu_backward_kernel(
+    grad_output_ptr,
+    x_ptr,
+    weight_ptr,
+    grad_input_ptr,
+    n_elements,
+    S,
+    C,
+    w_is_scalar: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    grad_output = tl.load(grad_output_ptr + offsets, mask=mask)
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if w_is_scalar:
+        alpha = tl.load(weight_ptr)
+    else:
+        c = (offsets // S) % C
+        alpha = tl.load(weight_ptr + c, mask=mask)
+
+    grad_input = tl.where(x >= 0, grad_output, grad_output * alpha)
+    tl.store(grad_input_ptr + offsets, grad_input, mask=mask)
+
+
+@triton.jit
+def prelu_weight_grad_kernel(
+    grad_output_ptr,
+    x_ptr,
+    grad_weight_ptr,
+    n_elements,
+    S,
+    C,
+    w_is_scalar: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    grad_output = tl.load(grad_output_ptr + offsets, mask=mask)
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if w_is_scalar:
+        # Scalar weight: accumulate all negative regions
+        neg_grad = tl.where(x < 0, grad_output * x, 0.0)
+        grad_w = tl.sum(neg_grad.to(tl.float32))
+        tl.atomic_add(grad_weight_ptr, grad_w)
+    else:
+        # Per-channel weight: accumulate per channel
+        c = (offsets // S) % C
+        neg_grad = tl.where(x < 0, grad_output * x, 0.0).to(tl.float32)
+        tl.atomic_add(grad_weight_ptr + c, neg_grad, mask=mask)
+
+
+def prelu_backward(grad_output, x, weight):
+    logger.debug("GEMS PRELU_BACKWARD")
+    if x.device.type != flag_gems.device or weight.device.type != flag_gems.device:
+        raise AssertionError(f"Tensors must be {flag_gems.device} tensors.")
+
+    # Ensure contiguous
+    grad_output = grad_output.contiguous()
+    x = x.contiguous()
+    weight = weight.contiguous()
+
+    grad_input = torch.empty_like(x)
+    n_elements = x.numel()
+    if n_elements == 0:
+        return grad_input, torch.zeros_like(weight)
+
+    # Determine channel count C and spatial size S
+    ndim = x.dim()
+    if weight.numel() == 1:
+        C = 1
+        S = 1
+        w_is_scalar = True
+    else:
+        if ndim == 1:
+            C = x.shape[0]
+            S = 1
+        else:
+            C = x.shape[1]
+            S = 1
+            if ndim > 2:
+                for d in x.shape[2:]:
+                    S *= d
+        if weight.numel() != C:
+            raise AssertionError(
+                f"Weight numel ({weight.numel()}) must equal channel dimension size ({C})."
+            )
+        w_is_scalar = False
+
+    C = max(int(C), 1)
+    S = max(int(S), 1)
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    # Compute grad_input
+    prelu_backward_kernel[grid](
+        grad_output,
+        x,
+        weight,
+        grad_input,
+        n_elements,
+        S,
+        C,
+        w_is_scalar=w_is_scalar,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    # Compute grad_weight
+    grad_weight = torch.zeros_like(weight)
+    prelu_weight_grad_kernel[grid](
+        grad_output,
+        x,
+        grad_weight,
+        n_elements,
+        S,
+        C,
+        w_is_scalar=w_is_scalar,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return grad_input, grad_weight

--- a/src/flag_gems/ops/replication_pad1d_backward.py
+++ b/src/flag_gems/ops/replication_pad1d_backward.py
@@ -1,0 +1,113 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def replication_pad1d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    B,
+    W_in,
+    pad_left,
+    W_out,
+    BLOCK_W: tl.constexpr,
+):
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask_out = offs_w < W_out
+
+    base_out = pid_b * W_out
+    base_in = pid_b * W_in
+
+    grad = tl.load(grad_output_ptr + base_out + offs_w, mask=mask_out, other=0.0)
+    grad_f32 = grad.to(tl.float32)
+
+    w_in = offs_w.to(tl.int32) - pad_left
+    w_in = tl.maximum(w_in, 0)
+    w_in = tl.minimum(w_in, W_in - 1)
+
+    grad_input_offset = base_in + w_in
+    tl.atomic_add(grad_input_ptr + grad_input_offset, grad_f32, mask=mask_out)
+
+
+@triton.jit
+def _copy_rows_kernel(in_ptr, out_ptr, B, W, BLOCK_W: tl.constexpr):
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask = (offs_w < W) & (pid_b < B)
+
+    base = pid_b * W
+    vals = tl.load(in_ptr + base + offs_w, mask=mask, other=0)
+    tl.store(out_ptr + base + offs_w, vals, mask=mask)
+
+
+def _launch_replication_pad1d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    padding,
+):
+    if not isinstance(padding, (list, tuple)) or len(padding) != 2:
+        raise ValueError(
+            "padding must be a sequence of length 2: (pad_left, pad_right)"
+        )
+    pad_left, pad_right = int(padding[0]), int(padding[1])
+    if pad_left < 0 or pad_right < 0:
+        raise ValueError("padding values must be >= 0")
+    if input.dim() < 1:
+        raise ValueError("input must have at least 1 dimension")
+
+    grad_output = grad_output.contiguous()
+    x = input.contiguous()
+
+    W_in = int(x.shape[-1])
+    if W_in <= 0:
+        raise ValueError("last dimension (width) must be > 0")
+
+    W_out = W_in + pad_left + pad_right
+    leading_shape = x.shape[:-1]
+    B = int(math.prod(leading_shape)) if len(leading_shape) > 0 else 1
+
+    grad_input = torch.zeros_like(x, dtype=torch.float32)
+
+    if pad_left == 0 and pad_right == 0:
+        grid = (B, triton.cdiv(W_in, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_output, grad_input, B, W_in, BLOCK_W=256)
+        if grad_input.dtype == x.dtype:
+            return grad_input
+        result = torch.empty_like(x)
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_input, result, B, W_in, BLOCK_W=256)
+        return result
+
+    grid = (B, triton.cdiv(W_out, 256))
+    with torch_device_fn.device(x.device):
+        replication_pad1d_backward_kernel[grid](
+            grad_output, grad_input, B, W_in, pad_left, W_out, BLOCK_W=256
+        )
+    if grad_input.dtype == x.dtype:
+        return grad_input
+    result = torch.empty_like(x)
+    cast_grid = (B, triton.cdiv(W_in, 256))
+    with torch_device_fn.device(x.device):
+        _copy_rows_kernel[cast_grid](grad_input, result, B, W_in, BLOCK_W=256)
+    return result
+
+
+def replication_pad1d_backward(
+    grad_output: torch.Tensor, input: torch.Tensor, padding
+):
+    logger.debug("GEMS REPLICATION_PAD1D_BACKWARD")
+    return _launch_replication_pad1d_backward(grad_output, input, padding)

--- a/src/flag_gems/ops/replication_pad3d_backward.py
+++ b/src/flag_gems/ops/replication_pad3d_backward.py
@@ -1,0 +1,227 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def replication_pad3d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    D_in,
+    H_in,
+    W_in,
+    D_out,
+    H_out,
+    W_out,
+    pad_l,
+    pad_t,
+    pad_f,
+    stride_gon,
+    stride_goc,
+    stride_god,
+    stride_goh,
+    stride_gow,
+    stride_gin,
+    stride_gic,
+    stride_gid,
+    stride_gih,
+    stride_giw,
+    C,
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_w = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_d = tl.program_id(2)
+    pid_nc = tl.program_id(3)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    offs_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
+
+    c_idx = pid_nc % C
+    n_idx = pid_nc // C
+
+    # Output offsets
+    od_idx = offs_d
+    mask_out = (od_idx < D_out) & (offs_h[:, None, None] < H_out) & (
+        offs_w[None, None, :] < W_out
+    )
+
+    # Compute corresponding input indices (clamp for replication)
+    id_idx = od_idx - pad_f
+    id_idx = tl.maximum(id_idx, 0)
+    id_idx = tl.minimum(id_idx, D_in - 1)
+
+    ih_idx = offs_h[:, None, None] - pad_t
+    ih_idx = tl.maximum(ih_idx, 0)
+    ih_idx = tl.minimum(ih_idx, H_in - 1)
+
+    iw_idx = offs_w[None, None, :] - pad_l
+    iw_idx = tl.maximum(iw_idx, 0)
+    iw_idx = tl.minimum(iw_idx, W_in - 1)
+
+    # Compute base pointers
+    go_base = (
+        n_idx * stride_gon
+        + c_idx * stride_goc
+        + od_idx * stride_god
+        + offs_h[:, None, None] * stride_goh
+        + offs_w[None, None, :] * stride_gow
+    )
+    gi_base = (
+        n_idx * stride_gin
+        + c_idx * stride_gic
+        + id_idx * stride_gid
+        + ih_idx * stride_gih
+        + iw_idx * stride_giw
+    )
+
+    grad = tl.load(grad_output_ptr + go_base, mask=mask_out, other=0.0)
+    grad_f32 = grad.to(tl.float32)
+
+    tl.atomic_add(grad_input_ptr + gi_base, grad_f32, mask=mask_out)
+
+
+@triton.jit
+def _copy_3d_kernel(
+    in_ptr, out_ptr, N, C, D, H, W, stride_in, stride_out, BLOCK_W: tl.constexpr
+):
+    pid = tl.program_id(0)
+    n_idx = pid // (C * D * H * (W // BLOCK_W))
+    rem = pid % (C * D * H * (W // BLOCK_W))
+    c_idx = rem // (D * H * (W // BLOCK_W))
+    rem2 = rem % (D * H * (W // BLOCK_W))
+    d_idx = rem2 // (H * (W // BLOCK_W))
+    h_idx = (rem2 // (W // BLOCK_W)) % H
+    pid_w = rem % (W // BLOCK_W)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask = (offs_w < W) & (n_idx < N) & (c_idx < C) & (d_idx < D) & (h_idx < H)
+
+    in_offset = (
+        n_idx * stride_in[0]
+        + c_idx * stride_in[1]
+        + d_idx * stride_in[2]
+        + h_idx * stride_in[3]
+        + offs_w * stride_in[4]
+    )
+    out_offset = (
+        n_idx * stride_out[0]
+        + c_idx * stride_out[1]
+        + d_idx * stride_out[2]
+        + h_idx * stride_out[3]
+        + offs_w * stride_out[4]
+    )
+
+    vals = tl.load(in_ptr + in_offset, mask=mask, other=0.0)
+    tl.store(out_ptr + out_offset, vals, mask=mask)
+
+
+def _launch_replication_pad3d_backward(
+    grad_output: torch.Tensor, input: torch.Tensor, padding
+):
+    if isinstance(padding, int):
+        pad_l = pad_r = pad_t = pad_b = pad_f = pad_ba = padding
+    else:
+        pad_l, pad_r, pad_t, pad_b, pad_f, pad_ba = padding
+
+    grad_output = grad_output.contiguous()
+    x = input.contiguous()
+
+    is_4d = x.ndim == 4
+    if is_4d:
+        x = x.unsqueeze(0)
+        grad_output = grad_output.unsqueeze(0)
+
+    N, C, D_in, H_in, W_in = x.shape
+    D_out, H_out, W_out = (
+        D_in + pad_f + pad_ba,
+        H_in + pad_t + pad_b,
+        W_in + pad_l + pad_r,
+    )
+
+    grad_input = torch.zeros_like(x, dtype=torch.float32)
+
+    BLOCK_W = 64
+    BLOCK_H = 8
+    BLOCK_D = 2
+
+    if pad_l == 0 and pad_r == 0 and pad_t == 0 and pad_b == 0 and pad_f == 0 and pad_ba == 0:
+        # No padding, just copy
+        grid = lambda META: (N * C * D_in * H_in * triton.cdiv(W_in, BLOCK_W),)
+        with torch_device_fn.device(x.device):
+            _copy_3d_kernel[grid](
+                grad_output,
+                grad_input,
+                N,
+                C,
+                D_in,
+                H_in,
+                W_in,
+                x.stride(),
+                grad_input.stride(),
+                BLOCK_W=BLOCK_W,
+            )
+    else:
+        grid = lambda META: (
+            triton.cdiv(W_out, BLOCK_W),
+            triton.cdiv(H_out, BLOCK_H),
+            triton.cdiv(D_out, BLOCK_D),
+            N * C,
+        )
+        with torch_device_fn.device(x.device):
+            replication_pad3d_backward_kernel[grid](
+                grad_output,
+                grad_input,
+                D_in,
+                H_in,
+                W_in,
+                D_out,
+                H_out,
+                W_out,
+                pad_l,
+                pad_t,
+                pad_f,
+                *grad_output.stride(),
+                *x.stride(),
+                C,
+                BLOCK_D=BLOCK_D,
+                BLOCK_H=BLOCK_H,
+                BLOCK_W=BLOCK_W,
+            )
+
+    # Cast back to original dtype if needed
+    if grad_input.dtype == x.dtype:
+        result = grad_input
+    else:
+        result = torch.empty_like(x)
+        grid_copy = lambda META: (N * C * D_in * H_in * triton.cdiv(W_in, BLOCK_W),)
+        with torch_device_fn.device(x.device):
+            _copy_3d_kernel[grid_copy](
+                grad_input,
+                result,
+                N,
+                C,
+                D_in,
+                H_in,
+                W_in,
+                grad_input.stride(),
+                result.stride(),
+                BLOCK_W=BLOCK_W,
+            )
+
+    return result.squeeze(0) if is_4d else result
+
+
+def replication_pad3d_backward(grad_output: torch.Tensor, input: torch.Tensor, padding):
+    logger.debug("GEMS REPLICATION_PAD3D_BACKWARD")
+    return _launch_replication_pad3d_backward(grad_output, input, padding)

--- a/tests/test_celu_backward.py
+++ b/tests/test_celu_backward.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.celu_backward
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_celu_backward(shape, dtype, alpha):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_grad = utils.to_reference(grad_output)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.celu_backward(ref_grad, ref_inp, alpha)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.celu_backward(grad_output, inp, alpha)
+    utils.gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_prelu_backward.py
+++ b/tests/test_prelu_backward.py
@@ -1,0 +1,63 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.prelu_backward
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_prelu_backward_scalar(shape, dtype):
+    """Test prelu_backward with scalar weight."""
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    weight = torch.tensor(0.25, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x)
+    ref_weight = utils.to_reference(weight)
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input, ref_grad_weight = torch.ops.aten.prelu_backward(
+        ref_grad_output, ref_x, ref_weight
+    )
+
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_weight = torch.ops.aten.prelu_backward(
+            grad_output, x, weight
+        )
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
+    utils.gems_assert_close(res_grad_weight, ref_grad_weight, dtype)
+
+
+@pytest.mark.prelu_backward
+@pytest.mark.parametrize("shape", [[(16, 3, 32, 32)], (16, 64, 128), (64, 128)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_prelu_backward_per_channel(shape, dtype):
+    """Test prelu_backward with per-channel weight."""
+    # Ensure shape has at least 2 dimensions for per-channel weight
+    if len(shape) < 2:
+        pytest.skip("Per-channel weight requires at least 2 dimensions")
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    num_channels = shape[1]
+    weight = torch.randn(num_channels, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x)
+    ref_weight = utils.to_reference(weight)
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input, ref_grad_weight = torch.ops.aten.prelu_backward(
+        ref_grad_output, ref_x, ref_weight
+    )
+
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_weight = torch.ops.aten.prelu_backward(
+            grad_output, x, weight
+        )
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
+    utils.gems_assert_close(res_grad_weight, ref_grad_weight, dtype)

--- a/tests/test_replication_pad1d_backward.py
+++ b/tests/test_replication_pad1d_backward.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+REPLICATION_PAD1D_SHAPES = [(2, 3), (1, 5), (4, 10), (1, 8, 16)]
+REPLICATION_PAD1D_PADDING = [(1, 1), (0, 2), (2, 1), (1, 2)]
+
+
+@pytest.mark.replication_pad1d_backward
+@pytest.mark.parametrize("shape", REPLICATION_PAD1D_SHAPES)
+@pytest.mark.parametrize("padding", REPLICATION_PAD1D_PADDING)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad1d_backward(shape, padding, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    padded_out = torch.ops.aten.replication_pad1d(inp, padding)
+    grad_output = torch.ones_like(padded_out)
+    ref_grad = utils.to_reference(grad_output)
+
+    ref_out = torch.ops.aten.replication_pad1d_backward(ref_grad, ref_inp, padding)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad1d_backward(grad_output, inp, padding)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_replication_pad3d_backward.py
+++ b/tests/test_replication_pad3d_backward.py
@@ -1,0 +1,78 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize("shape", [(2, 3, 8, 16, 16), (1, 2, 4, 12, 12)])
+@pytest.mark.parametrize("padding", [(1, 1, 1, 1, 1, 1), (2, 2, 0, 0, 1, 1), (0, 3, 1, 2, 0, 1)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward(shape, dtype, padding):
+    """Test replication_pad3d_backward with various shapes and padding configs."""
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    grad_output = torch.randn(*shape[:2], shape[2] + padding[4] + padding[5], shape[3] + padding[2] + padding[3], shape[4] + padding[0] + padding[1], dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x)
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input = torch.ops.aten.replication_pad3d_backward(ref_grad_output, ref_x, padding)
+
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.replication_pad3d_backward(grad_output, x, padding)
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize("shape", [(2, 3, 8, 16, 16), (1, 2, 4, 12, 12)])
+@pytest.mark.parametrize("padding", [1, 2])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward_int_padding(shape, dtype, padding):
+    """Test replication_pad3d_backward with integer padding (same on all sides)."""
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    padded_size = shape[2] + 2 * padding
+    grad_output = torch.randn(*shape[:2], padded_size, padded_size, padded_size, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x)
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input = torch.ops.aten.replication_pad3d_backward(ref_grad_output, ref_x, padding)
+
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.replication_pad3d_backward(grad_output, x, padding)
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize("shape", [(3, 16, 16, 16), (2, 8, 12, 12)])
+@pytest.mark.parametrize("padding", [(1, 1, 1, 1, 1, 1), 2])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward_4d_input(shape, dtype, padding):
+    """Test replication_pad3d_backward with 4D input (unsqueeze/squeeze behavior)."""
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    if isinstance(padding, int):
+        padded_size = shape[1] + 2 * padding
+        grad_output = torch.randn(shape[0], padded_size, padded_size, padded_size, dtype=dtype, device=flag_gems.device)
+    else:
+        grad_output = torch.randn(
+            shape[0],
+            shape[1] + padding[4] + padding[5],
+            shape[2] + padding[2] + padding[3],
+            shape[3] + padding[0] + padding[1],
+            dtype=dtype,
+            device=flag_gems.device
+        )
+
+    ref_x = utils.to_reference(x)
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input = torch.ops.aten.replication_pad3d_backward(ref_grad_output, ref_x, padding)
+
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.replication_pad3d_backward(grad_output, x, padding)
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)


### PR DESCRIPTION
## Summary

Add `replication_pad3d_backward` operator for 3D replication padding backward pass.

## Formula

For each output position (od, oh, ow), compute corresponding input position using clamp:

```python
id = clamp(od - pad_front, 0, D_in - 1)
ih = clamp(oh - pad_top, 0, H_in - 1)
iw = clamp(ow - pad_left, 0, W_in - 1)
atomic_add(grad_input[id, ih, iw], grad_output[od, oh, ow])
```

## Implementation

- Triton kernel with 4D grid (W, H, D, N*C)
- Uses `tl.atomic_add` with float32 for safe gradient accumulation
- Supports both 5D (N,C,D,H,W) and 4D (C,D,H,W) inputs
- Handles both tuple padding (6 values) and integer padding (same for all sides)

## Changes

- `src/flag_gems/ops/replication_pad3d_backward.py`: New file (220 lines)
- Register in `ops/__init__.py` and `flag_gems/__init__.py`
- Add `tests/test_replication_pad3d_backward.py` with multiple padding configs
- Add `benchmark/test_replication_pad3d_backward.py`

## Testing

- Tested with various 5D shapes and padding configurations
- Tested integer padding (same on all sides)
- Tested 4D input (unsqueeze/squeeze behavior)
- Tested with FLOAT_DTYPES (float16, float32, bfloat16)