### PR TITLE
[Kunlunxin] Register cumprod / cumprod_ in __init__

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
@@ -59,6 +59,7 @@ from .cos import cos, cos_
 from .count_nonzero import count_nonzero
 from .cummax import cummax
 from .cummin import cummin
+from .cumprod import cumprod, cumprod_
 from .cumsum import cumsum, cumsum_out, normed_cumsum
 from .diag import diag
 from .diag_embed import diag_embed
@@ -319,6 +320,7 @@ __all__ = [
     "count_nonzero",
     "cummax",
     "cummin",
+    "cumprod",
     "cumprod_",
     "cumsum",
     "cumsum_out",


### PR DESCRIPTION
The cumprod op implementation (ops/cumprod.py) already exists on the kunlunxin backend but was never imported, so it was effectively unregistered. Add the missing import and __all__ entry.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
