### PR TITLE
docs(release): place dev tag on empty commit after release, not on release tag

### DIFF
--- a/docs/content/en/release/versioning.md
+++ b/docs/content/en/release/versioning.md
@@ -52,20 +52,33 @@ suffix is automatically stripped when publishing to PyPI.
 
 ## Development Cycle
 
-After each stable release, a dev tag is created to mark the start of the next
-version cycle:
+After each stable release, create a dev tag to mark the start of the next version
+cycle. **Never place the dev tag on the same commit as the release tag** —
+when a patch release follows, `git tag -f` would be needed to move the dev tag,
+and that two-step fix is easily forgotten.
+
+After pushing the release tag, immediately create an empty commit as the anchor
+for the dev tag:
+
+```bash
+# Release tag is already pushed (v5.4.0), continue:
+git commit --allow-empty -m "Start v5.5.0 development cycle"
+git tag v5.5.0.dev0
+git push origin master v5.5.0.dev0
+```
 
 ```
-v5.3.0          ← stable release
+v5.4.0              ← stable release
   │
-  ├── commit 1  ← 5.4.0.dev1+gabcdef0
-  ├── commit 2  ← 5.4.0.dev2+g1234567
+  │  Start v5.5.0 development cycle  ← empty commit
+  │  v5.5.0.dev0                     ← dev tag on this commit
+  │
+  ├── commit 1  ← 5.5.0.dev1+gabcdef0
+  ├── commit 2  ← 5.5.0.dev2+g1234567
   ├── ...
-  ├── commit N  ← 5.4.0.devN+g<hash>
+  ├── commit N
   │
-v5.4.0          ← next stable release
-  │
-v5.5.0.dev0     ← start of next dev cycle
+v5.5.0              ← next stable release
 ```
 
 ## Release Process
@@ -88,8 +101,9 @@ v5.5.0.dev0     ← start of next dev cycle
 
 4. **Start the next dev cycle:**
    ```bash
+   git commit --allow-empty -m "Start v5.5.0 development cycle"
    git tag v5.5.0.dev0
-   git push origin v5.5.0.dev0
+   git push origin master v5.5.0.dev0
    ```
    From this point, all commits on `master` produce versions like
    `5.5.0.dev1+gabcdef0`.

--- a/docs/content/zh-cn/release/versioning.md
+++ b/docs/content/zh-cn/release/versioning.md
@@ -92,19 +92,31 @@ version cycle:
 -->
 ## 开发周期
 
-每次稳定版发布后，创建一个开发标签来标记下一个版本周期的开始：
+每次稳定版发布后，创建一个开发标签来标记下一个版本周期的开始。
+**dev 标签不能和发布标签打在同一个 commit 上**，否则后续补丁发布时需要
+`git tag -f` 移动 dev 标签，容易遗漏。
+
+做法：发布标签推送后，立即用一个空提交作为下一开发周期的起点，再把 dev 标签打上去：
+
+```bash
+# 发布标签已经推送（v5.4.0），继续执行：
+git commit --allow-empty -m "Start v5.5.0 development cycle"
+git tag v5.5.0.dev0
+git push origin master v5.5.0.dev0
+```
 
 ```
-v5.3.0          ← 稳定版发布
+v5.4.0              ← 稳定版发布
   │
-  ├── commit 1  ← 5.4.0.dev1+gabcdef0
-  ├── commit 2  ← 5.4.0.dev2+g1234567
+  │  Start v5.5.0 development cycle   ← 空提交
+  │  v5.5.0.dev0                      ← dev 标签打在此处
+  │
+  ├── commit 1  ← 5.5.0.dev1+gabcdef0
+  ├── commit 2  ← 5.5.0.dev2+g1234567
   ├── ...
-  ├── commit N  ← 5.4.0.devN+g<hash>
+  ├── commit N
   │
-v5.4.0          ← 下一个稳定版发布
-  │
-v5.5.0.dev0     ← 新的开发周期开始
+v5.5.0              ← 下一个稳定版发布
 ```
 
 <!--
@@ -145,8 +157,9 @@ v5.5.0.dev0     ← 新的开发周期开始
 
 4. **启动下一个开发周期：**
    ```bash
+   git commit --allow-empty -m "Start v5.5.0 development cycle"
    git tag v5.5.0.dev0
-   git push origin v5.5.0.dev0
+   git push origin master v5.5.0.dev0
    ```
    此后 `master` 上的所有提交将生成 `5.5.0.dev1+gabcdef0` 格式的版本号。
 


### PR DESCRIPTION
## Summary

After a stable release (e.g. v5.4.0), the next-cycle dev tag (v5.5.0.dev0) must not land on the same commit as the release tag. Otherwise, a later patch release merged back to master requires `git tag -f` + `git push -f` — a two-step fix that is easy to forget.

## Changes

Update both the English and Chinese versioning docs to prescribe:

1. After pushing the release tag, immediately create an empty commit followed by the dev tag
2. Explain why dev and release tags must not share the same commit
3. Update the development cycle diagram to show the empty commit

This PR was written in part with the assistance of generative AI.