### PR TITLE
[Track 1-B] Add hardtanh, hardtanh_, and hardtanh_backward operators

### DIFF
--- a/benchmark/test_hardtanh.py
+++ b/benchmark/test_hardtanh.py
@@ -1,0 +1,43 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+class HardTanhBenchmark(base.UnaryPointwiseBenchmark):
+    def get_input_iter(self, dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            input = utils.generate_tensor_input(shape, dtype, self.device)
+            yield input, -1.0, 1.0
+
+
+class HardTanhBackwardBenchmark(base.UnaryPointwiseBenchmark):
+    def get_input_iter(self, dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            input = utils.generate_tensor_input(shape, dtype, self.device)
+            grad_output = utils.generate_tensor_input(shape, dtype, self.device)
+            yield grad_output, input, -1.0, 1.0
+
+
+@pytest.mark.hardtanh
+def test_hardtanh():
+    bench = HardTanhBenchmark(
+        op_name="hardtanh",
+        torch_op=torch.ops.aten.hardtanh,
+        dtypes=consts.FLOAT_DTYPES,
+        shapes=[(1024,), (4096,), (16384,), (65536,)],
+    )
+    bench.run()
+
+
+@pytest.mark.hardtanh_backward
+def test_hardtanh_backward():
+    bench = HardTanhBackwardBenchmark(
+        op_name="hardtanh_backward",
+        torch_op=torch.ops.aten.hardtanh_backward,
+        dtypes=consts.FLOAT_DTYPES,
+        shapes=[(1024,), (4096,), (16384,), (65536,)],
+    )
+    bench.run()

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -174,6 +174,7 @@ from flag_gems.ops.hadamard_transform import (
 )
 from flag_gems.ops.hardsigmoid import hardsigmoid, hardsigmoid_out
 from flag_gems.ops.hardswish_ import hardswish_
+from flag_gems.ops.hardtanh import hardtanh, hardtanh_, hardtanh_backward
 from flag_gems.ops.histc import histc
 from flag_gems.ops.hstack import hstack
 from flag_gems.ops.hypot import hypot, hypot_out
@@ -616,6 +617,9 @@ __all__ = [
     "hardsigmoid",
     "hardsigmoid_out",
     "hardswish_",
+    "hardtanh",
+    "hardtanh_",
+    "hardtanh_backward",
     "histc",
     "hstack",
     "hypot",

--- a/src/flag_gems/ops/hardtanh.py
+++ b/src/flag_gems/ops/hardtanh.py
@@ -1,0 +1,56 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, False, False], promotion_methods=[(0, 1, 2, "DEFAULT")])
+@triton.jit
+def hardtanh_func(x, min_val, max_val):
+    xf = x.to(tl.float32)
+    return tl.minimum(max_val, tl.maximum(min_val, xf))
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def hardtanh_func_min(x, min_val):
+    xf = x.to(tl.float32)
+    return tl.maximum(min_val, xf)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def hardtanh_func_max(x, max_val):
+    xf = x.to(tl.float32)
+    return tl.minimum(max_val, xf.to(tl.float32))
+
+
+@pointwise_dynamic(is_tensor=[True, False, False])
+@triton.jit
+def hardtanh_backward_func(x, grad_output, min_val, max_val):
+    xf = x.to(tl.float32)
+    mask = (xf >= min_val) & (xf <= max_val)
+    return tl.where(mask, grad_output.to(tl.float32), 0.0)
+
+
+def hardtanh(x, min_val=-1.0, max_val=1.0):
+    logger.debug("GEMS HARDTANH")
+    if min_val >= max_val:
+        raise ValueError(f"min_val ({min_val}) must be less than max_val ({max_val})")
+    return hardtanh_func(x, min_val, max_val)
+
+
+def hardtanh_(x, min_val=-1.0, max_val=1.0):
+    logger.debug("GEMS HARDTANH_")
+    if min_val >= max_val:
+        raise ValueError(f"min_val ({min_val}) must be less than max_val ({max_val})")
+    return hardtanh_func(x, min_val, max_val, out0=x)
+
+
+def hardtanh_backward(grad_output, x, min_val, max_val):
+    logger.debug("GEMS HARDTANH_BACKWARD")
+    return hardtanh_backward_func(x, grad_output, min_val, max_val)

--- a/tests/test_hardtanh.py
+++ b/tests/test_hardtanh.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("min_val,max_val", [(-1.0, 1.0), (0.0, 1.0), (-2.0, 2.0)])
+@pytest.mark.parametrize("shape", [(64,), (16, 16), (8, 16, 16)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_hardtanh(shape, min_val, max_val, dtype):
+    """Test hardtanh with various shapes and min/max values."""
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = utils.to_reference(input)
+    ref_output = torch.ops.aten.hardtanh(ref_input, min_val, max_val)
+
+    with flag_gems.use_gems():
+        res_output = torch.ops.aten.hardtanh(input, min_val, max_val)
+
+    utils.gems_assert_close(res_output, ref_output, dtype)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("min_val,max_val", [(-1.0, 1.0), (0.0, 1.0)])
+@pytest.mark.parametrize("shape", [(64,), (16, 16)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_hardtanh_inplace(shape, min_val, max_val, dtype):
+    """Test hardtanh_ in-place operation."""
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    input_copy = input.clone()
+
+    ref_input = utils.to_reference(input_copy)
+    ref_output = torch.ops.aten.hardtanh_(ref_input, min_val, max_val)
+
+    with flag_gems.use_gems():
+        res_output = torch.ops.aten.hardtanh_(input, min_val, max_val)
+
+    utils.gems_assert_close(res_output, ref_output, dtype)
+
+
+@pytest.mark.hardtanh_backward
+@pytest.mark.parametrize("min_val,max_val", [(-1.0, 1.0), (0.0, 1.0), (-2.0, 2.0)])
+@pytest.mark.parametrize("shape", [(64,), (16, 16), (8, 16, 16)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_hardtanh_backward(shape, min_val, max_val, dtype):
+    """Test hardtanh_backward with various shapes and min/max values."""
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = utils.to_reference(input)
+    ref_grad = utils.to_reference(grad_output)
+
+    ref_grad_input = torch.ops.aten.hardtanh_backward(ref_grad, ref_input, min_val, max_val)
+
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.hardtanh_backward(grad_output, input, min_val, max_val)
+
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)


### PR DESCRIPTION
[FlagGems Operator Development Competition]

Add , , and  operators using @pointwise_dynamic pattern.

## Implementation
- Forward (hardtanh/hardtanh_): clamp(x, min_val, max_val) with configurable bounds
- Backward (hardtanh_backward): gradient only passes through for x in [min_val, max_val]
- Uses @pointwise_dynamic for automatic type promotion and non-contiguous support

## Changes
- : New operators (69 lines)
- : Accuracy tests for forward and backward
- : Performance benchmark
- : Register operators