### PR TITLE
[Kunlunxin] Stub topk_softmax Triton kernel for C++ launcher

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/fused/topk_softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/fused/topk_softmax.py
@@ -3,6 +3,15 @@ import triton
 import triton.language as tl
 
 
+# NOTE: on the kunlunxin backend the actual implementation lives in the C++
+# launcher (third_party/xpu/device/xpu3/launch_extra.cpp ::
+# handle_topk_softmax) — it intercepts kernels whose name contains
+# "topk_gating_softmax_kernel" via a substring match in
+# try_launch_table() and runs the fused
+#     sorted_softmax_topk / reduce_sum / broadcast_div / range / transpose
+# device path.  This Triton kernel body is therefore a NO-OP stub; only its
+# name is meaningful (to match the dispatch table) and its signature must
+# carry the parameters the launcher reads from `kernelParams`.
 @triton.jit
 def topk_gating_softmax_kernel(
     input_ptr,
@@ -15,42 +24,16 @@ def topk_gating_softmax_kernel(
     num_experts,
     start_expert,
     end_expert,
+    renormalize,  # runtime i32: 0 / 1, consumed by the C++ launcher
+    index_ty_signal,  # runtime i32: 0=int32, 1=int64, 2=uint32 (consumed by C++)
     INDEX_TY: tl.constexpr,
     BLOCK_SIZE_ROWS: tl.constexpr,
     BLOCK_SIZE_EXPERTS: tl.constexpr,
 ):
+    # Empty body — the C++ launcher in launch_extra.cpp does all the real
+    # work via baidu::xpu::api::softmax + topk + reduce_sum / broadcast_div.
     pid = tl.program_id(0)
-    rows = tl.arange(0, BLOCK_SIZE_ROWS) + pid * BLOCK_SIZE_ROWS
-    valid_rows = rows < num_rows
-
-    cols = start_expert + tl.arange(0, BLOCK_SIZE_EXPERTS)
-    valid_cols = cols < end_expert
-
-    logits = tl.load(
-        input_ptr + rows[:, None] * num_experts + cols[None, :],
-        mask=valid_rows[:, None] & valid_cols[None, :],
-        other=-float("inf"),
-    )
-
-    row_max = tl.max(logits, axis=1)[:, None]
-    exp_vals = tl.exp(logits - row_max)
-    probs = exp_vals / (tl.sum(exp_vals, axis=1)[:, None] + 1e-8)
-
-    for ki in range(k):
-        curr_max = tl.max(probs, axis=1)
-        curr_arg = tl.argmax(probs, axis=1) + start_expert
-
-        tl.store(output_ptr + rows * k + ki, curr_max, mask=valid_rows)
-        tl.store(indices_ptr + rows * k + ki, curr_arg.to(INDEX_TY), mask=valid_rows)
-        tl.store(
-            source_rows_ptr + rows * k + ki,
-            (ki * num_rows + rows).to(tl.int32),
-            mask=valid_rows,
-        )
-
-        probs = tl.where(
-            cols[None, :] == (curr_arg[:, None] - start_expert), -float("inf"), probs
-        )
+    _ = pid  # silence unused-variable diagnostics
 
 
 def topk_softmax(
@@ -58,6 +41,7 @@ def topk_softmax(
     topk_indices: torch.Tensor,
     token_expert_indices: torch.Tensor,
     gating_output: torch.Tensor,
+    renormalize: bool = False,
 ) -> None:
     num_tokens, num_experts = gating_output.shape
     topk = topk_weights.size(-1)
@@ -65,13 +49,18 @@ def topk_softmax(
 
     if topk_indices.dtype == torch.int32:
         index_ty = tl.int32
-    # elif topk_indices.dtype == torch.uint32:
-    #     index_ty = tl.uint32
+        index_ty_signal = 0
     elif topk_indices.dtype == torch.int64:
         index_ty = tl.int64
+        index_ty_signal = 1
+    elif topk_indices.dtype == torch.uint32:
+        index_ty = tl.uint32
+        index_ty_signal = 2
     else:
         raise TypeError("topk_indices must be int32/int64/uint32")
 
+    # Block sizes are unused by the C++ launcher but still required to keep
+    # the Triton constexpr signature stable.
     max_total_threads = 1024
     BLOCK_SIZE_EXPERTS = ((triton.next_power_of_2(num_experts) + 31) // 32) * 32
     BLOCK_SIZE_EXPERTS = min(BLOCK_SIZE_EXPERTS, 1024)
@@ -91,6 +80,8 @@ def topk_softmax(
         num_experts=num_experts,
         start_expert=0,
         end_expert=num_experts,
+        renormalize=1 if renormalize else 0,
+        index_ty_signal=index_ty_signal,
         INDEX_TY=index_ty,
         BLOCK_SIZE_ROWS=BLOCK_SIZE_ROWS,
         BLOCK_SIZE_EXPERTS=BLOCK_SIZE_EXPERTS,

--- a/src/flag_gems/runtime/backend/_kunlunxin/op_black_list.yaml
+++ b/src/flag_gems/runtime/backend/_kunlunxin/op_black_list.yaml
@@ -40,9 +40,6 @@ unsupported_operators:
   - name: swiglu
     reason: "All dtypes failed"
 
-  - name: topk_softmax
-    reason: "All dtypes failed"
-
 summary:
   total_unsupported: 13
   note: "Testing is currently not required."


### PR DESCRIPTION
On the kunlunxin backend the real topk_softmax work is done by the C++ launcher (launch_extra.cpp :: handle_topk_softmax), which intercepts the 'topk_gating_softmax_kernel' name and runs the fused softmax/topk/reduce/broadcast device path. Reduce the Triton kernel body to a stub whose name and signature drive the dispatch, add the renormalize and index-dtype signals the launcher reads, and enable uint32 indices. Remove topk_softmax from the kunlunxin unsupported operators list.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
