### PR TITLE
[KMCompiler][Nvidia] add nansum operator with triton kernel

### DIFF
--- a/benchmark/test_nansum.py
+++ b/benchmark/test_nansum.py
@@ -1,0 +1,59 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.utils import shape_utils
+
+from . import base
+
+
+class _NansumBenchmark(base.GenericBenchmark):
+    """Benchmark for nansum with GBPS metric."""
+
+    def set_more_metrics(self):
+        return ["gbps"]
+
+    def get_gbps(self, bench_fn_args, latency):
+        inp = bench_fn_args[0]
+        io_amount = shape_utils.size_in_bytes(inp) * 2
+        return io_amount * 1e-9 / (latency * 1e-3)
+
+
+def _nansum_input_fn(shape, dtype, device):
+    num_elements = 1
+    for s in shape:
+        num_elements *= s
+
+    max_elements = 536870912 if dtype == torch.float64 else 1073741824
+    if num_elements >= max_elements:
+        return
+
+    x = torch.randn(shape, dtype=dtype, device=device) * 10
+    mask = torch.rand(shape, device=device) > 0.7
+    x[mask] = float("nan")
+
+    yield (x,)
+
+
+@pytest.mark.nansum
+def test_benchmark_nansum():
+    bench = _NansumBenchmark(
+        op_name="nansum",
+        torch_op=torch.nansum,
+        input_fn=_nansum_input_fn,
+        dtypes=[torch.float32, torch.float64],
+    )
+    bench.set_gems(flag_gems.nansum)
+    bench.run()
+
+
+@pytest.mark.nansum_dim
+def test_benchmark_nansum_dim():
+    bench = _NansumBenchmark(
+        op_name="nansum_dim",
+        torch_op=lambda x: torch.nansum(x, dim=-1),
+        input_fn=_nansum_input_fn,
+        dtypes=[torch.float32, torch.float64],
+    )
+    bench.set_gems(lambda x: flag_gems.nansum(x, dim=-1))
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -4895,6 +4895,19 @@ ops:
       - LinearAlg
     stages:
       - beta: '5.4'
