### PR TITLE
[KernelGen] Fix max_pool3d_with_indices: accuracy_fail

### DIFF
--- a/tests/test_max_pool3d.py
+++ b/tests/test_max_pool3d.py
@@ -32,7 +32,6 @@ MAXPOOL3D_CONFIGS = [
 
 
 @pytest.mark.max_pool3d_with_indices
-@pytest.mark.skip(reason="Issue #2865: this test always fail.")
 @pytest.mark.parametrize(
     "shape, kernel_size, stride, padding, dilation, ceil_mode", MAXPOOL3D_CONFIGS
 )


### PR DESCRIPTION
## Summary
- **Operator:** max_pool3d_with_indices
- **Error type:** accuracy_fail
- **Root cause:** The test had an unconditional @pytest.mark.skip decorator (referencing Issue #2865) that prevented the tests from running. The operator implementation itself is correct and passes all accuracy checks.
- **Fix:** Removed the @pytest.mark.skip decorator from test_max_pool3d_with_indices only. The backward test (test_max_pool3d_backward) skip is retained as it still has accuracy issues on float16/bfloat16.
- **Files modified:**
  - `tests/test_max_pool3d.py`

## Verification
- Accuracy test: 27/27 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'max_pool3d_with_indices' tests/ --ref cpu -vs`
- [ ] `pytest -m 'max_pool3d_with_indices' benchmark/ --level core --record log`

## Issue
- WEEKTEST-423