### PR TITLE
[KernelGen][Nvidia] Add persistent_topk operator with Triton kernel for VLLM

### DIFF
--- a/benchmark/test_persistent_topk.py
+++ b/benchmark/test_persistent_topk.py
@@ -1,0 +1,96 @@
+"""Benchmark for persistent_topk (DeepSeek V4 sparse attention top-K).
+
+Shapes simulate DeepSeek V4 sparse attention inference patterns:
+    - (1, 1024-4096, k=1024): decode path, single token
+    - (4-32, 4096-32768, k=1024): batched decode / prefill
+    - k=512/2048 variants: alternative top-k sizes
+
+The baseline uses vLLM's CUDA persistent_topk when available,
+falling back to torch.topk.
+"""
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import persistent_topk
+
+from . import base
+
+device = flag_gems.device
+
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA device required",
+)
+
+# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_persistent_topk(logits, seq_lens, topk_indices, workspace, k, stride):
+        torch.ops._C.persistent_topk(
+            logits, seq_lens, topk_indices, workspace, k, stride
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_persistent_topk = None
+
+
+def _torch_topk_ref(logits, seq_lens, topk_indices, workspace, k, stride):
+    """Pure-PyTorch fallback reference using torch.topk."""
+    num_rows = logits.shape[0]
+    for i in range(num_rows):
+        seq_len = seq_lens[i].item()
+        valid_logits = logits[i, :seq_len]
+        _, top_idx = torch.topk(valid_logits, k, largest=True, sorted=False)
+        topk_indices[i].copy_(top_idx.to(torch.int32))
+
+
+_baseline_op = _vllm_persistent_topk if HAS_VLLM else _torch_topk_ref
+
+
+class PersistentTopkBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_DESC = "num_rows, seq_len, top_k"
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            (1, 1024, 1024),
+            (1, 2048, 1024),
+            (1, 4096, 1024),
+            (4, 4096, 1024),
+            (8, 8192, 1024),
+            (16, 16384, 1024),
+            (32, 32768, 1024),
+            (4, 4096, 512),
+            (4, 4096, 2048),
+        ]
+
+    def get_input_iter(self, dtype):
+        for num_rows, seq_len, k in self.shapes:
+            stride = seq_len
+            logits = torch.randn(num_rows, stride, device=device, dtype=torch.float32)
+            seq_lens = torch.full(
+                (num_rows,), seq_len, device=device, dtype=torch.int32
+            )
+            topk_indices = torch.zeros(num_rows, k, device=device, dtype=torch.int32)
+            workspace = torch.zeros(
+                RADIX_TOPK_WORKSPACE_SIZE, device=device, dtype=torch.uint8
+            )
+
+            yield logits, seq_lens, topk_indices, workspace, k, stride
+
+
+@pytest.mark.persistent_topk
+def test_persistent_topk():
+    bench = PersistentTopkBenchmark(
+        op_name="persistent_topk",
+        torch_op=_baseline_op,
+        gems_op=persistent_topk,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -7047,6 +7047,18 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
+  - id: persistent_topk
+    description: |
+      Triton persistent top-K for DeepSeek V4 sparse attention inference.
+      Workspace-cached ternary search algorithm selecting top-k indices from logits rows.
+    for:
+      - None
+    labels:
+      - fused
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.3'
   - id: top_k_per_row_prefill
     description: |
       Triton top-K per row for DeepSeek V4 sparse attention prefill phase.

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -63,6 +63,7 @@ from flag_gems.fused.moe_sum import moe_sum
 from flag_gems.fused.mrope import mrope
 from flag_gems.fused.outer import outer
 from flag_gems.fused.pack_seq import pack_seq_triton
+from flag_gems.fused.persistent_topk import persistent_topk
 from flag_gems.fused.reglu import dreglu, reglu
 from flag_gems.fused.reshape_and_cache import reshape_and_cache
 from flag_gems.fused.reshape_and_cache_flash import reshape_and_cache_flash
@@ -148,6 +149,7 @@ __all__ = [
     "skip_layer_norm",
     "sparse_attn_triton",
     "swiglu",
+    "persistent_topk",
     "top_k_per_row_decode",
     "top_k_per_row_prefill",
     "topk_softmax",

--- a/src/flag_gems/fused/persistent_topk.py
+++ b/src/flag_gems/fused/persistent_topk.py
@@ -1,0 +1,367 @@
+"""Persistent top-k kernel using workspace-cached ternary search.
+
+Selects the top-k indices from each row of a logits tensor, designed for
+DeepSeek-V4 sparse attention inference. Uses a two-phase approach:
+  1. Cache row data to workspace for L2 locality, find min/max.
+  2. Ternary search (4-way narrowing, 14 passes) to find threshold.
+  3. Scatter indices above threshold.
+  4. Fill remaining slots with elements equal to threshold.
+
+Falls back to direct HBM reads when workspace is too small.
+"""
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _topk_kernel_cached(
+    input_ptr,
+    output_ptr,
+    lengths_ptr,
+    cache_ptr,
+    num_rows,
+    stride,
+    top_k: tl.constexpr,
+    BLK: tl.constexpr,
+    NITER: tl.constexpr,
+):
+    """Workspace-cached ternary search.
+
+    Stores row data to workspace during min/max phase, then all subsequent
+    passes read from the workspace buffer for L2 locality.
+    """
+    row_idx = tl.program_id(0)
+    if row_idx >= num_rows:
+        return
+
+    seq_len = tl.load(lengths_ptr + row_idx).to(tl.int32)
+    seq_len = tl.where(seq_len > stride, stride, seq_len)
+    input_row = input_ptr + row_idx * stride
+    cache_row = cache_ptr + row_idx * stride
+    output_row = output_ptr + row_idx * top_k
+
+    # Trivial case: seq_len <= k, return all valid indices
+    if seq_len <= top_k:
+        for start in range(0, top_k, BLK):
+            offs = start + tl.arange(0, BLK)
+            store_mask = offs < top_k
+            vals = tl.where(
+                offs < seq_len,
+                offs.to(tl.int32),
+                tl.full([BLK], -1, dtype=tl.int32),
+            )
+            tl.store(output_row + offs, vals, mask=store_mask)
+        return
+
+    pos_inf = tl.full([BLK], float("inf"), dtype=tl.float32)
+    neg_inf = tl.full([BLK], float("-inf"), dtype=tl.float32)
+
+    # Phase 1: find min/max, cache row in workspace for L2 locality
+    row_min = tl.full([], float("inf"), dtype=tl.float32)
+    row_max = tl.full([], float("-inf"), dtype=tl.float32)
+
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(input_row + offs, mask=mask, other=0.0)
+        tl.store(cache_row + offs, vals, mask=mask)
+        row_min = tl.minimum(row_min, tl.min(tl.where(mask, vals, pos_inf), axis=0))
+        row_max = tl.maximum(row_max, tl.max(tl.where(mask, vals, neg_inf), axis=0))
+
+    K = top_k
+
+    # Phase 2: ternary search from workspace cache
+    # 4-way narrowing per iteration: 14 passes = 28 effective bisections
+    lo = row_min
+    hi = row_max
+
+    for _ in range(NITER):
+        span = hi - lo
+        mid1 = lo + span * 0.25
+        mid2 = lo + span * 0.5
+        mid3 = lo + span * 0.75
+
+        count1 = tl.zeros([], dtype=tl.int32)
+        count2 = tl.zeros([], dtype=tl.int32)
+        count3 = tl.zeros([], dtype=tl.int32)
+
+        for start in range(0, seq_len, BLK):
+            offs = start + tl.arange(0, BLK)
+            mask = offs < seq_len
+            vals = tl.load(cache_row + offs, mask=mask, other=float("-inf"))
+
+            above1 = mask & (vals >= mid1)
+            above2 = mask & (vals >= mid2)
+            above3 = mask & (vals >= mid3)
+
+            count1 += tl.sum(above1.to(tl.int32))
+            count2 += tl.sum(above2.to(tl.int32))
+            count3 += tl.sum(above3.to(tl.int32))
+
+        lo = tl.where(
+            count3 >= K,
+            mid3,
+            tl.where(count2 >= K, mid2, tl.where(count1 >= K, mid1, lo)),
+        )
+        hi = tl.where(
+            count3 >= K,
+            hi,
+            tl.where(count2 >= K, mid3, tl.where(count1 >= K, mid2, mid1)),
+        )
+
+    threshold = lo
+
+    # Phase 3: scatter indices where value > threshold (from cache)
+    write_pos = tl.zeros([], dtype=tl.int32)
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(cache_row + offs, mask=mask, other=float("-inf"))
+        above_mask = mask & (vals > threshold)
+        above_int = above_mask.to(tl.int32)
+        local_cumsum = tl.cumsum(above_int, axis=0)
+        write_offs = local_cumsum - 1 + write_pos
+        store_mask = above_mask & (write_offs < top_k)
+        tl.store(output_row + write_offs, offs.to(tl.int32), mask=store_mask)
+        write_pos += tl.sum(above_int)
+
+    # Phase 4: fill remaining slots with elements == threshold
+    equal_needed = top_k - write_pos
+    equal_written = tl.zeros([], dtype=tl.int32)
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(cache_row + offs, mask=mask, other=float("-inf"))
+        still_need = equal_needed - equal_written
+        eq_base = mask & (vals == threshold)
+        local_cumsum_eq = tl.cumsum(eq_base.to(tl.int32), axis=0)
+        eq_mask = eq_base & (local_cumsum_eq <= still_need)
+        eq_int = eq_mask.to(tl.int32)
+        local_cumsum = tl.cumsum(eq_int, axis=0)
+        write_offs = local_cumsum - 1 + write_pos + equal_written
+        store_mask = eq_mask & (write_offs < top_k) & (write_offs >= 0)
+        tl.store(output_row + write_offs, offs.to(tl.int32), mask=store_mask)
+        equal_written += tl.sum(eq_int)
+
+
+@triton.jit
+def _topk_kernel_direct(
+    input_ptr,
+    output_ptr,
+    lengths_ptr,
+    num_rows,
+    stride,
+    top_k: tl.constexpr,
+    BLK: tl.constexpr,
+    NITER: tl.constexpr,
+):
+    """Direct ternary search fallback when workspace is too small.
+
+    Same algorithm as cached variant but reads from HBM each iteration.
+    """
+    row_idx = tl.program_id(0)
+    if row_idx >= num_rows:
+        return
+
+    seq_len = tl.load(lengths_ptr + row_idx).to(tl.int32)
+    seq_len = tl.where(seq_len > stride, stride, seq_len)
+    input_row = input_ptr + row_idx * stride
+    output_row = output_ptr + row_idx * top_k
+
+    # Trivial case: seq_len <= k, return all valid indices
+    if seq_len <= top_k:
+        for start in range(0, top_k, BLK):
+            offs = start + tl.arange(0, BLK)
+            store_mask = offs < top_k
+            vals = tl.where(
+                offs < seq_len,
+                offs.to(tl.int32),
+                tl.full([BLK], -1, dtype=tl.int32),
+            )
+            tl.store(output_row + offs, vals, mask=store_mask)
+        return
+
+    pos_inf = tl.full([BLK], float("inf"), dtype=tl.float32)
+    neg_inf = tl.full([BLK], float("-inf"), dtype=tl.float32)
+
+    # Phase 1: find min/max of the row
+    row_min = tl.full([], float("inf"), dtype=tl.float32)
+    row_max = tl.full([], float("-inf"), dtype=tl.float32)
+
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(input_row + offs, mask=mask, other=0.0)
+        row_min = tl.minimum(row_min, tl.min(tl.where(mask, vals, pos_inf), axis=0))
+        row_max = tl.maximum(row_max, tl.max(tl.where(mask, vals, neg_inf), axis=0))
+
+    K = top_k
+
+    # Phase 2: ternary search from HBM
+    lo = row_min
+    hi = row_max
+
+    for _ in range(NITER):
+        span = hi - lo
+        mid1 = lo + span * 0.25
+        mid2 = lo + span * 0.5
+        mid3 = lo + span * 0.75
+
+        count1 = tl.zeros([], dtype=tl.int32)
+        count2 = tl.zeros([], dtype=tl.int32)
+        count3 = tl.zeros([], dtype=tl.int32)
+
+        for start in range(0, seq_len, BLK):
+            offs = start + tl.arange(0, BLK)
+            mask = offs < seq_len
+            vals = tl.load(input_row + offs, mask=mask, other=float("-inf"))
+
+            above1 = mask & (vals >= mid1)
+            above2 = mask & (vals >= mid2)
+            above3 = mask & (vals >= mid3)
+
+            count1 += tl.sum(above1.to(tl.int32))
+            count2 += tl.sum(above2.to(tl.int32))
+            count3 += tl.sum(above3.to(tl.int32))
+
+        lo = tl.where(
+            count3 >= K,
+            mid3,
+            tl.where(count2 >= K, mid2, tl.where(count1 >= K, mid1, lo)),
+        )
+        hi = tl.where(
+            count3 >= K,
+            hi,
+            tl.where(count2 >= K, mid3, tl.where(count1 >= K, mid2, mid1)),
+        )
+
+    threshold = lo
+
+    # Phase 3: scatter indices where value > threshold
+    write_pos = tl.zeros([], dtype=tl.int32)
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(input_row + offs, mask=mask, other=float("-inf"))
+        above_mask = mask & (vals > threshold)
+        above_int = above_mask.to(tl.int32)
+        local_cumsum = tl.cumsum(above_int, axis=0)
+        write_offs = local_cumsum - 1 + write_pos
+        store_mask = above_mask & (write_offs < top_k)
+        tl.store(output_row + write_offs, offs.to(tl.int32), mask=store_mask)
+        write_pos += tl.sum(above_int)
+
+    # Phase 4: fill remaining slots with elements == threshold
+    equal_needed = top_k - write_pos
+    equal_written = tl.zeros([], dtype=tl.int32)
+    for start in range(0, seq_len, BLK):
+        offs = start + tl.arange(0, BLK)
+        mask = offs < seq_len
+        vals = tl.load(input_row + offs, mask=mask, other=float("-inf"))
+        still_need = equal_needed - equal_written
+        eq_base = mask & (vals == threshold)
+        local_cumsum_eq = tl.cumsum(eq_base.to(tl.int32), axis=0)
+        eq_mask = eq_base & (local_cumsum_eq <= still_need)
+        eq_int = eq_mask.to(tl.int32)
+        local_cumsum = tl.cumsum(eq_int, axis=0)
+        write_offs = local_cumsum - 1 + write_pos + equal_written
+        store_mask = eq_mask & (write_offs < top_k) & (write_offs >= 0)
+        tl.store(output_row + write_offs, offs.to(tl.int32), mask=store_mask)
+        equal_written += tl.sum(eq_int)
+
+
+# Default kernel parameters (passed as tl.constexpr)
+_DEFAULT_BLOCK_SIZE = 4096
+_DEFAULT_NUM_SEARCH_ITERS = 14  # 14 ternary passes = 28 effective bisections
+
+# Workspace size in bytes (must be >= 1 MiB for the CUDA baseline contract)
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+
+def persistent_topk(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_workspace: torch.Tensor,
+    k: int,
+    max_seq_len: int,
+) -> None:
+    """Select top-k indices per row using persistent ternary search.
+
+    Args:
+        logits: [num_rows, stride] float32 input logits.
+        seq_lens: [num_rows] or [batch, next_n] int32 sequence lengths.
+        topk_indices: [num_rows, k] int32 output buffer (mutated in-place).
+        topk_workspace: [>=1048576] uint8 workspace buffer.
+        k: Number of top elements to select per row.
+        max_seq_len: Maximum sequence length (used as stride).
+    """
+    logger.debug("GEMS PERSISTENT_TOPK")
+
+    num_rows = topk_indices.shape[0]
+    stride = max_seq_len
+
+    # Handle multi-dimensional seq_lens (batch, next_n) format
+    if seq_lens.dim() == 2:
+        batch_size = seq_lens.shape[0]
+        next_n = seq_lens.shape[1]
+        if next_n == 1:
+            tokens_per_batch = num_rows // batch_size
+            seq_lens_flat = (
+                seq_lens.squeeze(1)
+                .unsqueeze(1)
+                .expand(batch_size, tokens_per_batch)
+                .reshape(-1)
+                .contiguous()
+            )
+        else:
+            seq_lens_flat = seq_lens.reshape(-1).contiguous()
+    else:
+        seq_lens_flat = seq_lens
+
+    # Expand seq_lens if fewer entries than rows (broadcast per batch)
+    if seq_lens_flat.shape[0] < num_rows:
+        batch_size = seq_lens_flat.shape[0]
+        tokens_per_batch = num_rows // batch_size
+        seq_lens_flat = (
+            seq_lens_flat.unsqueeze(1)
+            .expand(batch_size, tokens_per_batch)
+            .reshape(-1)
+            .contiguous()
+        )
+
+    ws_float = topk_workspace.view(torch.float32)
+    ws_needed = num_rows * stride
+    use_cache = ws_float.numel() >= ws_needed
+
+    grid = (num_rows,)
+
+    if use_cache:
+        _topk_kernel_cached[grid](
+            logits,
+            topk_indices,
+            seq_lens_flat,
+            ws_float,
+            num_rows,
+            stride,
+            k,
+            BLK=_DEFAULT_BLOCK_SIZE,
+            NITER=_DEFAULT_NUM_SEARCH_ITERS,
+        )
+    else:
+        _topk_kernel_direct[grid](
+            logits,
+            topk_indices,
+            seq_lens_flat,
+            num_rows,
+            stride,
+            k,
+            BLK=_DEFAULT_BLOCK_SIZE,
+            NITER=_DEFAULT_NUM_SEARCH_ITERS,
+        )

--- a/tests/test_persistent_topk.py
+++ b/tests/test_persistent_topk.py
@@ -1,0 +1,89 @@
+"""Accuracy tests for persistent_topk (DeepSeek V4 sparse attention top-K).
+
+Tests the Triton workspace-cached ternary search kernel against the vLLM CUDA
+reference. Uses value-based comparison (sorted selected values must match) to
+handle non-deterministic tie-breaking between implementations.
+"""
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import persistent_topk
+
+from . import conftest as cfg
+
+device = flag_gems.device
+
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+# --- vLLM CUDA reference (optional) ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_persistent_topk(logits, seq_lens, topk_indices, workspace, k, stride):
+        torch.ops._C.persistent_topk(
+            logits, seq_lens, topk_indices, workspace, k, stride
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_persistent_topk = None
+
+
+def _torch_topk_ref(logits, seq_lens, topk_indices, workspace, k, stride):
+    """Pure-PyTorch fallback reference using torch.topk."""
+    num_rows = logits.shape[0]
+    for i in range(num_rows):
+        seq_len = seq_lens[i].item()
+        valid_logits = logits[i, :seq_len]
+        _, top_idx = torch.topk(valid_logits, k, largest=True, sorted=False)
+        topk_indices[i].copy_(top_idx.to(torch.int32))
+
+
+_baseline_op = _vllm_persistent_topk if HAS_VLLM else _torch_topk_ref
+
+# --- Shape configuration with QUICK_MODE support ---
+if cfg.QUICK_MODE:
+    SHAPES = [(1, 4096, 1024)]
+else:
+    SHAPES = [
+        (1, 1024, 1024),
+        (1, 2048, 1024),
+        (1, 4096, 1024),
+        (4, 4096, 1024),
+        (8, 8192, 1024),
+        (16, 16384, 1024),
+        (32, 32768, 1024),
+        (4, 4096, 512),
+        (4, 4096, 2048),
+    ]
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=[f"{r}x{s}_k{k}" for r, s, k in SHAPES])
+def test_persistent_topk(shape):
+    num_rows, seq_len, k = shape
+    stride = seq_len
+
+    logits = torch.randn(num_rows, stride, device=device, dtype=torch.float32)
+    seq_lens = torch.full((num_rows,), seq_len, device=device, dtype=torch.int32)
+    topk_indices_ref = torch.zeros(num_rows, k, device=device, dtype=torch.int32)
+    topk_indices_res = torch.zeros(num_rows, k, device=device, dtype=torch.int32)
+    workspace = torch.zeros(RADIX_TOPK_WORKSPACE_SIZE, device=device, dtype=torch.uint8)
+
+    # Reference
+    _baseline_op(logits, seq_lens, topk_indices_ref, workspace, k, stride)
+
+    # Triton implementation
+    persistent_topk(logits, seq_lens, topk_indices_res, workspace, k, stride)
+
+    # Compare: top-k indices are unordered, so compare selected values
+    for i in range(num_rows):
+        ref_idx = topk_indices_ref[i].long()
+        res_idx = topk_indices_res[i].long()
+
+        ref_vals = torch.sort(logits[i][ref_idx], descending=True).values
+        res_vals = torch.sort(logits[i][res_idx], descending=True).values
+
+        torch.testing.assert_close(res_vals, ref_vals, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
## Summary

Add a Triton implementation of `persistent_topk` for DeepSeek-V4 sparse attention inference. This operator selects the top-k indices from each row of a logits tensor using a workspace-cached ternary search algorithm (4-way narrowing, 14 passes = 28 effective bisections). It replaces the vLLM CUDA `persistent_topk` kernel with a portable Triton implementation.

## Algorithm

1. **Phase 1**: Cache row data to workspace for L2 locality, compute min/max.
2. **Phase 2**: Ternary search (14 iterations) to find threshold value.
3. **Phase 3**: Scatter indices where value > threshold.
4. **Phase 4**: Fill remaining slots with elements equal to threshold.

Falls back to direct HBM reads when workspace is too small for caching.

## Correctness Verification

All test shapes pass correctness check against vLLM CUDA baseline (`torch.ops._C.persistent_topk`).
Comparison method: sort selected values descending and assert_close (atol=1e-6, rtol=1e-6).

| num_rows | seq_len | k | Result |
|----------|---------|------|--------|
| 1 | 1024 | 1024 | PASS |
| 1 | 2048 | 1024 | PASS |
| 1 | 4096 | 1024 | PASS |
| 4 | 4096 | 1024 | PASS |
| 8 | 8192 | 1024 | PASS |
| 16 | 16384 | 1024 | PASS |
| 32 | 32768 | 1024 | PASS |
| 4 | 4096 | 512 | PASS |
| 4 | 4096 | 2048 | PASS |

## Performance vs VLLM (NVIDIA H20)

| Configuration | Triton (us) | vLLM CUDA (us) | Speedup |
|---------------|-------------|----------------|---------|
| decode-1-1k (1, 1024, k=1024) | 28.5 | 18.1 | 0.64x |
| decode-1-2k (1, 2048, k=1024) | 28.2 | 23.2 | 0.82x |
| decode-1-4k (1, 4096, k=1024) | 28.9 | 17.5 | 0.61x |
| decode-4-4k (4, 4096, k=1024) | 29.4 | 19.9 | 0.68x |
| decode-8-8k (8, 8192, k=1024) | 56.2 | 23.8 | 0.42x |
| batch-16-16k (16, 16384, k=1024) | 107.8 | 21.6 | 0.20x |
| batch-32-32k (32, 32768, k=1024) | 217.8 | 24.2 | 0.11x |
| decode-4-4k-k512 (4, 4096, k=512) | 29.3 | 20.1 | 0.69x |
| decode-4-4k-k2048 (4, 4096, k=2048) | 32.3 | 19.1 | 0.59x |

Geometric mean speedup: 0.53x

## Files Changed

- **New**: `src/flag_gems/fused/persistent_topk.py` — Triton kernel implementation
- **New**: `tests/test_persistent_topk.py` — Correctness tests vs vLLM CUDA
- **New**: `benchmark/test_persistent_topk.py` — Performance benchmark
- **Modified**: `src/flag_gems/fused/__init__.py` — Register operator import
- **Modified**: `conf/operators.yaml` — Add operator metadata