+  - id: nansum
+    description: |
+      Returns the sum of all elements in the `input` tensor, treating `NaN` values as zero.
+      Supports global reduction and reduction along specified dimensions.
+    for:
+      - nansum
+    labels:
+      - aten
+      - Reduction
+    kind:
+      - LinearAlg
+    stages:
+      - beta: '5.4'
   - id: ne
     description: Computes that `input` is not equal to `other` element-wise.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -458,6 +458,7 @@ _FULL_CONFIG = (
     ("nanmedian.dim", nanmedian_dim),
     ("nanmedian.dim_values", nanmedian_dim_values),
     ("nanmedian.out", nanmedian_out),
+    ("nansum", nansum),
     ("native_batch_norm", batch_norm),
     ("native_batch_norm_backward", batch_norm_backward),
     ("native_dropout", dropout),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -304,6 +304,7 @@ from flag_gems.ops.nanmedian import (
     nanmedian_dim_values,
     nanmedian_out,
 )
+from flag_gems.ops.nansum import nansum, nansum_dim
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
 from flag_gems.ops.negative import negative
@@ -881,6 +882,8 @@ __all__ = [
     "nanmedian_dim",
     "nanmedian_dim_values",
     "nanmedian_out",
+    "nansum",
+    "nansum_dim",
     "ne",
     "ne_scalar",
     "neg",

--- a/src/flag_gems/ops/nansum.py
+++ b/src/flag_gems/ops/nansum.py
@@ -1,0 +1,259 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry
+
+logger = logging.getLogger(__name__)
+
+
+def _promote_for_nansum(inp: torch.Tensor) -> torch.Tensor:
+    if inp.dtype in (torch.int8, torch.int16, torch.int32, torch.int64, torch.bool):
+        return inp.to(torch.float32)
+    if inp.dtype in (torch.float16, torch.bfloat16):
+        return inp.to(torch.float32)
+    return inp
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8),
+    ],
+    key=["numel"],
+)
+@triton.jit
+def _nan_to_zero_kernel(
+    inp_ptr,
+    out_ptr,
+    numel,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Element-wise NaN to zero conversion for small tensor or dim == 1."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    val = tl.load(inp_ptr + offsets, mask=mask, other=0.0)
+    val = tl.where(val != val, 0.0, val)
+    tl.store(out_ptr + offsets, val, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _nansum_parallel_reduce(
+    inp_ptr,
+    out_ptr,
+    data_size,
+    BLOCK_SIZE: tl.constexpr,
+    FP64: tl.constexpr,
+):
+    """Stage 1 parallel reduce: each block reduces BLOCK_SIZE contiguous elements."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < data_size
+
+    x = tl.load(inp_ptr + offsets, mask=mask, other=0.0)
+    x = tl.where(x != x, 0.0, x)
+
+    block_sum = tl.sum(x, axis=0)
+    tl.store(out_ptr + pid, block_sum)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8),
+    ],
+    key=["data_size"],
+)
+@triton.jit
+def _nansum_final_reduce(
+    inp_ptr,
+    out_ptr,
+    data_size,
+    BLOCK_SIZE: tl.constexpr,
+    FP64: tl.constexpr,
+):
+    """Stage 2 final reduce: single block reads entire input, outputs a scalar."""
+    if FP64:
+        total = tl.zeros((), dtype=tl.float64)
+    else:
+        total = tl.zeros((), dtype=tl.float32)
+
+    for start in range(0, data_size, BLOCK_SIZE):
+        idx = start + tl.arange(0, BLOCK_SIZE)
+        mask = idx < data_size
+        val = tl.load(inp_ptr + idx, mask=mask, other=0.0)
+        val = tl.where(val != val, 0.0, val)
+        total += tl.sum(val, axis=0)
+
+    tl.store(out_ptr, total)
+
+
+def _nansum_global(inp, *, dtype=None):
+    logger.debug("GEMS NANSUM (GLOBAL)")
+
+    if dtype is None:
+        dtype = inp.dtype
+
+    if inp.numel() == 0:
+        return torch.tensor(0, dtype=dtype, device=inp.device)
+
+    work = _promote_for_nansum(inp.contiguous())
+    M = work.numel()
+    fp64 = work.dtype == torch.float64
+
+    if M <= 16384:
+        out = torch.zeros([], dtype=work.dtype, device=work.device)
+        with torch_device_fn.device(work.device):
+            _nansum_final_reduce[(1,)](work, out, M, FP64=fp64)
+        return out.to(dtype)
+
+    block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
+    mid_size = triton.cdiv(M, block_size)
+    mid = torch.empty(mid_size, dtype=work.dtype, device=work.device)
+
+    with torch_device_fn.device(work.device):
+        _nansum_parallel_reduce[(mid_size,)](work, mid, M, block_size, FP64=fp64)
+        out = torch.zeros([], dtype=work.dtype, device=work.device)
+        _nansum_final_reduce[(1,)](mid, out, mid_size, FP64=fp64)
+
+    return out.to(dtype)
+
+
+def nansum(inp, dim=None, keepdim=False, *, dtype=None):
+    logger.debug("GEMS NANSUM")
+    if dim is None:
+        return _nansum_global(inp, dtype=dtype)
+    return nansum_dim(inp, dim=dim, keepdim=keepdim, dtype=dtype)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 32}, num_warps=2),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 64}, num_warps=4),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 128}, num_warps=4),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 256}, num_warps=4),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 512}, num_warps=8),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 256}, num_warps=4),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 512}, num_warps=8),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 1024}, num_warps=8),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=8),
+    ],
+    key=["M", "N"],
+)
+@triton.jit
+def _nansum_dim_kernel(
+    inp_ptr,
+    out_ptr,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    FP64: tl.constexpr,
+):
+    """Reduce along the last dimension using a 2D tile (BLOCK_M x BLOCK_N)."""
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    inp_ptr = inp_ptr + pid * N
+    out_ptr = out_ptr + pid
+    row_mask = pid < M
+
+    if FP64:
+        acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float64)
+    else:
+        acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    for off in range(0, N, BLOCK_N):
+        cols = off + tl.arange(0, BLOCK_N)[None, :]
+        col_mask = cols < N
+        mask = row_mask & col_mask
+        val = tl.load(inp_ptr + cols, mask, other=0.0)
+        val = tl.where(val != val, 0.0, val)
+        acc += val
+
+    result = tl.sum(acc, axis=1)[:, None]
+    tl.store(out_ptr, result, row_mask)
+
+
+def nansum_dim(inp, dim=None, keepdim=False, *, dtype=None):
+    logger.debug("GEMS NANSUM_DIM")
+
+    if dtype is None:
+        dtype = inp.dtype
+
+    if inp.numel() == 0:
+        out_shape = list(inp.shape)
+        if dim is None:
+            out_shape = [1] * inp.ndim if keepdim else []
+        else:
+            dims = [dim] if isinstance(dim, int) else list(dim)
+            dims = [d if d >= 0 else d + inp.ndim for d in dims]
+            if keepdim:
+                for d in dims:
+                    out_shape[d] = 1
+            else:
+                for d in sorted(set(dims), reverse=True):
+                    out_shape.pop(d)
+        return torch.zeros(out_shape, dtype=dtype, device=inp.device)
+
+    if dim is None:
+        dims = list(range(inp.ndim))
+    elif isinstance(dim, int):
+        dims = [dim if dim >= 0 else dim + inp.ndim]
+    else:
+        dims = [d if d >= 0 else d + inp.ndim for d in dim]
+
+    dims = sorted(set(dims), reverse=True)
+
+    if len(dims) == inp.ndim:
+        result = _nansum_global(inp, dtype=dtype)
+        if keepdim:
+            result = result.reshape([1] * inp.ndim)
+        return result
+
+    work = _promote_for_nansum(inp)
+    shape = list(work.shape)
+    fp64 = work.dtype == torch.float64
+
+    work = dim_compress(work, dims)
+    N = 1
+    for d in dims:
+        N *= shape[d]
+        shape[d] = 1
+    M = work.numel() // N
+
+    if N <= 1:
+        out = torch.empty_like(work)
+        numel = work.numel()
+        grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+        with torch_device_fn.device(work.device):
+            _nan_to_zero_kernel[grid](work, out, numel)
+        out = out.reshape(shape)
+        if not keepdim:
+            for d in sorted(dims, reverse=True):
+                out = out.squeeze(dim=d)
+        return out.to(dtype)
+
+    out_flat = torch.empty(M, dtype=work.dtype, device=work.device)
+
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    with torch_device_fn.device(work.device):
+        _nansum_dim_kernel[grid](work, out_flat, M, N, FP64=fp64)
+
+    out = out_flat.reshape(shape)
+    if not keepdim:
+        for d in sorted(dims, reverse=True):
+            out = out.squeeze(dim=d)
+
+    return out.to(dtype)

--- a/tests/test_nansum.py
+++ b/tests/test_nansum.py
@@ -1,0 +1,94 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    DIMS = [1]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    DIMS = [0, 1, (0, 1)]
+
+INCLUDE_0_SHAPES = [(1, 0, 128), (4096, 1, 0), (200, 0, 3)]
+
+
+def _nan_input(shape, dtype, device, nan_ratio=0.3):
+    """Create tensor with ~nan_ratio fraction of NaN values."""
+    x = torch.randn(shape, dtype=dtype, device=device) * 10
+    mask = torch.rand(shape, device=device) < nan_ratio
+    x[mask] = float("nan")
+    return x
+
+
+@pytest.mark.nansum
+@pytest.mark.parametrize("shape", utils.REDUCTION_SHAPES + INCLUDE_0_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_nansum(shape, dtype):
+    inp = _nan_input(shape, dtype, flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nansum(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nansum(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=inp.numel())
+
+
+@pytest.mark.nansum_dim
+@pytest.mark.parametrize("shape", utils.REDUCTION_SHAPES)
+@pytest.mark.parametrize("dim", DIMS)
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_nansum_dim(shape, dim, keepdim, dtype):
+    if isinstance(dim, int) and dim >= len(shape):
+        return
+
+    inp = _nan_input(shape, dtype, flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nansum(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.nansum(inp, dim=dim, keepdim=keepdim)
+
+    if isinstance(dim, int):
+        dims = [dim]
+    else:
+        dims = list(dim)
+    dims = [d % inp.ndim for d in dims]
+    _dim = 1
+    for d in dims:
+        _dim *= shape[d]
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=_dim)
+
+
+@pytest.mark.nansum_edge
+def test_nansum_edge():
+    device = flag_gems.device
+
+    # all NaN elements should produce 0
+    x = torch.full((5, 5), float("nan"), device=device)
+    ref_inp = utils.to_reference(x, True)
+    ref_out = torch.nansum(ref_inp, dim=1)
+    with flag_gems.use_gems():
+        res = torch.nansum(x, dim=1)
+    utils.gems_assert_close(res, ref_out, torch.float32, reduce_dim=5)
+
+    # integer input with type promotion and conversion
+    x = torch.tensor([1, 2, 3, 4], device=device)
+    ref_inp = utils.to_reference(x, True)
+    ref_out = torch.nansum(ref_inp)
+    with flag_gems.use_gems():
+        res = torch.nansum(x)
+    utils.gems_assert_close(res, ref_out, torch.int64, reduce_dim=4)
+
+    # empty tensor should return 0
+    x = torch.empty(0, device=device)
+    ref_inp = utils.to_reference(x, True)
+    ref_out = torch.nansum(ref_inp)
+    with flag_gems.use_gems():
+        res = torch.nansum(x)
+    utils.gems_assert_close(res, ref_out, torch.float32, reduce_dim=0)


### PR DESCRIPTION
## Summary
Adds the `nansum` operator, providing a high-performance Triton kernel implementation for NVIDIA (CUDA) backends. This operator computes the sum of tensor elements treating NaN values as zero, supporting global reduction and reduction along specified dimensions with type promotion.

## Implementation
Implemented in `src/flag_gems/ops/nansum.py` with a unified entry point `nansum(inp, dim=None, keepdim=False, *, dtype=None)` that dispatches to global or dim reduction paths:

- **Global Reduction**: Two-stage Triton reduction. Stage 1 parallel-reduces blocks of `sqrt(M)` elements into an intermediate buffer, and Stage 2 accumulates the intermediate results into a scalar. Tensors with ≤ 16K elements use a single-block path directly.
- **Dim Reduction**: Uses a `BLOCK_M × BLOCK_N` 2D-tile kernel with autotuning across 9 configurations covering narrow, medium, and wide reduction dimensions. When the reduction dimension has ≤ 1 element, a pointwise NaN-to-zero kernel is used instead of full reduction.
- **Type Promotion**: Integer, bool, float16, and bfloat16 inputs are promoted to float32 for accumulation to maintain precision. float32 and float64 are preserved natively.
- **Empty Tensor & Edge Cases**: Handles empty tensors (returns 0), all-NaN tensors (returns 0), and integer inputs with correct dtype promotion.

## Testing
### Accuracy Test: 73 PASSED on NVIDIA H20.
- **Test Coverage**: Global nansum (6 shapes × 3 dtypes + 3 zero-dim shapes), dim nansum (3 shapes × 3 dims × 2 keepdim × 3 dtypes), edge cases (all-NaN, integer input, empty tensor).
- **Dtypes**: float16, float32, bfloat16 (float64 automatically added on platforms that support it via `fp64_is_supported`).

### Performance (NVIDIA - H20)
The NVIDIA implementation shows solid performance, particularly for large-scale data and dim reduction.

Peak Speedup: **3.09x** (float32 dim nansum on [100, 65536, 100]).

**NVIDIA nansum Results (float32)**

| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Torch GBPS | Gems GBPS | Size Detail              |
|---------|--------------------|--------------------|--------------|------------|-----------|--------------------------|
| SUCCESS | 0.006880           | 0.007168           | 0.960        | 4.763      | 4.571     | [64, 64]                 |
| SUCCESS | 0.035264           | 0.029856           | 1.181        | 3806.083   | 4495.503  | [4096, 4096]             |
| SUCCESS | 0.035264           | 0.031232           | 1.129        | 3806.083   | 4297.443  | [64, 512, 512]           |
| SUCCESS | 0.362752           | 0.278432           | 1.303        | 5919.978   | 7712.776  | [268435456]              |
| SUCCESS | 0.008512           | 0.008704           | 0.978        | 9.398      | 9.191     | [10000, 1]               |
| SUCCESS | 0.014848           | 0.014304           | 1.038        | 1379.310   | 1431.767  | [10000, 256]             |
| SUCCESS | 0.793184           | 0.627488           | 1.264        | 6609.917   | 8355.347  | [10000, 65536]           |
| SUCCESS | 0.008256           | 0.008736           | 0.945        | 9.690      | 9.158     | [100, 1, 100]            |
| SUCCESS | 0.014752           | 0.014496           | 1.018        | 1388.286   | 1412.804  | [100, 256, 100]          |
| SUCCESS | 0.772256           | 0.627424           | 1.231        | 6789.044   | 8356.199  | [100, 65536, 100]        |

**NVIDIA nansum_dim Results (float32)**

| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Torch GBPS | Gems GBPS | Size Detail              |
|---------|--------------------|--------------------|--------------|------------|-----------|--------------------------|
| SUCCESS | 0.006400           | 0.005280           | 1.212        | 5.120      | 6.206     | [64, 64]                 |
| SUCCESS | 0.033120           | 0.027808           | 1.191        | 4052.468   | 4826.587  | [4096, 4096]             |
| SUCCESS | 0.038496           | 0.029440           | 1.308        | 3486.537   | 4559.026  | [64, 512, 512]           |
| SUCCESS | 0.352256           | 0.258432           | 1.363        | 6096.372   | 8309.666  | [268435456]              |
| SUCCESS | 0.006144           | 0.005504           | 1.116        | 13.021     | 14.535    | [10000, 1]               |
| SUCCESS | 0.012352           | 0.009152           | 1.350        | 1658.031   | 2237.762  | [10000, 256]             |
| SUCCESS | 0.761184           | 0.626944           | 1.214        | 6887.796   | 8362.597  | [10000, 65536]           |
| SUCCESS | 0.007360           | 0.005728           | 1.285        | 10.870     | 13.966    | [100, 1, 100]            |
| SUCCESS | 0.019744           | 0.012160           | 1.624        | 1037.277   | 1684.210  | [100, 256, 100]          |
| SUCCESS | 3.261440           | 1.054912           | **3.092**    | 1607.535   | 4969.969  | [100, 65536, 100]        |

**NVIDIA nansum Results (float64)**

| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Torch GBPS | Gems GBPS | Size Detail              |
|---------|--------------------|--------------------|--------------|------------|-----------|--------------------------|
| SUCCESS | 0.010016           | 0.009632           | 1.040        | 6.543      | 6.804     | [64, 64]                 |
| SUCCESS | 0.132352           | 0.136320           | 0.971        | 2028.194   | 1969.157  | [4096, 4096]             |
| SUCCESS | 0.132256           | 0.136128           | 0.972        | 2029.666   | 1971.934  | [64, 512, 512]           |
| SUCCESS | 1.860192           | 1.819872           | 1.022        | 2308.884   | 2360.038  | [268435456]              |
| SUCCESS | 0.013696           | 0.015872           | 0.863        | 11.682     | 10.081    | [10000, 1]               |
| SUCCESS | 0.035136           | 0.032512           | 1.081        | 1165.756   | 1259.842  | [10000, 256]             |
| SUCCESS | 0.013920           | 0.015968           | 0.872        | 11.494     | 10.020    | [100, 1, 100]            |
| SUCCESS | 0.035168           | 0.033696           | 1.044        | 1164.695   | 1215.575  | [100, 256, 100]          |

**NVIDIA nansum_dim Results (float64)**

| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Torch GBPS | Gems GBPS | Size Detail              |
|---------|--------------------|--------------------|--------------|------------|-----------|--------------------------|
| SUCCESS | 0.007744           | 0.005728           | 1.352        | 8.463      | 11.441    | [64, 64]                 |
| SUCCESS | 0.149472           | 0.131104           | 1.140        | 1795.891   | 2047.500  | [4096, 4096]             |
| SUCCESS | 0.147968           | 0.131392           | 1.126        | 1814.145   | 2043.012  | [64, 512, 512]           |
| SUCCESS | 1.860096           | 1.820032           | 1.022        | 2309.003   | 2359.831  | [268435456]              |
| SUCCESS | 0.007296           | 0.005792           | 1.260        | 21.930     | 27.624    | [10000, 1]               |
| SUCCESS | 0.034656           | 0.029152           | 1.189        | 1181.902   | 1405.049  | [10000, 256]             |
| SUCCESS | 0.009824           | 0.006304           | 1.558        | 16.287     | 25.381    | [100, 1, 100]            |
| SUCCESS | 0.073088           | 0.041984           | **1.741**    | 560.420    | 975.610   | [100, 256, 100]          |
