### PR TITLE
[KMCompiler]Add linalg_cross operator

### DIFF
--- a/benchmark/test_linalg_cross.py
+++ b/benchmark/test_linalg_cross.py
@@ -1,0 +1,79 @@
+from typing import Generator
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+# Mirror the layouts covered by tests/test_linalg_cross.py at the smallest
+# performance scale that clears fixed kernel-launch overhead on each backend.
+LINALG_CROSS_COMMON_CASES = [
+    ((262144, 3, 4), (1, 3, 4), 1),
+    ((1, 3), (131072, 3), -1),
+    ((65536, 4, 3), (65536, 4, 3), -1),
+    ((131072, 3), (131072, 3), -1),
+    ((262144, 3), (262144, 3), -1),
+    ((524288, 3), (524288, 3), -1),
+    ((1048576, 3), (1048576, 3), -1),
+]
+
+
+def _randn(shape, dtype, device):
+    if dtype.is_complex and flag_gems.vendor_name == "ascend":
+        # torch_npu cannot generate complex normal values directly on the NPU.
+        return torch.randn(shape, dtype=dtype).to(device)
+    return torch.randn(shape, dtype=dtype, device=device)
+
+
+class LinalgCrossBenchmark(base.Benchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = list(LINALG_CROSS_COMMON_CASES)
+        if flag_gems.vendor_name == "ascend":
+            self.shapes.insert(0, ((16384, 3, 4), (1, 3, 4), 1))
+
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for input_shape, other_shape, dim in self.shapes:
+            input = _randn(input_shape, cur_dtype, self.device)
+            other = _randn(other_shape, cur_dtype, self.device)
+            yield input, other, {"dim": dim}
+
+
+class LinalgCrossOutBenchmark(LinalgCrossBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for input_shape, other_shape, dim in self.shapes:
+            input = _randn(input_shape, cur_dtype, self.device)
+            other = _randn(other_shape, cur_dtype, self.device)
+            out = torch.empty(
+                torch.broadcast_shapes(input_shape, other_shape),
+                dtype=cur_dtype,
+                device=self.device,
+            )
+            yield input, other, {"dim": dim, "out": out}
+
+
+@pytest.mark.linalg_cross
+def test_linalg_cross():
+    bench = LinalgCrossBenchmark(
+        op_name="linalg_cross",
+        torch_op=torch.linalg.cross,
+        gems_op=flag_gems.linalg_cross if flag_gems.vendor_name == "ascend" else None,
+        # Final performance is the arithmetic mean of the per-shape averages
+        # for FP16, FP32, and BF16.
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.linalg_cross_out
+def test_linalg_cross_out():
+    bench = LinalgCrossOutBenchmark(
+        op_name="linalg_cross_out",
+        torch_op=torch.ops.aten.linalg_cross.out,
+        gems_op=(
+            flag_gems.linalg_cross_out if flag_gems.vendor_name == "ascend" else None
+        ),
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5437,6 +5437,26 @@ ops:
       - BLAS
     stages:
       - alpha: '5.4'
+  - id: linalg_cross
+    description: Computes the cross product of two 3-dimensional vectors along a specified dimension.
+    for:
+      - linalg_cross
+    labels:
+      - aten
+    kind:
+      - LinearAlg
+    stages:
+      - alpha: '5.4'
+  - id: linalg_cross_out
+    description: A variant of `linalg_cross` that allows the output to be assigned to `out`.
+    for:
+      - linalg_cross.out
+    labels:
+      - aten
+    kind:
+      - LinearAlg
+    stages:
+      - alpha: '5.4'
   - id: linalg_eigvals
     description: Computes the eigenvalues of a square matrix.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -588,6 +588,8 @@ _FULL_CONFIG = (
     ("lift_fresh", lift_fresh),
     ("lift_fresh_copy", lift_fresh_copy),
     ("linalg_cholesky", linalg_cholesky),
+    ("linalg_cross", linalg_cross),
+    ("linalg_cross.out", linalg_cross_out),
     ("linalg_ldl_factor", ldl_factor),
     ("linalg_ldl_factor_ex", ldl_factor_ex),
     ("linalg_lu_factor", linalg_lu_factor),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -396,6 +396,7 @@ from flag_gems.ops.lift import lift, lift_out
 from flag_gems.ops.lift_fresh import lift_fresh
 from flag_gems.ops.lift_fresh_copy import lift_fresh_copy, lift_fresh_copy_out
 from flag_gems.ops.linalg_cholesky import linalg_cholesky
+from flag_gems.ops.linalg_cross import linalg_cross, linalg_cross_out
 from flag_gems.ops.linalg_ldl_factor import ldl_factor
 from flag_gems.ops.linalg_ldl_solve import linalg_ldl_solve
 from flag_gems.ops.linalg_lstsq import linalg_lstsq
@@ -1220,6 +1221,8 @@ __all__ = [
     "lift_fresh_copy_out",
     "lift_out",
     "linalg_cholesky",
+    "linalg_cross",
+    "linalg_cross_out",
     "linalg_ldl_solve",
     "linalg_lstsq",
     "linalg_lu_factor",

--- a/src/flag_gems/ops/linalg_cross.py
+++ b/src/flag_gems/ops/linalg_cross.py
@@ -1,0 +1,1032 @@
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_DTYPES = (
+    torch.float16,
+    torch.float32,
+    torch.bfloat16,
+    torch.float64,
+    torch.complex64,
+    torch.complex128,
+)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+@triton.jit
+def _real_cross_component(
+    lhs_a,
+    rhs_a,
+    lhs_b,
+    rhs_b,
+    ELEMENT_TY: tl.constexpr,
+):
+    if tl.constexpr(ELEMENT_TY == tl.float16) or tl.constexpr(
+        ELEMENT_TY == tl.bfloat16
+    ):
+        return (
+            lhs_a.to(tl.float32) * rhs_a.to(tl.float32)
+            - lhs_b.to(tl.float32) * rhs_b.to(tl.float32)
+        ).to(ELEMENT_TY, fp_downcast_rounding="rtne")
+    return lhs_a * rhs_a - lhs_b * rhs_b
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Compute a block of contiguous, real three-component cross products."""
+    vector_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    offsets = vector_offsets * 3
+
+    input_0 = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+    input_1 = tl.load(input_ptr + offsets + 1, mask=mask, other=0.0)
+    input_2 = tl.load(input_ptr + offsets + 2, mask=mask, other=0.0)
+    other_0 = tl.load(other_ptr + offsets, mask=mask, other=0.0)
+    other_1 = tl.load(other_ptr + offsets + 1, mask=mask, other=0.0)
+    other_2 = tl.load(other_ptr + offsets + 2, mask=mask, other=0.0)
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + offsets, output_0, mask=mask)
+    tl.store(output_ptr + offsets + 1, output_1, mask=mask)
+    tl.store(output_ptr + offsets + 2, output_2, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Compute a block of cross products over interleaved real/imaginary data."""
+    vector_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    offsets = vector_offsets * 6
+
+    input_0_real = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+    input_0_imag = tl.load(input_ptr + offsets + 1, mask=mask, other=0.0)
+    input_1_real = tl.load(input_ptr + offsets + 2, mask=mask, other=0.0)
+    input_1_imag = tl.load(input_ptr + offsets + 3, mask=mask, other=0.0)
+    input_2_real = tl.load(input_ptr + offsets + 4, mask=mask, other=0.0)
+    input_2_imag = tl.load(input_ptr + offsets + 5, mask=mask, other=0.0)
+
+    other_0_real = tl.load(other_ptr + offsets, mask=mask, other=0.0)
+    other_0_imag = tl.load(other_ptr + offsets + 1, mask=mask, other=0.0)
+    other_1_real = tl.load(other_ptr + offsets + 2, mask=mask, other=0.0)
+    other_1_imag = tl.load(other_ptr + offsets + 3, mask=mask, other=0.0)
+    other_2_real = tl.load(other_ptr + offsets + 4, mask=mask, other=0.0)
+    other_2_imag = tl.load(other_ptr + offsets + 5, mask=mask, other=0.0)
+
+    product_12_real = input_1_real * other_2_real - input_1_imag * other_2_imag
+    product_12_imag = input_1_real * other_2_imag + input_1_imag * other_2_real
+    product_21_real = input_2_real * other_1_real - input_2_imag * other_1_imag
+    product_21_imag = input_2_real * other_1_imag + input_2_imag * other_1_real
+
+    product_20_real = input_2_real * other_0_real - input_2_imag * other_0_imag
+    product_20_imag = input_2_real * other_0_imag + input_2_imag * other_0_real
+    product_02_real = input_0_real * other_2_real - input_0_imag * other_2_imag
+    product_02_imag = input_0_real * other_2_imag + input_0_imag * other_2_real
+
+    product_01_real = input_0_real * other_1_real - input_0_imag * other_1_imag
+    product_01_imag = input_0_real * other_1_imag + input_0_imag * other_1_real
+    product_10_real = input_1_real * other_0_real - input_1_imag * other_0_imag
+    product_10_imag = input_1_real * other_0_imag + input_1_imag * other_0_real
+
+    tl.store(output_ptr + offsets, product_12_real - product_21_real, mask=mask)
+    tl.store(output_ptr + offsets + 1, product_12_imag - product_21_imag, mask=mask)
+    tl.store(output_ptr + offsets + 2, product_20_real - product_02_real, mask=mask)
+    tl.store(output_ptr + offsets + 3, product_20_imag - product_02_imag, mask=mask)
+    tl.store(output_ptr + offsets + 4, product_01_real - product_10_real, mask=mask)
+    tl.store(output_ptr + offsets + 5, product_01_imag - product_10_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_contiguous_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Use coalesced transactions for interleaved contiguous complex data."""
+    vector_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    head_columns = tl.arange(0, 4)
+    tail_columns = tl.arange(0, 2)
+    vector_mask = vector_offsets < num_vectors
+    vector_base = vector_offsets[:, None] * 6
+    head_offsets = vector_base + head_columns[None, :]
+    tail_offsets = vector_base + 4 + tail_columns[None, :]
+    mask = vector_mask[:, None]
+
+    input_head = tl.load(input_ptr + head_offsets, mask=mask, other=0.0)
+    input_tail = tl.load(input_ptr + tail_offsets, mask=mask, other=0.0)
+    other_head = tl.load(other_ptr + head_offsets, mask=mask, other=0.0)
+    other_tail = tl.load(other_ptr + tail_offsets, mask=mask, other=0.0)
+
+    input_head_real, input_head_imag = tl.split(
+        tl.reshape(input_head, (BLOCK_SIZE * 2, 2))
+    )
+    input_0_real, input_1_real = tl.split(tl.reshape(input_head_real, (BLOCK_SIZE, 2)))
+    input_0_imag, input_1_imag = tl.split(tl.reshape(input_head_imag, (BLOCK_SIZE, 2)))
+    input_2_real, input_2_imag = tl.split(input_tail)
+
+    other_head_real, other_head_imag = tl.split(
+        tl.reshape(other_head, (BLOCK_SIZE * 2, 2))
+    )
+    other_0_real, other_1_real = tl.split(tl.reshape(other_head_real, (BLOCK_SIZE, 2)))
+    other_0_imag, other_1_imag = tl.split(tl.reshape(other_head_imag, (BLOCK_SIZE, 2)))
+    other_2_real, other_2_imag = tl.split(other_tail)
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+
+    output_head = tl.where(
+        head_columns[None, :] == 0,
+        out_0_real[:, None],
+        tl.where(
+            head_columns[None, :] == 1,
+            out_0_imag[:, None],
+            tl.where(
+                head_columns[None, :] == 2,
+                out_1_real[:, None],
+                out_1_imag[:, None],
+            ),
+        ),
+    )
+    output_tail = tl.where(
+        tail_columns[None, :] == 0, out_2_real[:, None], out_2_imag[:, None]
+    )
+    tl.store(output_ptr + head_offsets, output_head, mask=mask)
+    tl.store(output_ptr + tail_offsets, output_tail, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_strided_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_OUTER0_STRIDE: tl.constexpr,
+    INPUT_OUTER1_STRIDE: tl.constexpr,
+    INPUT_COMPONENT_STRIDE: tl.constexpr,
+    OTHER_OUTER0_STRIDE: tl.constexpr,
+    OTHER_OUTER1_STRIDE: tl.constexpr,
+    OTHER_COMPONENT_STRIDE: tl.constexpr,
+    OUTPUT_OUTER0_STRIDE: tl.constexpr,
+    OUTPUT_OUTER1_STRIDE: tl.constexpr,
+    OUTPUT_COMPONENT_STRIDE: tl.constexpr,
+    OUTER1_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    outer0 = vector_offsets // OUTER1_SIZE
+    outer1 = vector_offsets % OUTER1_SIZE
+
+    input_base = outer0 * INPUT_OUTER0_STRIDE + outer1 * INPUT_OUTER1_STRIDE
+    other_base = outer0 * OTHER_OUTER0_STRIDE + outer1 * OTHER_OUTER1_STRIDE
+    output_base = outer0 * OUTPUT_OUTER0_STRIDE + outer1 * OUTPUT_OUTER1_STRIDE
+
+    input_0 = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_1 = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    input_2 = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_0 = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_1 = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_2 = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=mask)
+    tl.store(
+        output_ptr + output_base + OUTPUT_COMPONENT_STRIDE,
+        output_1,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE,
+        output_2,
+        mask=mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_strided_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_OUTER0_STRIDE: tl.constexpr,
+    INPUT_OUTER1_STRIDE: tl.constexpr,
+    INPUT_COMPONENT_STRIDE: tl.constexpr,
+    OTHER_OUTER0_STRIDE: tl.constexpr,
+    OTHER_OUTER1_STRIDE: tl.constexpr,
+    OTHER_COMPONENT_STRIDE: tl.constexpr,
+    OUTPUT_OUTER0_STRIDE: tl.constexpr,
+    OUTPUT_OUTER1_STRIDE: tl.constexpr,
+    OUTPUT_COMPONENT_STRIDE: tl.constexpr,
+    OUTER1_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    outer0 = vector_offsets // OUTER1_SIZE
+    outer1 = vector_offsets % OUTER1_SIZE
+
+    input_base = outer0 * INPUT_OUTER0_STRIDE + outer1 * INPUT_OUTER1_STRIDE
+    other_base = outer0 * OTHER_OUTER0_STRIDE + outer1 * OTHER_OUTER1_STRIDE
+    output_base = outer0 * OUTPUT_OUTER0_STRIDE + outer1 * OUTPUT_OUTER1_STRIDE
+
+    input_0_real = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_0_imag = tl.load(input_ptr + input_base + 1, mask=mask, other=0.0)
+    input_1_real = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    input_1_imag = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+    input_2_real = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE,
+        mask=mask,
+        other=0.0,
+    )
+    input_2_imag = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+
+    other_0_real = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_0_imag = tl.load(other_ptr + other_base + 1, mask=mask, other=0.0)
+    other_1_real = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_1_imag = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+    other_2_real = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE,
+        mask=mask,
+        other=0.0,
+    )
+    other_2_imag = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + OUTPUT_COMPONENT_STRIDE, out_1_real, mask=mask)
+    tl.store(
+        output_ptr + output_base + OUTPUT_COMPONENT_STRIDE + 1,
+        out_1_imag,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE,
+        out_2_real,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE + 1,
+        out_2_imag,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _complex_cross_values(
+    input_0_real,
+    input_0_imag,
+    input_1_real,
+    input_1_imag,
+    input_2_real,
+    input_2_imag,
+    other_0_real,
+    other_0_imag,
+    other_1_real,
+    other_1_imag,
+    other_2_real,
+    other_2_imag,
+):
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+    return (
+        out_0_real,
+        out_0_imag,
+        out_1_real,
+        out_1_imag,
+        out_2_real,
+        out_2_imag,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_lastdim_broadcast_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_VECTORS: tl.constexpr,
+    OTHER_VECTORS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vectors = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vectors < num_vectors
+    input_base = (vectors % INPUT_VECTORS) * 3
+    other_base = (vectors % OTHER_VECTORS) * 3
+    output_base = vectors * 3
+
+    input_0 = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_1 = tl.load(input_ptr + input_base + 1, mask=mask, other=0.0)
+    input_2 = tl.load(input_ptr + input_base + 2, mask=mask, other=0.0)
+    other_0 = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_1 = tl.load(other_ptr + other_base + 1, mask=mask, other=0.0)
+    other_2 = tl.load(other_ptr + other_base + 2, mask=mask, other=0.0)
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=mask)
+    tl.store(output_ptr + output_base + 1, output_1, mask=mask)
+    tl.store(output_ptr + output_base + 2, output_2, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_lastdim_broadcast_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_VECTORS: tl.constexpr,
+    OTHER_VECTORS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vectors = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vectors < num_vectors
+    input_base = (vectors % INPUT_VECTORS) * 6
+    other_base = (vectors % OTHER_VECTORS) * 6
+    output_base = vectors * 6
+
+    (
+        out_0_real,
+        out_0_imag,
+        out_1_real,
+        out_1_imag,
+        out_2_real,
+        out_2_imag,
+    ) = _complex_cross_values(
+        tl.load(input_ptr + input_base, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 1, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 2, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 3, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 4, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 5, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 1, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 2, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 3, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 4, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 5, mask=mask, other=0.0),
+    )
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + 2, out_1_real, mask=mask)
+    tl.store(output_ptr + output_base + 3, out_1_imag, mask=mask)
+    tl.store(output_ptr + output_base + 4, out_2_real, mask=mask)
+    tl.store(output_ptr + output_base + 5, out_2_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_dim1_3d_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INNER_SIZE: tl.constexpr,
+    INPUT_BATCH_STRIDE: tl.constexpr,
+    OTHER_BATCH_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vectors = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vectors < num_vectors
+    batch = vectors // INNER_SIZE
+    inner = vectors % INNER_SIZE
+    input_base = batch * INPUT_BATCH_STRIDE + inner
+    other_base = batch * OTHER_BATCH_STRIDE + inner
+    output_base = batch * (3 * INNER_SIZE) + inner
+
+    input_0 = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_1 = tl.load(input_ptr + input_base + INNER_SIZE, mask=mask, other=0.0)
+    input_2 = tl.load(input_ptr + input_base + 2 * INNER_SIZE, mask=mask, other=0.0)
+    other_0 = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_1 = tl.load(other_ptr + other_base + INNER_SIZE, mask=mask, other=0.0)
+    other_2 = tl.load(other_ptr + other_base + 2 * INNER_SIZE, mask=mask, other=0.0)
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=mask)
+    tl.store(
+        output_ptr + output_base + INNER_SIZE,
+        output_1,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * INNER_SIZE,
+        output_2,
+        mask=mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_dim1_3d_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INNER_SIZE: tl.constexpr,
+    INPUT_BATCH_STRIDE: tl.constexpr,
+    OTHER_BATCH_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vectors = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vectors < num_vectors
+    batch = vectors // INNER_SIZE
+    inner = vectors % INNER_SIZE
+    input_base = 2 * (batch * INPUT_BATCH_STRIDE + inner)
+    other_base = 2 * (batch * OTHER_BATCH_STRIDE + inner)
+    output_base = 2 * (batch * (3 * INNER_SIZE) + inner)
+    component_stride = 2 * INNER_SIZE
+
+    (
+        out_0_real,
+        out_0_imag,
+        out_1_real,
+        out_1_imag,
+        out_2_real,
+        out_2_imag,
+    ) = _complex_cross_values(
+        tl.load(input_ptr + input_base, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 1, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + component_stride, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + component_stride + 1, mask=mask, other=0.0),
+        tl.load(input_ptr + input_base + 2 * component_stride, mask=mask, other=0.0),
+        tl.load(
+            input_ptr + input_base + 2 * component_stride + 1,
+            mask=mask,
+            other=0.0,
+        ),
+        tl.load(other_ptr + other_base, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 1, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + component_stride, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + component_stride + 1, mask=mask, other=0.0),
+        tl.load(other_ptr + other_base + 2 * component_stride, mask=mask, other=0.0),
+        tl.load(
+            other_ptr + other_base + 2 * component_stride + 1,
+            mask=mask,
+            other=0.0,
+        ),
+    )
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + component_stride, out_1_real, mask=mask)
+    tl.store(output_ptr + output_base + component_stride + 1, out_1_imag, mask=mask)
+    tl.store(output_ptr + output_base + 2 * component_stride, out_2_real, mask=mask)
+    tl.store(
+        output_ptr + output_base + 2 * component_stride + 1,
+        out_2_imag,
+        mask=mask,
+    )
+
+
+def _normalize_dim(dim, ndim, name):
+    if ndim == 0:
+        raise RuntimeError(f"linalg_cross: {name} must have at least one dimension")
+    if dim < -ndim or dim >= ndim:
+        raise IndexError(
+            f"Dimension out of range (expected range [{-ndim}, {ndim - 1}], "
+            f"but got {dim})"
+        )
+    return dim % ndim
+
+
+def _validate_inputs(input, other, dim):
+    if input.device != other.device:
+        raise RuntimeError("linalg_cross: input and other must be on the same device")
+    if input.ndim != other.ndim:
+        raise RuntimeError(
+            "linalg.cross: inputs must have the same number of dimensions."
+        )
+    if input.dtype != other.dtype:
+        raise RuntimeError("linalg_cross: input and other must have the same dtype")
+    if input.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(
+            "linalg_cross only supports float16, float32, bfloat16, float64, "
+            "complex64, and complex128"
+        )
+
+    input_dim = _normalize_dim(dim, input.ndim, "input")
+    other_dim = _normalize_dim(dim, other.ndim, "other")
+    if input.shape[input_dim] != 3 or other.shape[other_dim] != 3:
+        raise RuntimeError(
+            "linalg_cross: inputs must have length 3 along the cross-product dimension"
+        )
+
+    if input.shape == other.shape:
+        output_shape = input.shape
+    else:
+        output_shape = []
+        for input_size, other_size in zip(input.shape, other.shape):
+            if input_size == other_size or other_size == 1:
+                output_shape.append(input_size)
+            elif input_size == 1:
+                output_shape.append(other_size)
+            else:
+                raise RuntimeError(
+                    "The size of tensor input must match the size of tensor other "
+                    "at non-singleton dimensions"
+                )
+        output_shape = tuple(output_shape)
+    return input_dim, output_shape
+
+
+def _prepare_inputs(input, other, dim):
+    """Materialized fallback used only for tensors with more than three dims."""
+    input_dim, _ = _validate_inputs(input, other, dim)
+    input_moved = input.movedim(input_dim, -1)
+    other_moved = other.movedim(input_dim, -1)
+    input_moved, other_moved = torch.broadcast_tensors(input_moved, other_moved)
+    return input_moved.contiguous(), other_moved.contiguous(), input_dim
+
+
+def _resolve_view(input):
+    if input.is_complex() and input.is_conj():
+        input = torch.ops.aten.conj_physical.default.redispatch(_FALLBACK_KEYSET, input)
+    if input.is_neg():
+        input = torch.ops.aten.neg.default.redispatch(_FALLBACK_KEYSET, input)
+    return input
+
+
+def _get_strided_layout(input, other, output, dim):
+    outer_dims = [axis for axis in range(output.ndim) if axis != dim]
+    if len(outer_dims) > 2:
+        return None
+
+    input_strides = list(input.stride())
+    other_strides = list(other.stride())
+    for axis, output_size in enumerate(output.shape):
+        if input.shape[axis] == 1 and output_size != 1:
+            input_strides[axis] = 0
+        if other.shape[axis] == 1 and output_size != 1:
+            other_strides[axis] = 0
+
+    if len(outer_dims) == 0:
+        outer1_size = 1
+        input_outer_strides = (0, 0)
+        other_outer_strides = (0, 0)
+        output_outer_strides = (0, 0)
+    elif len(outer_dims) == 1:
+        axis = outer_dims[0]
+        outer1_size = output.shape[axis]
+        input_outer_strides = (0, input_strides[axis])
+        other_outer_strides = (0, other_strides[axis])
+        output_outer_strides = (0, output.stride(axis))
+    else:
+        outer0, outer1 = outer_dims
+        outer1_size = output.shape[outer1]
+        input_outer_strides = (
+            input_strides[outer0],
+            input_strides[outer1],
+        )
+        other_outer_strides = (
+            other_strides[outer0],
+            other_strides[outer1],
+        )
+        output_outer_strides = (output.stride(outer0), output.stride(outer1))
+
+    return (
+        input_outer_strides,
+        other_outer_strides,
+        output_outer_strides,
+        input.stride(dim),
+        other.stride(dim),
+        output.stride(dim),
+        outer1_size,
+    )
+
+
+def _launch_linalg_cross_kernel(input, other, output, dim, layout=None):
+    num_vectors = output.numel() // 3
+    if num_vectors == 0:
+        return
+
+    block_size = 128 if output.is_complex() and layout is not None else 256
+    grid = (triton.cdiv(num_vectors, block_size),)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            input_real = torch.view_as_real(input)
+            other_real = torch.view_as_real(other)
+            output_real = torch.view_as_real(output)
+            if layout is None:
+                _linalg_cross_complex_contiguous_kernel[grid](
+                    input_real,
+                    other_real,
+                    output_real,
+                    num_vectors,
+                    BLOCK_SIZE=block_size,
+                    num_warps=8,
+                )
+            else:
+                (
+                    input_outer,
+                    other_outer,
+                    output_outer,
+                    input_component,
+                    other_component,
+                    output_component,
+                    outer1_size,
+                ) = layout
+                _linalg_cross_complex_strided_kernel[grid](
+                    input_real,
+                    other_real,
+                    output_real,
+                    num_vectors,
+                    INPUT_OUTER0_STRIDE=2 * input_outer[0],
+                    INPUT_OUTER1_STRIDE=2 * input_outer[1],
+                    INPUT_COMPONENT_STRIDE=2 * input_component,
+                    OTHER_OUTER0_STRIDE=2 * other_outer[0],
+                    OTHER_OUTER1_STRIDE=2 * other_outer[1],
+                    OTHER_COMPONENT_STRIDE=2 * other_component,
+                    OUTPUT_OUTER0_STRIDE=2 * output_outer[0],
+                    OUTPUT_OUTER1_STRIDE=2 * output_outer[1],
+                    OUTPUT_COMPONENT_STRIDE=2 * output_component,
+                    OUTER1_SIZE=outer1_size,
+                    BLOCK_SIZE=block_size,
+                    num_warps=4,
+                )
+        else:
+            if layout is None:
+                _linalg_cross_real_kernel[grid](
+                    input,
+                    other,
+                    output,
+                    num_vectors,
+                    BLOCK_SIZE=block_size,
+                    num_warps=4,
+                )
+            else:
+                (
+                    input_outer,
+                    other_outer,
+                    output_outer,
+                    input_component,
+                    other_component,
+                    output_component,
+                    outer1_size,
+                ) = layout
+                _linalg_cross_real_strided_kernel[grid](
+                    input,
+                    other,
+                    output,
+                    num_vectors,
+                    INPUT_OUTER0_STRIDE=input_outer[0],
+                    INPUT_OUTER1_STRIDE=input_outer[1],
+                    INPUT_COMPONENT_STRIDE=input_component,
+                    OTHER_OUTER0_STRIDE=other_outer[0],
+                    OTHER_OUTER1_STRIDE=other_outer[1],
+                    OTHER_COMPONENT_STRIDE=other_component,
+                    OUTPUT_OUTER0_STRIDE=output_outer[0],
+                    OUTPUT_OUTER1_STRIDE=output_outer[1],
+                    OUTPUT_COMPONENT_STRIDE=output_component,
+                    OUTER1_SIZE=outer1_size,
+                    BLOCK_SIZE=block_size,
+                    num_warps=4,
+                )
+
+
+def _launch_lastdim_broadcast_kernel(input, other, output):
+    num_vectors = output.numel() // 3
+    block_size = 128 if output.is_complex() else 256
+    grid = (triton.cdiv(num_vectors, block_size),)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            _linalg_cross_complex_lastdim_broadcast_kernel[grid](
+                torch.view_as_real(input),
+                torch.view_as_real(other),
+                torch.view_as_real(output),
+                num_vectors,
+                INPUT_VECTORS=input.numel() // 3,
+                OTHER_VECTORS=other.numel() // 3,
+                BLOCK_SIZE=block_size,
+                num_warps=4,
+            )
+        else:
+            _linalg_cross_real_lastdim_broadcast_kernel[grid](
+                input,
+                other,
+                output,
+                num_vectors,
+                INPUT_VECTORS=input.numel() // 3,
+                OTHER_VECTORS=other.numel() // 3,
+                BLOCK_SIZE=block_size,
+                num_warps=4,
+            )
+
+
+def _launch_dim1_3d_kernel(input, other, output):
+    num_vectors = output.numel() // 3
+    is_small = num_vectors <= 32
+    block_size = (
+        triton.next_power_of_2(num_vectors)
+        if is_small
+        else (128 if output.is_complex() else 256)
+    )
+    num_warps = 1 if is_small else 4
+    grid = (triton.cdiv(num_vectors, block_size),)
+    input_batch_stride = 0 if input.shape[0] == 1 else input.stride(0)
+    other_batch_stride = 0 if other.shape[0] == 1 else other.stride(0)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            _linalg_cross_complex_dim1_3d_kernel[grid](
+                torch.view_as_real(input),
+                torch.view_as_real(other),
+                torch.view_as_real(output),
+                num_vectors,
+                INNER_SIZE=output.shape[2],
+                INPUT_BATCH_STRIDE=input_batch_stride,
+                OTHER_BATCH_STRIDE=other_batch_stride,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        else:
+            _linalg_cross_real_dim1_3d_kernel[grid](
+                input,
+                other,
+                output,
+                num_vectors,
+                INNER_SIZE=output.shape[2],
+                INPUT_BATCH_STRIDE=input_batch_stride,
+                OTHER_BATCH_STRIDE=other_batch_stride,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+
+
+def _linalg_cross_impl(input, other, dim, output=None):
+    dim, output_shape = _validate_inputs(input, other, dim)
+    input = _resolve_view(input)
+    other = _resolve_view(other)
+
+    if input.ndim <= 3:
+        if output is None:
+            if input.shape == output_shape and input.is_contiguous():
+                output = torch.empty_like(input)
+            elif other.shape == output_shape and other.is_contiguous():
+                output = torch.empty_like(other)
+            else:
+                output = torch.empty(
+                    output_shape, dtype=input.dtype, device=input.device
+                )
+
+        fast_contiguous = (
+            dim == input.ndim - 1
+            and input.shape == output_shape
+            and other.shape == output_shape
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and output.is_contiguous()
+        )
+        if fast_contiguous:
+            _launch_linalg_cross_kernel(input, other, output, dim)
+            return output
+
+        if (
+            input.ndim == 2
+            and dim == 1
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and output.is_contiguous()
+        ):
+            _launch_lastdim_broadcast_kernel(input, other, output)
+            return output
+
+        if (
+            input.ndim == 3
+            and dim == 1
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and input.shape[2] == output.shape[2]
+            and other.shape[2] == output.shape[2]
+            and output.is_contiguous()
+        ):
+            _launch_dim1_3d_kernel(input, other, output)
+            return output
+
+        layout = _get_strided_layout(input, other, output, dim)
+        _launch_linalg_cross_kernel(
+            input,
+            other,
+            output,
+            dim,
+            layout,
+        )
+        return output
+
+    input_moved, other_moved, output_dim = _prepare_inputs(input, other, dim)
+    output_moved = torch.empty_like(input_moved)
+    _launch_linalg_cross_kernel(input_moved, other_moved, output_moved, -1)
+    result = output_moved.movedim(-1, output_dim).contiguous()
+    if output is not None:
+        output.copy_(result)
+        return output
+    return result
+
+
+def linalg_cross(input, other, *, dim=-1):
+    """NVIDIA Triton implementation of ``torch.linalg.cross``."""
+    logger.debug("GEMS LINALG_CROSS")
+    return _linalg_cross_impl(input, other, dim)
+
+
+def linalg_cross_out(input, other, *, dim=-1, out):
+    logger.debug("GEMS LINALG_CROSS_OUT")
+    if torch._C._is_alias_of(out, input) or torch._C._is_alias_of(out, other):
+        raise RuntimeError(
+            "linalg_cross: out must not share memory with either input tensor"
+        )
+    dim, output_shape = _validate_inputs(input, other, dim)
+    if out.dtype != input.dtype:
+        raise RuntimeError(
+            f"linalg_cross: expected out dtype {input.dtype}, but got {out.dtype}"
+        )
+    if out.device != input.device:
+        raise RuntimeError("linalg_cross: out must be on the same device as input")
+    if out.shape != output_shape:
+        out.resize_(output_shape)
+    return _linalg_cross_impl(input, other, dim, output=out)

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -54,6 +54,7 @@ from .index import index
 from .index_add import index_add, index_add_
 from .index_select import index_select
 from .isin import isin
+from .linalg_cross import linalg_cross, linalg_cross_out
 from .linalg_lstsq import linalg_lstsq
 from .linalg_lu_factor import linalg_lu_factor, linalg_lu_factor_out
 from .linspace import linspace
@@ -163,6 +164,8 @@ __all__ = [
     "linalg_lu_factor",
     "linalg_lu_factor_out",
     "linspace",
+    "linalg_cross",
+    "linalg_cross_out",
     "log_softmax",
     "log_softmax_backward",
     "log_softmax_out",

--- a/src/flag_gems/runtime/backend/_ascend/ops/linalg_cross.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/linalg_cross.py
@@ -1,0 +1,1062 @@
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.linalg_cross import (
+    _get_strided_layout,
+    _prepare_inputs,
+    _resolve_view,
+    _validate_inputs,
+)
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_DTYPES = (
+    torch.float16,
+    torch.float32,
+    torch.bfloat16,
+    torch.complex64,
+)
+
+
+@triton.jit
+def _real_cross_component(
+    lhs_a,
+    rhs_a,
+    lhs_b,
+    rhs_b,
+    ELEMENT_TY: tl.constexpr,
+):
+    if tl.constexpr(ELEMENT_TY == tl.float16) or tl.constexpr(
+        ELEMENT_TY == tl.bfloat16
+    ):
+        return (
+            lhs_a.to(tl.float32) * rhs_a.to(tl.float32)
+            - lhs_b.to(tl.float32) * rhs_b.to(tl.float32)
+        ).to(ELEMENT_TY, fp_downcast_rounding="rtne")
+    return lhs_a * rhs_a - lhs_b * rhs_b
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    local_offsets = tl.arange(0, BLOCK_SIZE * 4)
+    valid_local = local_offsets < BLOCK_SIZE * 3
+    block_start = ext.program_id(0) * BLOCK_SIZE * 3
+    global_offsets = block_start + local_offsets
+    num_elements = num_vectors * 3
+    mask = valid_local & (global_offsets < num_elements)
+
+    input_values = tl.load(input_ptr + global_offsets, mask=mask, other=0.0)
+    other_values = tl.load(other_ptr + global_offsets, mask=mask, other=0.0)
+
+    safe_offsets = tl.where(valid_local, local_offsets, 0)
+    component = safe_offsets % 3
+    vector_base = safe_offsets - component
+    next_component = tl.where(component == 2, 0, component + 1)
+    last_component = tl.where(component == 0, 2, component - 1)
+    next_offsets = vector_base + next_component
+    last_offsets = vector_base + last_component
+    input_next = tl.gather(input_values, next_offsets, axis=0)
+    input_last = tl.gather(input_values, last_offsets, axis=0)
+    other_next = tl.gather(other_values, next_offsets, axis=0)
+    other_last = tl.gather(other_values, last_offsets, axis=0)
+
+    output_values = _real_cross_component(
+        input_next,
+        other_last,
+        input_last,
+        other_next,
+        input_ptr.dtype.element_ty,
+    )
+    tl.store(output_ptr + global_offsets, output_values, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    offsets = vector_offsets * 6
+
+    input_0_real = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+    input_0_imag = tl.load(input_ptr + offsets + 1, mask=mask, other=0.0)
+    input_1_real = tl.load(input_ptr + offsets + 2, mask=mask, other=0.0)
+    input_1_imag = tl.load(input_ptr + offsets + 3, mask=mask, other=0.0)
+    input_2_real = tl.load(input_ptr + offsets + 4, mask=mask, other=0.0)
+    input_2_imag = tl.load(input_ptr + offsets + 5, mask=mask, other=0.0)
+
+    other_0_real = tl.load(other_ptr + offsets, mask=mask, other=0.0)
+    other_0_imag = tl.load(other_ptr + offsets + 1, mask=mask, other=0.0)
+    other_1_real = tl.load(other_ptr + offsets + 2, mask=mask, other=0.0)
+    other_1_imag = tl.load(other_ptr + offsets + 3, mask=mask, other=0.0)
+    other_2_real = tl.load(other_ptr + offsets + 4, mask=mask, other=0.0)
+    other_2_imag = tl.load(other_ptr + offsets + 5, mask=mask, other=0.0)
+
+    product_12_real = input_1_real * other_2_real - input_1_imag * other_2_imag
+    product_12_imag = input_1_real * other_2_imag + input_1_imag * other_2_real
+    product_21_real = input_2_real * other_1_real - input_2_imag * other_1_imag
+    product_21_imag = input_2_real * other_1_imag + input_2_imag * other_1_real
+
+    product_20_real = input_2_real * other_0_real - input_2_imag * other_0_imag
+    product_20_imag = input_2_real * other_0_imag + input_2_imag * other_0_real
+    product_02_real = input_0_real * other_2_real - input_0_imag * other_2_imag
+    product_02_imag = input_0_real * other_2_imag + input_0_imag * other_2_real
+
+    product_01_real = input_0_real * other_1_real - input_0_imag * other_1_imag
+    product_01_imag = input_0_real * other_1_imag + input_0_imag * other_1_real
+    product_10_real = input_1_real * other_0_real - input_1_imag * other_0_imag
+    product_10_imag = input_1_real * other_0_imag + input_1_imag * other_0_real
+
+    tl.store(output_ptr + offsets, product_12_real - product_21_real, mask=mask)
+    tl.store(output_ptr + offsets + 1, product_12_imag - product_21_imag, mask=mask)
+    tl.store(output_ptr + offsets + 2, product_20_real - product_02_real, mask=mask)
+    tl.store(output_ptr + offsets + 3, product_20_imag - product_02_imag, mask=mask)
+    tl.store(output_ptr + offsets + 4, product_01_real - product_10_real, mask=mask)
+    tl.store(output_ptr + offsets + 5, product_01_imag - product_10_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_contiguous_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    columns = tl.arange(0, 8)
+    vector_mask = vector_offsets < num_vectors
+    offsets = vector_offsets[:, None] * 6 + columns[None, :]
+    mask = vector_mask[:, None] & (columns[None, :] < 6)
+
+    input_values = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+    other_values = tl.load(other_ptr + offsets, mask=mask, other=0.0)
+
+    input_real, input_imag = tl.split(tl.reshape(input_values, (BLOCK_SIZE * 4, 2)))
+    input_real_even, input_real_odd = tl.split(
+        tl.reshape(input_real, (BLOCK_SIZE * 2, 2))
+    )
+    input_imag_even, input_imag_odd = tl.split(
+        tl.reshape(input_imag, (BLOCK_SIZE * 2, 2))
+    )
+    input_0_real, input_2_real = tl.split(tl.reshape(input_real_even, (BLOCK_SIZE, 2)))
+    input_1_real, _ = tl.split(tl.reshape(input_real_odd, (BLOCK_SIZE, 2)))
+    input_0_imag, input_2_imag = tl.split(tl.reshape(input_imag_even, (BLOCK_SIZE, 2)))
+    input_1_imag, _ = tl.split(tl.reshape(input_imag_odd, (BLOCK_SIZE, 2)))
+
+    other_real, other_imag = tl.split(tl.reshape(other_values, (BLOCK_SIZE * 4, 2)))
+    other_real_even, other_real_odd = tl.split(
+        tl.reshape(other_real, (BLOCK_SIZE * 2, 2))
+    )
+    other_imag_even, other_imag_odd = tl.split(
+        tl.reshape(other_imag, (BLOCK_SIZE * 2, 2))
+    )
+    other_0_real, other_2_real = tl.split(tl.reshape(other_real_even, (BLOCK_SIZE, 2)))
+    other_1_real, _ = tl.split(tl.reshape(other_real_odd, (BLOCK_SIZE, 2)))
+    other_0_imag, other_2_imag = tl.split(tl.reshape(other_imag_even, (BLOCK_SIZE, 2)))
+    other_1_imag, _ = tl.split(tl.reshape(other_imag_odd, (BLOCK_SIZE, 2)))
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+
+    output_values = tl.where(
+        columns[None, :] == 0,
+        out_0_real[:, None],
+        tl.where(
+            columns[None, :] == 1,
+            out_0_imag[:, None],
+            tl.where(
+                columns[None, :] == 2,
+                out_1_real[:, None],
+                tl.where(
+                    columns[None, :] == 3,
+                    out_1_imag[:, None],
+                    tl.where(
+                        columns[None, :] == 4,
+                        out_2_real[:, None],
+                        out_2_imag[:, None],
+                    ),
+                ),
+            ),
+        ),
+    )
+    tl.store(output_ptr + offsets, output_values, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_strided_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_OUTER0_STRIDE: tl.constexpr,
+    INPUT_OUTER1_STRIDE: tl.constexpr,
+    INPUT_COMPONENT_STRIDE: tl.constexpr,
+    OTHER_OUTER0_STRIDE: tl.constexpr,
+    OTHER_OUTER1_STRIDE: tl.constexpr,
+    OTHER_COMPONENT_STRIDE: tl.constexpr,
+    OUTPUT_OUTER0_STRIDE: tl.constexpr,
+    OUTPUT_OUTER1_STRIDE: tl.constexpr,
+    OUTPUT_COMPONENT_STRIDE: tl.constexpr,
+    OUTER1_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    outer0 = vector_offsets // OUTER1_SIZE
+    outer1 = vector_offsets % OUTER1_SIZE
+
+    input_base = outer0 * INPUT_OUTER0_STRIDE + outer1 * INPUT_OUTER1_STRIDE
+    other_base = outer0 * OTHER_OUTER0_STRIDE + outer1 * OTHER_OUTER1_STRIDE
+    output_base = outer0 * OUTPUT_OUTER0_STRIDE + outer1 * OUTPUT_OUTER1_STRIDE
+
+    input_0 = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_1 = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    input_2 = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_0 = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_1 = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_2 = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=mask)
+    tl.store(
+        output_ptr + output_base + OUTPUT_COMPONENT_STRIDE,
+        output_1,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE,
+        output_2,
+        mask=mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_strided_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_OUTER0_STRIDE: tl.constexpr,
+    INPUT_OUTER1_STRIDE: tl.constexpr,
+    INPUT_COMPONENT_STRIDE: tl.constexpr,
+    OTHER_OUTER0_STRIDE: tl.constexpr,
+    OTHER_OUTER1_STRIDE: tl.constexpr,
+    OTHER_COMPONENT_STRIDE: tl.constexpr,
+    OUTPUT_OUTER0_STRIDE: tl.constexpr,
+    OUTPUT_OUTER1_STRIDE: tl.constexpr,
+    OUTPUT_COMPONENT_STRIDE: tl.constexpr,
+    OUTER1_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vector_offsets = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vector_offsets < num_vectors
+    outer0 = vector_offsets // OUTER1_SIZE
+    outer1 = vector_offsets % OUTER1_SIZE
+
+    input_base = outer0 * INPUT_OUTER0_STRIDE + outer1 * INPUT_OUTER1_STRIDE
+    other_base = outer0 * OTHER_OUTER0_STRIDE + outer1 * OTHER_OUTER1_STRIDE
+    output_base = outer0 * OUTPUT_OUTER0_STRIDE + outer1 * OUTPUT_OUTER1_STRIDE
+
+    input_0_real = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_0_imag = tl.load(input_ptr + input_base + 1, mask=mask, other=0.0)
+    input_1_real = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    input_1_imag = tl.load(
+        input_ptr + input_base + INPUT_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+    input_2_real = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE,
+        mask=mask,
+        other=0.0,
+    )
+    input_2_imag = tl.load(
+        input_ptr + input_base + 2 * INPUT_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+
+    other_0_real = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_0_imag = tl.load(other_ptr + other_base + 1, mask=mask, other=0.0)
+    other_1_real = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE, mask=mask, other=0.0
+    )
+    other_1_imag = tl.load(
+        other_ptr + other_base + OTHER_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+    other_2_real = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE,
+        mask=mask,
+        other=0.0,
+    )
+    other_2_imag = tl.load(
+        other_ptr + other_base + 2 * OTHER_COMPONENT_STRIDE + 1,
+        mask=mask,
+        other=0.0,
+    )
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + OUTPUT_COMPONENT_STRIDE, out_1_real, mask=mask)
+    tl.store(
+        output_ptr + output_base + OUTPUT_COMPONENT_STRIDE + 1,
+        out_1_imag,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE,
+        out_2_real,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * OUTPUT_COMPONENT_STRIDE + 1,
+        out_2_imag,
+        mask=mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_lastdim_broadcast_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_VECTORS: tl.constexpr,
+    OTHER_VECTORS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    local_offsets = tl.arange(0, BLOCK_SIZE * 4)
+    valid_local = local_offsets < BLOCK_SIZE * 3
+    block_start = ext.program_id(0) * BLOCK_SIZE * 3
+    global_offsets = block_start + local_offsets
+    mask = valid_local & (global_offsets < num_vectors * 3)
+    safe_offsets = tl.where(valid_local, local_offsets, 0)
+    component = safe_offsets % 3
+
+    if INPUT_VECTORS == 1:
+        input_0 = tl.load(input_ptr)
+        input_1 = tl.load(input_ptr + 1)
+        input_2 = tl.load(input_ptr + 2)
+        input_values = tl.where(
+            component == 0, input_0, tl.where(component == 1, input_1, input_2)
+        )
+    else:
+        input_values = tl.load(input_ptr + global_offsets, mask=mask, other=0.0)
+    if OTHER_VECTORS == 1:
+        other_0 = tl.load(other_ptr)
+        other_1 = tl.load(other_ptr + 1)
+        other_2 = tl.load(other_ptr + 2)
+        other_values = tl.where(
+            component == 0, other_0, tl.where(component == 1, other_1, other_2)
+        )
+    else:
+        other_values = tl.load(other_ptr + global_offsets, mask=mask, other=0.0)
+
+    vector_base = safe_offsets - component
+    next_component = tl.where(component == 2, 0, component + 1)
+    last_component = tl.where(component == 0, 2, component - 1)
+    next_offsets = vector_base + next_component
+    last_offsets = vector_base + last_component
+    input_next = tl.gather(input_values, next_offsets, axis=0)
+    input_last = tl.gather(input_values, last_offsets, axis=0)
+    other_next = tl.gather(other_values, next_offsets, axis=0)
+    other_last = tl.gather(other_values, last_offsets, axis=0)
+
+    output_values = _real_cross_component(
+        input_next,
+        other_last,
+        input_last,
+        other_next,
+        input_ptr.dtype.element_ty,
+    )
+    tl.store(output_ptr + global_offsets, output_values, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_lastdim_broadcast_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_vectors,
+    INPUT_VECTORS: tl.constexpr,
+    OTHER_VECTORS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    vectors = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = vectors < num_vectors
+    output_base = vectors * 6
+
+    if INPUT_VECTORS == 1:
+        input_0_real = tl.load(input_ptr)
+        input_0_imag = tl.load(input_ptr + 1)
+        input_1_real = tl.load(input_ptr + 2)
+        input_1_imag = tl.load(input_ptr + 3)
+        input_2_real = tl.load(input_ptr + 4)
+        input_2_imag = tl.load(input_ptr + 5)
+    else:
+        input_base = vectors * 6
+        input_0_real = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+        input_0_imag = tl.load(input_ptr + input_base + 1, mask=mask, other=0.0)
+        input_1_real = tl.load(input_ptr + input_base + 2, mask=mask, other=0.0)
+        input_1_imag = tl.load(input_ptr + input_base + 3, mask=mask, other=0.0)
+        input_2_real = tl.load(input_ptr + input_base + 4, mask=mask, other=0.0)
+        input_2_imag = tl.load(input_ptr + input_base + 5, mask=mask, other=0.0)
+    if OTHER_VECTORS == 1:
+        other_0_real = tl.load(other_ptr)
+        other_0_imag = tl.load(other_ptr + 1)
+        other_1_real = tl.load(other_ptr + 2)
+        other_1_imag = tl.load(other_ptr + 3)
+        other_2_real = tl.load(other_ptr + 4)
+        other_2_imag = tl.load(other_ptr + 5)
+    else:
+        other_base = vectors * 6
+        other_0_real = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+        other_0_imag = tl.load(other_ptr + other_base + 1, mask=mask, other=0.0)
+        other_1_real = tl.load(other_ptr + other_base + 2, mask=mask, other=0.0)
+        other_1_imag = tl.load(other_ptr + other_base + 3, mask=mask, other=0.0)
+        other_2_real = tl.load(other_ptr + other_base + 4, mask=mask, other=0.0)
+        other_2_imag = tl.load(other_ptr + other_base + 5, mask=mask, other=0.0)
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + 2, out_1_real, mask=mask)
+    tl.store(output_ptr + output_base + 3, out_1_imag, mask=mask)
+    tl.store(output_ptr + output_base + 4, out_2_real, mask=mask)
+    tl.store(output_ptr + output_base + 5, out_2_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_dim1_3d_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    INNER_SIZE: tl.constexpr,
+    INPUT_BATCH_STRIDE: tl.constexpr,
+    OTHER_BATCH_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    inner = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = inner < INNER_SIZE
+    input_base = batch * INPUT_BATCH_STRIDE + inner
+    other_base = batch * OTHER_BATCH_STRIDE + inner
+    output_base = batch * (3 * INNER_SIZE) + inner
+
+    input_0 = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_1 = tl.load(input_ptr + input_base + INNER_SIZE, mask=mask, other=0.0)
+    input_2 = tl.load(input_ptr + input_base + 2 * INNER_SIZE, mask=mask, other=0.0)
+    other_0 = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_1 = tl.load(other_ptr + other_base + INNER_SIZE, mask=mask, other=0.0)
+    other_2 = tl.load(other_ptr + other_base + 2 * INNER_SIZE, mask=mask, other=0.0)
+
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=mask)
+    tl.store(
+        output_ptr + output_base + INNER_SIZE,
+        output_1,
+        mask=mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * INNER_SIZE,
+        output_2,
+        mask=mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_real_dim1_small_inner_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    num_batches,
+    INNER_SIZE: tl.constexpr,
+    INPUT_BATCH_STRIDE: tl.constexpr,
+    OTHER_BATCH_STRIDE: tl.constexpr,
+    BATCH_BLOCK_SIZE: tl.constexpr,
+    INNER_BLOCK_SIZE: tl.constexpr,
+):
+    batches = tl.program_id(0) * BATCH_BLOCK_SIZE + tl.arange(0, BATCH_BLOCK_SIZE)
+    inner = tl.arange(0, INNER_BLOCK_SIZE)
+    batch_mask = batches[:, None] < num_batches
+    inner_mask = inner[None, :] < INNER_SIZE
+
+    if INPUT_BATCH_STRIDE == 0:
+        input_base = inner[None, :]
+        input_mask = inner_mask
+    else:
+        input_base = batches[:, None] * INPUT_BATCH_STRIDE + inner[None, :]
+        input_mask = batch_mask & inner_mask
+    if OTHER_BATCH_STRIDE == 0:
+        other_base = inner[None, :]
+        other_mask = inner_mask
+    else:
+        other_base = batches[:, None] * OTHER_BATCH_STRIDE + inner[None, :]
+        other_mask = batch_mask & inner_mask
+
+    input_0 = tl.load(input_ptr + input_base, mask=input_mask, other=0.0)
+    input_1 = tl.load(input_ptr + input_base + INNER_SIZE, mask=input_mask, other=0.0)
+    input_2 = tl.load(
+        input_ptr + input_base + 2 * INNER_SIZE, mask=input_mask, other=0.0
+    )
+    other_0 = tl.load(other_ptr + other_base, mask=other_mask, other=0.0)
+    other_1 = tl.load(other_ptr + other_base + INNER_SIZE, mask=other_mask, other=0.0)
+    other_2 = tl.load(
+        other_ptr + other_base + 2 * INNER_SIZE, mask=other_mask, other=0.0
+    )
+
+    output_base = batches[:, None] * (3 * INNER_SIZE) + inner[None, :]
+    output_mask = batch_mask & inner_mask
+    element_ty = input_ptr.dtype.element_ty
+    output_0 = _real_cross_component(input_1, other_2, input_2, other_1, element_ty)
+    output_1 = _real_cross_component(input_2, other_0, input_0, other_2, element_ty)
+    output_2 = _real_cross_component(input_0, other_1, input_1, other_0, element_ty)
+    tl.store(output_ptr + output_base, output_0, mask=output_mask)
+    tl.store(
+        output_ptr + output_base + INNER_SIZE,
+        output_1,
+        mask=output_mask,
+    )
+    tl.store(
+        output_ptr + output_base + 2 * INNER_SIZE,
+        output_2,
+        mask=output_mask,
+    )
+
+
+@libentry()
+@triton.jit
+def _linalg_cross_complex_dim1_3d_kernel(
+    input_ptr,
+    other_ptr,
+    output_ptr,
+    INNER_SIZE: tl.constexpr,
+    INPUT_BATCH_STRIDE: tl.constexpr,
+    OTHER_BATCH_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    inner = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = inner < INNER_SIZE
+    input_base = 2 * (batch * INPUT_BATCH_STRIDE + inner)
+    other_base = 2 * (batch * OTHER_BATCH_STRIDE + inner)
+    output_base = 2 * (batch * (3 * INNER_SIZE) + inner)
+    component_stride = 2 * INNER_SIZE
+
+    input_0_real = tl.load(input_ptr + input_base, mask=mask, other=0.0)
+    input_0_imag = tl.load(input_ptr + input_base + 1, mask=mask, other=0.0)
+    input_1_real = tl.load(
+        input_ptr + input_base + component_stride, mask=mask, other=0.0
+    )
+    input_1_imag = tl.load(
+        input_ptr + input_base + component_stride + 1, mask=mask, other=0.0
+    )
+    input_2_real = tl.load(
+        input_ptr + input_base + 2 * component_stride, mask=mask, other=0.0
+    )
+    input_2_imag = tl.load(
+        input_ptr + input_base + 2 * component_stride + 1, mask=mask, other=0.0
+    )
+    other_0_real = tl.load(other_ptr + other_base, mask=mask, other=0.0)
+    other_0_imag = tl.load(other_ptr + other_base + 1, mask=mask, other=0.0)
+    other_1_real = tl.load(
+        other_ptr + other_base + component_stride, mask=mask, other=0.0
+    )
+    other_1_imag = tl.load(
+        other_ptr + other_base + component_stride + 1, mask=mask, other=0.0
+    )
+    other_2_real = tl.load(
+        other_ptr + other_base + 2 * component_stride, mask=mask, other=0.0
+    )
+    other_2_imag = tl.load(
+        other_ptr + other_base + 2 * component_stride + 1, mask=mask, other=0.0
+    )
+
+    out_0_real = (
+        input_1_real * other_2_real
+        - input_1_imag * other_2_imag
+        - input_2_real * other_1_real
+        + input_2_imag * other_1_imag
+    )
+    out_0_imag = (
+        input_1_real * other_2_imag
+        + input_1_imag * other_2_real
+        - input_2_real * other_1_imag
+        - input_2_imag * other_1_real
+    )
+    out_1_real = (
+        input_2_real * other_0_real
+        - input_2_imag * other_0_imag
+        - input_0_real * other_2_real
+        + input_0_imag * other_2_imag
+    )
+    out_1_imag = (
+        input_2_real * other_0_imag
+        + input_2_imag * other_0_real
+        - input_0_real * other_2_imag
+        - input_0_imag * other_2_real
+    )
+    out_2_real = (
+        input_0_real * other_1_real
+        - input_0_imag * other_1_imag
+        - input_1_real * other_0_real
+        + input_1_imag * other_0_imag
+    )
+    out_2_imag = (
+        input_0_real * other_1_imag
+        + input_0_imag * other_1_real
+        - input_1_real * other_0_imag
+        - input_1_imag * other_0_real
+    )
+
+    tl.store(output_ptr + output_base, out_0_real, mask=mask)
+    tl.store(output_ptr + output_base + 1, out_0_imag, mask=mask)
+    tl.store(output_ptr + output_base + component_stride, out_1_real, mask=mask)
+    tl.store(output_ptr + output_base + component_stride + 1, out_1_imag, mask=mask)
+    tl.store(output_ptr + output_base + 2 * component_stride, out_2_real, mask=mask)
+    tl.store(
+        output_ptr + output_base + 2 * component_stride + 1,
+        out_2_imag,
+        mask=mask,
+    )
+
+
+def _launch_linalg_cross_kernel(input, other, output, dim, layout=None):
+    num_vectors = output.numel() // 3
+    if num_vectors == 0:
+        return
+
+    block_size = 128 if output.is_complex() else 256
+    grid = (triton.cdiv(num_vectors, block_size),)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            input_real = torch.view_as_real(input)
+            other_real = torch.view_as_real(other)
+            output_real = torch.view_as_real(output)
+            if layout is None:
+                _linalg_cross_complex_kernel[grid](
+                    input_real,
+                    other_real,
+                    output_real,
+                    num_vectors,
+                    BLOCK_SIZE=block_size,
+                )
+            else:
+                (
+                    input_outer,
+                    other_outer,
+                    output_outer,
+                    input_component,
+                    other_component,
+                    output_component,
+                    outer1_size,
+                ) = layout
+                _linalg_cross_complex_strided_kernel[grid](
+                    input_real,
+                    other_real,
+                    output_real,
+                    num_vectors,
+                    INPUT_OUTER0_STRIDE=2 * input_outer[0],
+                    INPUT_OUTER1_STRIDE=2 * input_outer[1],
+                    INPUT_COMPONENT_STRIDE=2 * input_component,
+                    OTHER_OUTER0_STRIDE=2 * other_outer[0],
+                    OTHER_OUTER1_STRIDE=2 * other_outer[1],
+                    OTHER_COMPONENT_STRIDE=2 * other_component,
+                    OUTPUT_OUTER0_STRIDE=2 * output_outer[0],
+                    OUTPUT_OUTER1_STRIDE=2 * output_outer[1],
+                    OUTPUT_COMPONENT_STRIDE=2 * output_component,
+                    OUTER1_SIZE=outer1_size,
+                    BLOCK_SIZE=block_size,
+                )
+        else:
+            if layout is None:
+                _linalg_cross_real_kernel[grid](
+                    input,
+                    other,
+                    output,
+                    num_vectors,
+                    BLOCK_SIZE=block_size,
+                )
+            else:
+                (
+                    input_outer,
+                    other_outer,
+                    output_outer,
+                    input_component,
+                    other_component,
+                    output_component,
+                    outer1_size,
+                ) = layout
+                _linalg_cross_real_strided_kernel[grid](
+                    input,
+                    other,
+                    output,
+                    num_vectors,
+                    INPUT_OUTER0_STRIDE=input_outer[0],
+                    INPUT_OUTER1_STRIDE=input_outer[1],
+                    INPUT_COMPONENT_STRIDE=input_component,
+                    OTHER_OUTER0_STRIDE=other_outer[0],
+                    OTHER_OUTER1_STRIDE=other_outer[1],
+                    OTHER_COMPONENT_STRIDE=other_component,
+                    OUTPUT_OUTER0_STRIDE=output_outer[0],
+                    OUTPUT_OUTER1_STRIDE=output_outer[1],
+                    OUTPUT_COMPONENT_STRIDE=output_component,
+                    OUTER1_SIZE=outer1_size,
+                    BLOCK_SIZE=block_size,
+                )
+
+
+def _launch_lastdim_broadcast_kernel(input, other, output):
+    num_vectors = output.numel() // 3
+    block_size = 128 if output.is_complex() else 256
+    grid = (triton.cdiv(num_vectors, block_size),)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            _linalg_cross_complex_lastdim_broadcast_kernel[grid](
+                torch.view_as_real(input),
+                torch.view_as_real(other),
+                torch.view_as_real(output),
+                num_vectors,
+                INPUT_VECTORS=input.numel() // 3,
+                OTHER_VECTORS=other.numel() // 3,
+                BLOCK_SIZE=block_size,
+            )
+        else:
+            _linalg_cross_real_lastdim_broadcast_kernel[grid](
+                input,
+                other,
+                output,
+                num_vectors,
+                INPUT_VECTORS=input.numel() // 3,
+                OTHER_VECTORS=other.numel() // 3,
+                BLOCK_SIZE=block_size,
+            )
+
+
+def _launch_dim1_3d_kernel(input, other, output):
+    block_size = 128 if output.is_complex() else 256
+    grid = (output.shape[0], triton.cdiv(output.shape[2], block_size))
+    input_batch_stride = 0 if input.shape[0] == 1 else input.stride(0)
+    other_batch_stride = 0 if other.shape[0] == 1 else other.stride(0)
+    with torch_device_fn.device(output.device):
+        if output.is_complex():
+            _linalg_cross_complex_dim1_3d_kernel[grid](
+                torch.view_as_real(input),
+                torch.view_as_real(other),
+                torch.view_as_real(output),
+                INNER_SIZE=output.shape[2],
+                INPUT_BATCH_STRIDE=input_batch_stride,
+                OTHER_BATCH_STRIDE=other_batch_stride,
+                BLOCK_SIZE=block_size,
+            )
+        else:
+            _linalg_cross_real_dim1_3d_kernel[grid](
+                input,
+                other,
+                output,
+                INNER_SIZE=output.shape[2],
+                INPUT_BATCH_STRIDE=input_batch_stride,
+                OTHER_BATCH_STRIDE=other_batch_stride,
+                BLOCK_SIZE=block_size,
+            )
+
+
+def _launch_dim1_small_inner_kernel(input, other, output):
+    batch_block_size = min(64, triton.next_power_of_2(output.shape[0]))
+    inner_block_size = triton.next_power_of_2(output.shape[2])
+    grid = (triton.cdiv(output.shape[0], batch_block_size),)
+    input_batch_stride = 0 if input.shape[0] == 1 else input.stride(0)
+    other_batch_stride = 0 if other.shape[0] == 1 else other.stride(0)
+    with torch_device_fn.device(output.device):
+        _linalg_cross_real_dim1_small_inner_kernel[grid](
+            input,
+            other,
+            output,
+            output.shape[0],
+            INNER_SIZE=output.shape[2],
+            INPUT_BATCH_STRIDE=input_batch_stride,
+            OTHER_BATCH_STRIDE=other_batch_stride,
+            BATCH_BLOCK_SIZE=batch_block_size,
+            INNER_BLOCK_SIZE=inner_block_size,
+        )
+
+
+def _linalg_cross_impl(input, other, dim, output=None):
+    if input.dtype not in _SUPPORTED_DTYPES or other.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(
+            "linalg_cross on Ascend only supports float16, float32, bfloat16, "
+            "and complex64"
+        )
+    dim, output_shape = _validate_inputs(input, other, dim)
+    input = _resolve_view(input)
+    other = _resolve_view(other)
+
+    if input.ndim <= 3:
+        if output is None:
+            if input.shape == output_shape and input.is_contiguous():
+                output = torch.empty_like(input)
+            elif other.shape == output_shape and other.is_contiguous():
+                output = torch.empty_like(other)
+            else:
+                output = torch.empty(
+                    output_shape, dtype=input.dtype, device=input.device
+                )
+
+        fast_contiguous = (
+            dim == input.ndim - 1
+            and input.shape == output_shape
+            and other.shape == output_shape
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and output.is_contiguous()
+        )
+        if fast_contiguous:
+            _launch_linalg_cross_kernel(input, other, output, dim)
+            return output
+
+        if (
+            input.ndim == 2
+            and dim == 1
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and output.is_contiguous()
+        ):
+            _launch_lastdim_broadcast_kernel(input, other, output)
+            return output
+
+        if (
+            input.ndim == 3
+            and dim == 1
+            and input.is_contiguous()
+            and other.is_contiguous()
+            and input.shape[2] == output.shape[2]
+            and other.shape[2] == output.shape[2]
+            and output.is_contiguous()
+        ):
+            if output.shape[2] <= 16:
+                if output.is_complex():
+                    layout = _get_strided_layout(input, other, output, dim)
+                    _launch_linalg_cross_kernel(
+                        input,
+                        other,
+                        output,
+                        dim,
+                        layout,
+                    )
+                else:
+                    _launch_dim1_small_inner_kernel(input, other, output)
+            else:
+                _launch_dim1_3d_kernel(input, other, output)
+            return output
+
+        layout = _get_strided_layout(input, other, output, dim)
+        _launch_linalg_cross_kernel(
+            input,
+            other,
+            output,
+            dim,
+            layout,
+        )
+        return output
+
+    input_moved, other_moved, output_dim = _prepare_inputs(input, other, dim)
+    output_moved = torch.empty_like(input_moved)
+    _launch_linalg_cross_kernel(input_moved, other_moved, output_moved, -1)
+    result = output_moved.movedim(-1, output_dim).contiguous()
+    if output is not None:
+        output.copy_(result)
+        return output
+    return result
+
+
+def linalg_cross(input, other, *, dim=-1):
+    logger.debug("GEMS_ASCEND LINALG_CROSS")
+    return _linalg_cross_impl(input, other, dim)
+
+
+def linalg_cross_out(input, other, *, dim=-1, out):
+    logger.debug("GEMS_ASCEND LINALG_CROSS_OUT")
+    if torch._C._is_alias_of(out, input) or torch._C._is_alias_of(out, other):
+        raise RuntimeError(
+            "linalg_cross: out must not share memory with either input tensor"
+        )
+    if input.dtype not in _SUPPORTED_DTYPES or other.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(
+            "linalg_cross on Ascend only supports float16, float32, bfloat16, "
+            "and complex64"
+        )
+    dim, output_shape = _validate_inputs(input, other, dim)
+    if out.dtype != input.dtype:
+        raise RuntimeError(
+            f"linalg_cross: expected out dtype {input.dtype}, but got {out.dtype}"
+        )
+    if out.device != input.device:
+        raise RuntimeError("linalg_cross: out must be on the same device as input")
+    if out.shape != output_shape:
+        out.resize_(output_shape)
+    return _linalg_cross_impl(input, other, dim, output=out)

--- a/tests/test_linalg_cross.py
+++ b/tests/test_linalg_cross.py
@@ -1,0 +1,135 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+SUPPORTED_DTYPES = [
+    torch.float16,
+    torch.float32,
+    torch.bfloat16,
+    torch.complex64,
+]
+COMPLEX_DTYPES = [torch.complex64]
+if flag_gems.runtime.device.support_fp64:
+    SUPPORTED_DTYPES.extend([torch.float64, torch.complex128])
+    COMPLEX_DTYPES.append(torch.complex128)
+
+
+def _randn(shape, dtype):
+    if dtype.is_complex and flag_gems.vendor_name == "ascend":
+        # torch_npu does not implement in-place normal generation for complex
+        # tensors, so create the test values on CPU and transfer them instead.
+        return torch.randn(shape, dtype=dtype).to(flag_gems.device)
+    return torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+
+def _to_cross_reference(tensor, dtype):
+    reference = utils.to_reference(tensor)
+    if dtype in (torch.float16, torch.bfloat16):
+        # CPU and accelerator linalg_cross implementations use different
+        # low-precision intermediate rounding on some backends. FP32 opmath is
+        # the common, more accurate reference for both execution locations.
+        reference = reference.to(torch.float32)
+    return reference
+
+
+def _assert_cross_close(result, reference, dtype):
+    if dtype == torch.complex64:
+        # Some backends do not implement isclose/abs for complex tensors.
+        # Compare the real-valued view without changing the reference device.
+        utils.gems_assert_close(
+            torch.view_as_real(result),
+            torch.view_as_real(reference),
+            torch.float32,
+        )
+    elif dtype == torch.complex128:
+        result = utils.to_cpu(result, reference)
+        torch.testing.assert_close(
+            torch.view_as_real(result),
+            torch.view_as_real(reference),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+    elif dtype == torch.float16:
+        utils.gems_assert_close(result, reference, dtype, atol=1e-3)
+    elif dtype == torch.bfloat16:
+        # BF16 has a wider quantization step than FP16 for unit-scale values.
+        utils.gems_assert_close(result, reference, dtype, atol=1e-2)
+    else:
+        utils.gems_assert_close(result, reference, dtype)
+
+
+@pytest.mark.linalg_cross
+@pytest.mark.parametrize("dtype", SUPPORTED_DTYPES)
+@pytest.mark.parametrize(
+    "input_shape,other_shape,dim",
+    [
+        ((3, 4), (3, 4), 0),
+        ((2, 3, 4), (1, 3, 4), 1),
+        ((4096, 3, 4), (1, 3, 4), 1),
+        ((2, 4, 3), (1, 4, 3), 2),
+        ((2, 3, 4), (1, 3, 4), -2),
+        ((1, 3), (5, 3), -1),
+        ((2, 4, 3), (2, 4, 3), -1),
+        ((2, 4, 3, 5), (1, 4, 3, 5), 2),
+    ],
+)
+def test_linalg_cross(input_shape, other_shape, dim, dtype):
+    input = _randn(input_shape, dtype)
+    other = _randn(other_shape, dtype)
+    ref_input = _to_cross_reference(input, dtype)
+    ref_other = _to_cross_reference(other, dtype)
+
+    ref_out = torch.linalg.cross(ref_input, ref_other, dim=dim)
+    with flag_gems.use_gems(include=["linalg_cross"]):
+        result = torch.linalg.cross(input, other, dim=dim)
+
+    _assert_cross_close(result, ref_out, dtype)
+
+
+@pytest.mark.linalg_cross_out
+@pytest.mark.parametrize("dtype", SUPPORTED_DTYPES)
+def test_linalg_cross_noncontiguous_input_and_out(dtype):
+    input = _randn((2, 4, 3), dtype).transpose(1, 2)
+    other = _randn((1, 4, 3), dtype).transpose(1, 2)
+    out = torch.empty((2, 4, 3), dtype=dtype, device=flag_gems.device).transpose(1, 2)
+    ref_input = _to_cross_reference(input, dtype)
+    ref_other = _to_cross_reference(other, dtype)
+    ref_out = torch.empty(
+        (2, 4, 3), dtype=ref_input.dtype, device=ref_input.device
+    ).transpose(1, 2)
+    torch.ops.aten.linalg_cross.out(ref_input, ref_other, dim=1, out=ref_out)
+    with flag_gems.use_gems(include=["linalg_cross_out"]):
+        result = torch.ops.aten.linalg_cross.out(input, other, dim=1, out=out)
+
+    assert result is out
+    _assert_cross_close(out, ref_out, dtype)
+
+
+@pytest.mark.linalg_cross
+def test_linalg_cross_rejects_different_input_ranks():
+    input = _randn((3,), torch.float32)
+    other = _randn((1, 3), torch.float32)
+
+    with (
+        flag_gems.use_gems(include=["linalg_cross"]),
+        pytest.raises(RuntimeError, match="same number of dimensions"),
+    ):
+        torch.linalg.cross(input, other)
+
+
+@pytest.mark.linalg_cross
+@pytest.mark.parametrize("dtype", COMPLEX_DTYPES)
+def test_linalg_cross_conjugated_view(dtype):
+    input = _randn((2, 3, 4), dtype).conj()
+    other = _randn((1, 3, 4), dtype)
+    ref_input = utils.to_reference(input)
+    ref_other = utils.to_reference(other)
+
+    ref_out = torch.linalg.cross(ref_input, ref_other, dim=1)
+    with flag_gems.use_gems(include=["linalg_cross"]):
+        result = torch.linalg.cross(input, other, dim=1)
+
+    _assert_cross_close(result, ref_out, dtype)


### PR DESCRIPTION
## Summary

This PR adds `linalg_cross` and `linalg_cross.out` support for NVIDIA GPUs, Huawei Ascend NPUs, T-Head PPUs, Hygon DCUs, MetaX GPUs, and Iluvatar GPUs.

The implementation follows PyTorch semantics for the cross-product dimension, same-rank batch broadcasting, real and complex inputs, non-contiguous layouts, conjugate views, and `out` handling.

## Changes

- Add Triton implementations for `linalg_cross` and `linalg_cross.out` without falling back to native `torch.linalg.cross` inside the FlagGems implementation.
- Add separate `linalg_cross` and `linalg_cross_out` operator metadata IDs and pytest markers.
- Register and export the operators from `flag_gems.ops` and the corresponding backend packages.
- Add real and complex kernels for contiguous, broadcast, and strided layouts.
- Add kernels for 2D last-dimension broadcasting and 3D `dim=1` broadcasting.
- Add higher-rank handling that moves the cross-product dimension, applies broadcasting, and executes the cross product with Triton.
- Add pure Triton Ascend kernels without calling the native torch_npu `linalg_cross` implementation.
- Reuse the NVIDIA Triton implementation for T-Head, Hygon, MetaX, and Iluvatar through backend-specific operator copies and registrations.
- Use explicit complex-result unpacking in the Iluvatar broadcast kernels for CoreX Triton compiler compatibility.
- Add FP16 and BF16 support while retaining FP32, FP64, complex64, and complex128 correctness coverage where supported by the backend.
- Add correctness tests for broadcasting, multiple positive and negative dimensions, `dim=1` scale inputs, non-contiguous tensors, `out`, invalid ranks, and conjugate views.
- Compare correctness directly against native `torch.linalg.cross`; Ascend testing does not require `--ref cpu`.
- Exclude backward testing because this change does not add a separate backward operator.
- Add benchmark coverage for FP16, FP32, and BF16.

## Test Command

```bash
pytest tests/test_linalg_cross.py
pytest -s benchmark/test_linalg_cross.py --mode kernel --level comprehensive --metrics latency_base --metrics latency --metrics speedup --warmup 1000 --iter 100
pytest -s benchmark/test_linalg_cross.py --mode operator --level comprehensive --metrics latency_base --metrics latency --metrics speedup --warmup 1000 --iter 100
```

## Benchmark

The arithmetic mean is calculated in two stages: first average the speedups of all shapes for each dtype, then average the FP16, FP32, and BF16 mean speedups to obtain the final operator speedup for each platform.

### NPU

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.341282|0.231862|1.472x|`([torch.Size([16384, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|5.198518|0.815345|6.376x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.177986|0.129332|1.376x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.324490|0.114374|2.837x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.168293|0.116004|1.451x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.324514|0.108317|2.996x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.621526|0.111246|5.587x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|1.173099|0.116305|10.086x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.320494|0.132945|2.411x|`([torch.Size([16384, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|4.914610|0.529151|9.288x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.162561|0.120661|1.347x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.300729|0.114574|2.625x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.152471|0.112943|1.350x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.300630|0.109593|2.743x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.598372|0.126149|4.743x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|1.140698|0.123897|9.207x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.339660|0.156230|2.174x|`([torch.Size([16384, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|5.193899|0.898783|5.779x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.177621|0.132572|1.340x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.324375|0.127989|2.534x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.167966|0.125769|1.336x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.324472|0.122006|2.659x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.621474|0.123599|5.028x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|1.173199|0.124219|9.445x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The FP16 arithmetic mean speedup is 4.023x, the FP32 arithmetic mean speedup is 4.214x, and the BF16 arithmetic mean speedup is 3.787x. Using the unrounded dtype means, the final NPU speedup is `(4.022625x + 4.214250x + 3.786875x) / 3 = 4.007917x`, reported as 4.008x, which is greater than 0.8x.

The NPU results are measured in operator mode. The Triton implementation fuses broadcasting, the three cross-product components, and output writes into one kernel. Native `torch.linalg.cross` has higher dispatch and layout-handling overhead on the measured Ascend cases, so the fused path shows a larger speedup, especially for the large broadcasting and throughput shapes.

### GPU

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.015904|0.009184|1.732x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.006752|0.006208|1.088x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.008224|0.008128|1.012x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.006752|0.006304|1.071x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.008096|0.008128|0.996x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.010560|0.010368|1.019x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.015360|0.015136|1.015x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.015040|0.011968|1.257x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.006720|0.006400|1.050x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.008736|0.008832|0.989x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.007296|0.006944|1.051x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.008672|0.008864|0.978x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.011296|0.011776|0.959x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.016832|0.018112|0.929x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.016352|0.008896|1.838x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.006880|0.005952|1.156x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.008384|0.007904|1.061x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.007008|0.006400|1.095x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.008384|0.008128|1.031x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.010656|0.010144|1.050x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.015904|0.015072|1.055x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The FP16 arithmetic mean speedup is 1.133x, the FP32 arithmetic mean speedup is 1.030x, and the BF16 arithmetic mean speedup is 1.184x. Using the unrounded dtype means, the final GPU speedup is `(1.133286x + 1.030429x + 1.183714x) / 3 = 1.115810x`, reported as 1.116x, which is greater than 0.8x.

### T-Head

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.016180|0.012360|1.309x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.004760|0.003520|1.352x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.007840|0.006480|1.210x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.005480|0.004240|1.292x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.007880|0.006480|1.216x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.011520|0.010720|1.075x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.020160|0.018880|1.068x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.023080|0.021920|1.053x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.005880|0.004880|1.205x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.011440|0.010440|1.096x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.007360|0.006160|1.195x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.011400|0.010440|1.092x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.020160|0.018960|1.063x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.037000|0.035520|1.042x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.016320|0.012360|1.320x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.004880|0.003520|1.386x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.008040|0.006480|1.241x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.005480|0.004240|1.292x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.008040|0.006520|1.233x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.011720|0.010760|1.089x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.020320|0.018920|1.074x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The T-Head backend reuses the NVIDIA Triton implementation. The FP16 arithmetic mean speedup is 1.217x, the FP32 arithmetic mean speedup is 1.107x, and the BF16 arithmetic mean speedup is 1.234x. Using the unrounded dtype means, the final T-Head speedup is `(1.217429x + 1.106571x + 1.233571x) / 3 = 1.185857x`, reported as 1.186x, which is greater than 0.8x.

### Hygon

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.025440|0.020160|1.262x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.016480|0.008160|2.020x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.018720|0.011360|1.648x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.016960|0.008000|2.120x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.018720|0.011840|1.581x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.022720|0.017280|1.315x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.033280|0.027440|1.213x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.029600|0.034240|0.864x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.016480|0.024640|0.669x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.019840|0.014400|1.378x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.017120|0.014080|1.216x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.019840|0.014240|1.393x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.026720|0.020960|1.275x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.042240|0.036160|1.168x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.032480|0.032320|1.005x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.016480|0.032160|0.512x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.019040|0.015360|1.240x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.017280|0.013760|1.256x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.019200|0.015280|1.257x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.022880|0.017280|1.324x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.033600|0.028320|1.186x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The Hygon backend reuses the NVIDIA Triton implementation. The FP16 arithmetic mean speedup is 1.594x, the FP32 arithmetic mean speedup is 1.138x, and the BF16 arithmetic mean speedup is 1.111x. Using the unrounded dtype means, the final Hygon speedup is `(1.594143x + 1.137571x + 1.111429x) / 3 = 1.281048x`, reported as 1.281x, which is greater than 0.8x.

### MetaX

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.073728|0.062464|1.180x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.032768|0.020224|1.620x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.036608|0.018944|1.932x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.033024|0.016128|2.048x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.036864|0.018944|1.946x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.048896|0.024064|2.032x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.071424|0.034048|2.098x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.083712|0.072448|1.155x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.033792|0.022016|1.535x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.037888|0.023040|1.644x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.033536|0.018688|1.795x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.037888|0.023040|1.644x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.049152|0.030720|1.600x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.071168|0.045056|1.580x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.076544|0.062464|1.225x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.033792|0.020224|1.671x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.038016|0.018944|2.007x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.033792|0.016384|2.063x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.037888|0.018944|2.000x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.050688|0.023552|2.152x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.074752|0.031488|2.374x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The MetaX backend reuses the NVIDIA Triton implementation. The FP16 arithmetic mean speedup is 1.837x, the FP32 arithmetic mean speedup is 1.565x, and the BF16 arithmetic mean speedup is 1.927x. Using the unrounded dtype means, the final MetaX speedup is `(1.836571x + 1.564714x + 1.927429x) / 3 = 1.776238x`, reported as 1.776x, which is greater than 0.8x.

### Iluvatar

|Operator|Dtype|Torch Latency (ms)|Gems Latency (ms)|Speedup|Size Detail|
|---|---|---:|---:|---:|---|
|linalg_cross|fp16|0.051708|0.037423|1.382x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp16|0.017673|0.008500|2.079x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.028346|0.019096|1.484x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.020577|0.011481|1.792x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.028192|0.018904|1.491x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.043923|0.033500|1.311x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp16|0.072500|0.060038|1.208x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.070519|0.062788|1.123x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|fp32|0.020615|0.012731|1.619x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.041500|0.033327|1.245x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.027154|0.018865|1.439x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.041423|0.033442|1.239x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.067654|0.059154|1.144x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|fp32|0.102346|0.093577|1.094x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.049673|0.037404|1.328x|`([torch.Size([262144, 3, 4]), torch.Size([1, 3, 4])], {'dim': 1})`|
|linalg_cross|bf16|0.018058|0.008788|2.055x|`([torch.Size([1, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.028481|0.018962|1.502x|`([torch.Size([65536, 4, 3]), torch.Size([65536, 4, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.020712|0.011423|1.813x|`([torch.Size([131072, 3]), torch.Size([131072, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.028538|0.018865|1.513x|`([torch.Size([262144, 3]), torch.Size([262144, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.043923|0.033500|1.311x|`([torch.Size([524288, 3]), torch.Size([524288, 3])], {'dim': -1})`|
|linalg_cross|bf16|0.072404|0.060058|1.206x|`([torch.Size([1048576, 3]), torch.Size([1048576, 3])], {'dim': -1})`|

The Iluvatar backend reuses the NVIDIA Triton implementation with explicit complex-result unpacking for CoreX compiler compatibility. The FP16 arithmetic mean speedup is 1.535x, the FP32 arithmetic mean speedup is 1.272x, and the BF16 arithmetic mean speedup is 1.533x. Using the unrounded dtype means, the final Iluvatar speedup is `(1.535286x + 1.271857x + 1.532571x) / 3 = 1.446571x`, reported as 1.447x, which is greater than 0.8x.

### Final Speedup Summary

|Platform|FP16 Mean Speedup|FP32 Mean Speedup|BF16 Mean Speedup|Final Speedup|Requirement|
|---|---:|---:|---:|---:|---|
|Ascend|4.023x|4.214x|3.787x|4.008x|PASS (>0.8x)|
|NVIDIA|1.133x|1.030x|1.184x|1.116x|PASS (>0.8x)|
|T-Head|1.217x|1.107x|1.234x|1.186x|PASS (>0.8x)|
|Hygon|1.594x|1.138x|1.111x|1.281x|PASS (>0.8x)|
|MetaX|1.837x|1.565x|1.927x|1.776x|PASS (>0.8x)|
|Iluvatar|1.535x|1.272x|1.533x|1.447x|PASS (>0.8x)|
