### PR TITLE
Optimize LayerNorm backward for large row counts

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -342,6 +342,15 @@ NormBenchmark:
     - [20, 6, 65536] # from perf
   shape_desc: "N, C, *"
 
+LayerNormBackwardLargeMBenchmark:
+  shapes:
+    - [[64, 16, 64, 16], [16]]
+    - [[128, 16, 16, 32], [32]]
+    - [[32768, 128], [128]]
+    - [[32768, 256], [256]]
+    - [[32768, 257], [257]]
+  shape_desc: "input_shape, normalized_shape"
+
 TensorSelectBenchmark:
   shapes:
     - [64, 64]

--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -347,6 +347,15 @@ NormBenchmark:
     - [20, 6, 65536] # from perf
   shape_desc: "N, C, *"
 
+LayerNormBackwardLargeMBenchmark:
+  shapes:
+    - [[64, 16, 64, 16], [16]]
+    - [[128, 16, 16, 32], [32]]
+    - [[32768, 128], [128]]
+    - [[32768, 256], [256]]
+    - [[32768, 257], [257]]
+  shape_desc: "input_shape, normalized_shape"
+
 TensorSelectBenchmark:
   shapes:
     - [64, 64]

--- a/benchmark/test_layer_norm.py
+++ b/benchmark/test_layer_norm.py
@@ -34,6 +34,37 @@ class NormBenchmark(base.GenericBenchmark):
         ]
 
 
+class LayerNormBackwardLargeMBenchmark(base.Benchmark):
+    DEFAULT_SHAPES = [
+        ((64, 16, 64, 16), (16,)),
+        ((128, 16, 16, 32), (32,)),
+        ((32768, 128), (128,)),
+        ((32768, 256), (256,)),
+        ((32768, 257), (257,)),
+    ]
+    DEFAULT_SHAPE_DESC = "input_shape, normalized_shape"
+
+    def get_input_iter(self, dtype):
+        for shape, normalized_shape in self.shapes:
+            grad_out = torch.randn(shape, dtype=dtype, device=self.device)
+            inp = torch.randn(shape, dtype=dtype, device=self.device)
+            weight = torch.randn(normalized_shape, dtype=dtype, device=self.device)
+            bias = torch.randn(normalized_shape, dtype=dtype, device=self.device)
+            _, mean, rstd = torch.ops.aten.native_layer_norm(
+                inp, normalized_shape, weight, bias, 1e-5
+            )
+            yield (
+                grad_out,
+                inp,
+                normalized_shape,
+                mean,
+                rstd,
+                weight,
+                bias,
+                [True, True, True],
+            )
+
+
 def input_fn(shape, dtype, device):
     inp = torch.randn(shape, dtype=dtype, device=device)
     layer_shape = shape[1:]
@@ -71,6 +102,16 @@ def test_layer_norm_backward():
     bench = NormBenchmark(
         op_name="layer_norm_backward",
         input_fn=input_fn_backward,
+        torch_op=torch.ops.aten.native_layer_norm_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.layer_norm_backward
+def test_layer_norm_backward_large_m():
+    bench = LayerNormBackwardLargeMBenchmark(
+        op_name="layer_norm_backward_large_m",
         torch_op=torch.ops.aten.native_layer_norm_backward,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_layer_norm.py
+++ b/benchmark/test_layer_norm.py
@@ -40,6 +40,37 @@ class NormBenchmark(base.GenericBenchmark):
         ]
 
 
+class LayerNormBackwardLargeMBenchmark(base.Benchmark):
+    DEFAULT_SHAPES = [
+        ((64, 16, 64, 16), (16,)),
+        ((128, 16, 16, 32), (32,)),
+        ((32768, 128), (128,)),
+        ((32768, 256), (256,)),
+        ((32768, 257), (257,)),
+    ]
+    DEFAULT_SHAPE_DESC = "input_shape, normalized_shape"
+
+    def get_input_iter(self, dtype):
+        for shape, normalized_shape in self.shapes:
+            grad_out = torch.randn(shape, dtype=dtype, device=self.device)
+            inp = torch.randn(shape, dtype=dtype, device=self.device)
+            weight = torch.randn(normalized_shape, dtype=dtype, device=self.device)
+            bias = torch.randn(normalized_shape, dtype=dtype, device=self.device)
+            _, mean, rstd = torch.ops.aten.native_layer_norm(
+                inp, normalized_shape, weight, bias, 1e-5
+            )
+            yield (
+                grad_out,
+                inp,
+                normalized_shape,
+                mean,
+                rstd,
+                weight,
+                bias,
+                [True, True, True],
+            )
+
+
 def input_fn(shape, dtype, device):
     inp = torch.randn(shape, dtype=dtype, device=device)
     layer_shape = shape[1:]
@@ -96,6 +127,16 @@ def test_layer_norm_backward():
     bench = NormBenchmark(
         op_name="layer_norm_backward",
         input_fn=input_fn_backward,
+        torch_op=torch.ops.aten.native_layer_norm_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.layer_norm_backward
+def test_layer_norm_backward_large_m():
+    bench = LayerNormBackwardLargeMBenchmark(
+        op_name="layer_norm_backward_large_m",
         torch_op=torch.ops.aten.native_layer_norm_backward,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import math
 
@@ -31,6 +32,88 @@ logger = logging.getLogger(__name__)
 def prev_multiple_of(a, b):
     # the largest x<a that x%b ==0
     return tl.cdiv(a, b) * b - b
+
+
+@functools.lru_cache(maxsize=None)
+def _layer_norm_parallel_units(device_index):
+    props = torch_device_fn.get_device_properties(device_index)
+    # Device runtimes expose the compute-unit count under different names.
+    property_names = (
+        "multi_processor_count",
+        "multiProcessorCount",
+        "vector_core_num",
+        "num_vectorcore",
+        "cube_core_num",
+        "num_aicore",
+    )
+    for name in property_names:
+        value = (
+            props.get(name) if isinstance(props, dict) else getattr(props, name, None)
+        )
+        if value:
+            return int(value)
+    return None
+
+
+def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
+    if output_mask is None or M <= 0 or N <= 0:
+        return None
+
+    compute_dx, compute_dw, compute_db = map(bool, output_mask)
+    if (
+        input.dtype not in (torch.float32, torch.float16, torch.bfloat16)
+        or not compute_dx
+        or not (compute_dw or compute_db)
+        or (compute_dw and weight is None)
+        or (compute_db and bias is None)
+    ):
+        return None
+
+    tile_n = triton.next_power_of_2(N)
+    args = {
+        "M": M,
+        "N": N,
+        "TILE_N": tile_n,
+        "IS_LOW_PRECISION": input.dtype != torch.float32,
+    }
+    # Backends opt in to the resident path by providing this heuristic group.
+    fused_heuristics = runtime.get_heuristic_config("layer_norm_backward_fused")
+    if fused_heuristics is None:
+        return None
+
+    max_resident_n = fused_heuristics["MAX_RESIDENT_N"](args)
+    enough_work = M * N >= fused_heuristics["MIN_ELEMENTS"](args)
+    if tile_n > max_resident_n or not enough_work:
+        return None
+
+    parallel_units = _layer_norm_parallel_units(torch_device_fn.current_device())
+    if parallel_units is None:
+        return None
+
+    direct_lowp_atomic_fn = fused_heuristics.get("DIRECT_LOWP_ATOMIC")
+    direct_lowp_atomic = (
+        direct_lowp_atomic_fn(args) if direct_lowp_atomic_fn is not None else False
+    )
+    # Accumulate through FP32 scratch when low-precision atomics are unavailable.
+    use_fp32_scratch = input.dtype != torch.float32 and not direct_lowp_atomic
+
+    # Large M is handled by the kernel's grid-stride row loop.
+    tile_elements = fused_heuristics["TILE_ELEMENTS"](args)
+    program_waves = fused_heuristics["PROGRAM_WAVES"](args)
+    block_m = max(1, tile_elements // tile_n)
+    max_block_m_fn = fused_heuristics.get("MAX_BLOCK_M")
+    if max_block_m_fn is not None:
+        block_m = min(block_m, max_block_m_fn(args))
+    row_tiles = triton.cdiv(M, block_m)
+    program_count = min(row_tiles, parallel_units * program_waves)
+    return (
+        block_m,
+        tile_n,
+        program_count,
+        compute_dw,
+        compute_db,
+        use_fp32_scratch,
+    )
 
 
 @libentry()
@@ -302,6 +385,209 @@ def layer_norm_backward_kernel(
 
 
 @libentry()
+@triton.jit
+def layer_norm_backward_zero_affine_kernel(
+    dW,
+    dB,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    cols = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+    if COMPUTE_DW:
+        tl.store(dW + cols, 0.0, mask=mask)
+    if COMPUTE_DB:
+        tl.store(dB + cols, 0.0, mask=mask)
+
+
+@libentry()
+@triton.jit
+def layer_norm_backward_cast_affine_kernel(
+    dWAcc,
+    dBAcc,
+    dW,
+    dB,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    cols = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+    if COMPUTE_DW:
+        tl.store(dW + cols, tl.load(dWAcc + cols, mask=mask), mask=mask)
+    if COMPUTE_DB:
+        tl.store(dB + cols, tl.load(dBAcc + cols, mask=mask), mask=mask)
+
+
+@libentry()
+@triton.jit
+def layer_norm_backward_resident_kernel(
+    dY,
+    X,
+    W,
+    Mean,
+    Rstd,
+    dX,
+    dW,
+    dB,
+    M,
+    N: tl.constexpr,
+    BLOCK_ROW_SIZE: tl.constexpr,
+    BLOCK_COL_SIZE: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    program_count = ext.num_programs(0)
+    cols = tl.arange(0, BLOCK_COL_SIZE)
+    col_mask = cols < N
+    if HAS_WEIGHT:
+        weight = tl.load(W + cols, mask=col_mask, other=0.0).to(tl.float32)
+    else:
+        weight = 1.0
+    if COMPUTE_DW:
+        partial_dw = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+    if COMPUTE_DB:
+        partial_db = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+
+    # Reuse the dX input scan and reduce one affine partial per program.
+    for row_start in range(pid * BLOCK_ROW_SIZE, M, program_count * BLOCK_ROW_SIZE):
+        rows = row_start + tl.arange(0, BLOCK_ROW_SIZE)
+        row_mask = rows < M
+        mask = row_mask[:, None] & col_mask[None, :]
+        offsets = rows[:, None] * N + cols[None, :]
+
+        dy = tl.load(dY + offsets, mask=mask, other=0.0).to(tl.float32)
+        x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+        mean = tl.load(Mean + rows, mask=row_mask, other=0.0)[:, None].to(tl.float32)
+        rstd = tl.load(Rstd + rows, mask=row_mask, other=0.0)[:, None].to(tl.float32)
+
+        x_hat = (x - mean) * rstd
+        dx_hat = dy * weight
+        sum_dx_hat = tl.sum(tl.where(mask, dx_hat, 0.0), axis=1)[:, None]
+        sum_dx_hat_x = tl.sum(tl.where(mask, dx_hat * x_hat, 0.0), axis=1)[:, None]
+        dx = rstd * (dx_hat - (sum_dx_hat + x_hat * sum_dx_hat_x) / N)
+        tl.store(dX + offsets, dx, mask=mask)
+
+        if COMPUTE_DW:
+            partial_dw += tl.sum(tl.where(mask, dy * x_hat, 0.0), axis=0)
+        if COMPUTE_DB:
+            partial_db += tl.sum(tl.where(mask, dy, 0.0), axis=0)
+
+    if COMPUTE_DW:
+        tl.atomic_add(dW + cols, partial_dw, mask=col_mask)
+    if COMPUTE_DB:
+        tl.atomic_add(dB + cols, partial_db, mask=col_mask)
+
+
+def _launch_layer_norm_backward_resident(
+    grad_out,
+    input,
+    mean,
+    rstd,
+    weight,
+    bias,
+    M,
+    N,
+    block_row_size,
+    block_col_size,
+    program_count,
+    compute_dw,
+    compute_db,
+    use_fp32_scratch,
+):
+    in_grad = torch.empty_like(input)
+    weight_grad = torch.empty_like(weight) if compute_dw else None
+    bias_grad = torch.empty_like(bias) if compute_db else None
+
+    # Atomic affine updates require zero-initialized accumulation buffers.
+    affine_scratch = (
+        torch.empty((2, N), dtype=torch.float32, device=input.device)
+        if use_fp32_scratch
+        else None
+    )
+    weight_acc = affine_scratch[0] if use_fp32_scratch and compute_dw else weight_grad
+    bias_acc = affine_scratch[1] if use_fp32_scratch and compute_db else bias_grad
+
+    with torch_device_fn.device(input.device):
+        affine_block_size = 256
+        if compute_dw or compute_db:
+            layer_norm_backward_zero_affine_kernel[
+                (triton.cdiv(N, affine_block_size), 1, 1)
+            ](
+                weight_acc,
+                bias_acc,
+                N,
+                BLOCK_SIZE=affine_block_size,
+                COMPUTE_DW=compute_dw,
+                COMPUTE_DB=compute_db,
+            )
+        layer_norm_backward_resident_kernel[(program_count, 1, 1)](
+            grad_out,
+            input,
+            weight,
+            mean,
+            rstd,
+            in_grad,
+            weight_acc,
+            bias_acc,
+            M,
+            N=N,
+            BLOCK_ROW_SIZE=block_row_size,
+            BLOCK_COL_SIZE=block_col_size,
+            HAS_WEIGHT=weight is not None,
+            COMPUTE_DW=compute_dw,
+            COMPUTE_DB=compute_db,
+        )
+        if use_fp32_scratch:
+            layer_norm_backward_cast_affine_kernel[
+                (triton.cdiv(N, affine_block_size), 1, 1)
+            ](
+                weight_acc,
+                bias_acc,
+                weight_grad,
+                bias_grad,
+                N,
+                BLOCK_SIZE=affine_block_size,
+                COMPUTE_DW=compute_dw,
+                COMPUTE_DB=compute_db,
+            )
+    return in_grad, weight_grad, bias_grad
+
+
+def _launch_fused_layer_norm_backward(
+    grad_out,
+    input,
+    mean,
+    rstd,
+    weight,
+    bias,
+    output_mask,
+    M,
+    N,
+):
+    config = _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias)
+    if config is None:
+        return None
+
+    return _launch_layer_norm_backward_resident(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight,
+        bias,
+        M,
+        N,
+        *config,
+    )
+
+
+@libentry()
 @triton.autotune(
     configs=runtime.get_tuned_config("weight_bias_backward"),
     key=["N"],
@@ -421,15 +707,33 @@ def layer_norm_backward(
 ):
     logger.debug("GEMS LAYERNORM BACKWARD")
 
-    grad_out = grad_out.contiguous()
-    input = input.contiguous()
-    mean = mean.contiguous()
-    rstd = rstd.contiguous()
-    weight = None if weight is None else weight.contiguous()
-    bias = None if bias is None else bias.contiguous()
+    grad_out = grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+    input = input if input.is_contiguous() else input.contiguous()
+    mean = mean if mean.is_contiguous() else mean.contiguous()
+    rstd = rstd if rstd.is_contiguous() else rstd.contiguous()
+    if weight is not None and not weight.is_contiguous():
+        weight = weight.contiguous()
+    if bias is not None and not bias.is_contiguous():
+        bias = bias.contiguous()
 
-    M = input.shape[0]
-    N = input.numel() // M
+    # LayerNorm flattens all leading dimensions into M and normalizes over N.
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    # Unsupported shapes or backends without heuristics keep the upstream path.
+    fused_grads = _launch_fused_layer_norm_backward(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight,
+        bias,
+        output_mask,
+        M,
+        N,
+    )
+    if fused_grads is not None:
+        return fused_grads
 
     if output_mask[0]:
         in_grad = torch.empty_like(input)
@@ -444,10 +748,10 @@ def layer_norm_backward(
     if output_mask[1] is False and output_mask[2] is False:
         return in_grad, None, None
 
-    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
     weight_grad = torch.empty_like(weight) if output_mask[1] else None
     bias_grad = torch.empty_like(bias) if output_mask[2] else None
     with torch_device_fn.device(input.device):
+        grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
         weight_bias_backward_kernel[grid](
             grad_out, input, mean, rstd, weight_grad, bias_grad, M, N
         )

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import math
 
@@ -31,6 +32,88 @@ logger = logging.getLogger(__name__)
 def prev_multiple_of(a, b):
     # the largest x<a that x%b ==0
     return tl.cdiv(a, b) * b - b
+
+
+@functools.lru_cache(maxsize=None)
+def _layer_norm_parallel_units(device_index):
+    props = torch_device_fn.get_device_properties(device_index)
+    # Device runtimes expose the compute-unit count under different names.
+    property_names = (
+        "multi_processor_count",
+        "multiProcessorCount",
+        "vector_core_num",
+        "num_vectorcore",
+        "cube_core_num",
+        "num_aicore",
+    )
+    for name in property_names:
+        value = (
+            props.get(name) if isinstance(props, dict) else getattr(props, name, None)
+        )
+        if value:
+            return int(value)
+    return None
+
+
+def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
+    if output_mask is None or M <= 0 or N <= 0:
+        return None
+
+    compute_dx, compute_dw, compute_db = map(bool, output_mask)
+    if (
+        input.dtype not in (torch.float32, torch.float16, torch.bfloat16)
+        or not compute_dx
+        or not (compute_dw or compute_db)
+        or (compute_dw and weight is None)
+        or (compute_db and bias is None)
+    ):
+        return None
+
+    tile_n = triton.next_power_of_2(N)
+    args = {
+        "M": M,
+        "N": N,
+        "TILE_N": tile_n,
+        "IS_LOW_PRECISION": input.dtype != torch.float32,
+    }
+    # Backends opt in to the resident path by providing this heuristic group.
+    fused_heuristics = runtime.get_heuristic_config("layer_norm_backward_fused")
+    if fused_heuristics is None:
+        return None
+
+    max_resident_n = fused_heuristics["MAX_RESIDENT_N"](args)
+    enough_work = M * N >= fused_heuristics["MIN_ELEMENTS"](args)
+    if tile_n > max_resident_n or not enough_work:
+        return None
+
+    parallel_units = _layer_norm_parallel_units(torch_device_fn.current_device())
+    if parallel_units is None:
+        return None
+
+    direct_lowp_atomic_fn = fused_heuristics.get("DIRECT_LOWP_ATOMIC")
+    direct_lowp_atomic = (
+        direct_lowp_atomic_fn(args) if direct_lowp_atomic_fn is not None else False
+    )
+    # Accumulate through FP32 scratch when low-precision atomics are unavailable.
+    use_fp32_scratch = input.dtype != torch.float32 and not direct_lowp_atomic
+
+    # Large M is handled by the kernel's grid-stride row loop.
+    tile_elements = fused_heuristics["TILE_ELEMENTS"](args)
+    program_waves = fused_heuristics["PROGRAM_WAVES"](args)
+    block_m = max(1, tile_elements // tile_n)
+    max_block_m_fn = fused_heuristics.get("MAX_BLOCK_M")
+    if max_block_m_fn is not None:
+        block_m = min(block_m, max_block_m_fn(args))
+    row_tiles = triton.cdiv(M, block_m)
+    program_count = min(row_tiles, parallel_units * program_waves)
+    return (
+        block_m,
+        tile_n,
+        program_count,
+        compute_dw,
+        compute_db,
+        use_fp32_scratch,
+    )
 
 
 @libentry()
@@ -302,6 +385,210 @@ def layer_norm_backward_kernel(
 
 
 @libentry()
+@triton.jit
+def layer_norm_backward_zero_affine_kernel(
+    dW,
+    dB,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    cols = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+    if COMPUTE_DW:
+        tl.store(dW + cols, 0.0, mask=mask)
+    if COMPUTE_DB:
+        tl.store(dB + cols, 0.0, mask=mask)
+
+
+@libentry()
+@triton.jit
+def layer_norm_backward_cast_affine_kernel(
+    dWAcc,
+    dBAcc,
+    dW,
+    dB,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    cols = ext.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+    if COMPUTE_DW:
+        tl.store(dW + cols, tl.load(dWAcc + cols, mask=mask), mask=mask)
+    if COMPUTE_DB:
+        tl.store(dB + cols, tl.load(dBAcc + cols, mask=mask), mask=mask)
+
+
+@libentry()
+@triton.jit
+def layer_norm_backward_resident_kernel(
+    dY,
+    X,
+    W,
+    Mean,
+    Rstd,
+    dX,
+    dW,
+    dB,
+    M,
+    N: tl.constexpr,
+    BLOCK_ROW_SIZE: tl.constexpr,
+    BLOCK_COL_SIZE: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    COMPUTE_DW: tl.constexpr,
+    COMPUTE_DB: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    program_count = ext.num_programs(0)
+    cols = tl.arange(0, BLOCK_COL_SIZE)
+    col_mask = cols < N
+    if HAS_WEIGHT:
+        weight = tl.load(W + cols, mask=col_mask, other=0.0).to(tl.float32)
+    else:
+        weight = 1.0
+    if COMPUTE_DW:
+        partial_dw = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+    if COMPUTE_DB:
+        partial_db = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+
+    # Reuse the dX input scan and reduce one affine partial per program.
+    for row_start in range(pid * BLOCK_ROW_SIZE, M, program_count * BLOCK_ROW_SIZE):
+        rows = row_start + tl.arange(0, BLOCK_ROW_SIZE)
+        row_mask = rows < M
+        mask = row_mask[:, None] & col_mask[None, :]
+        offsets = rows[:, None] * N + cols[None, :]
+
+        dy = tl.load(dY + offsets, mask=mask, other=0.0).to(tl.float32)
+        x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+        mean = tl.load(Mean + rows, mask=row_mask, other=0.0)[:, None].to(tl.float32)
+        rstd = tl.load(Rstd + rows, mask=row_mask, other=0.0)[:, None].to(tl.float32)
+
+        x_hat = (x - mean) * rstd
+        dx_hat = dy * weight
+        sum_dx_hat = tl.sum(tl.where(mask, dx_hat, 0.0), axis=1)[:, None]
+        sum_dx_hat_x = tl.sum(tl.where(mask, dx_hat * x_hat, 0.0), axis=1)[:, None]
+        dx = rstd * (dx_hat - (sum_dx_hat + x_hat * sum_dx_hat_x) / N)
+        tl.store(dX + offsets, dx, mask=mask)
+
+        if COMPUTE_DW:
+            partial_dw += tl.sum(tl.where(mask, dy * x_hat, 0.0), axis=0)
+        if COMPUTE_DB:
+            # Keep tail columns explicit across backend reduction lowerings.
+            partial_db += tl.sum(tl.where(col_mask[None, :], dy, 0.0), axis=0)
+
+    if COMPUTE_DW:
+        tl.atomic_add(dW + cols, partial_dw, mask=col_mask)
+    if COMPUTE_DB:
+        tl.atomic_add(dB + cols, partial_db, mask=col_mask)
+
+
+def _launch_layer_norm_backward_resident(
+    grad_out,
+    input,
+    mean,
+    rstd,
+    weight,
+    bias,
+    M,
+    N,
+    block_row_size,
+    block_col_size,
+    program_count,
+    compute_dw,
+    compute_db,
+    use_fp32_scratch,
+):
+    in_grad = torch.empty_like(input)
+    weight_grad = torch.empty_like(weight) if compute_dw else None
+    bias_grad = torch.empty_like(bias) if compute_db else None
+
+    # Atomic affine updates require zero-initialized accumulation buffers.
+    affine_scratch = (
+        torch.empty((2, N), dtype=torch.float32, device=input.device)
+        if use_fp32_scratch
+        else None
+    )
+    weight_acc = affine_scratch[0] if use_fp32_scratch and compute_dw else weight_grad
+    bias_acc = affine_scratch[1] if use_fp32_scratch and compute_db else bias_grad
+
+    with torch_device_fn.device(input.device):
+        affine_block_size = 256
+        if compute_dw or compute_db:
+            layer_norm_backward_zero_affine_kernel[
+                (triton.cdiv(N, affine_block_size), 1, 1)
+            ](
+                weight_acc,
+                bias_acc,
+                N,
+                BLOCK_SIZE=affine_block_size,
+                COMPUTE_DW=compute_dw,
+                COMPUTE_DB=compute_db,
+            )
+        layer_norm_backward_resident_kernel[(program_count, 1, 1)](
+            grad_out,
+            input,
+            weight,
+            mean,
+            rstd,
+            in_grad,
+            weight_acc,
+            bias_acc,
+            M,
+            N=N,
+            BLOCK_ROW_SIZE=block_row_size,
+            BLOCK_COL_SIZE=block_col_size,
+            HAS_WEIGHT=weight is not None,
+            COMPUTE_DW=compute_dw,
+            COMPUTE_DB=compute_db,
+        )
+        if use_fp32_scratch:
+            layer_norm_backward_cast_affine_kernel[
+                (triton.cdiv(N, affine_block_size), 1, 1)
+            ](
+                weight_acc,
+                bias_acc,
+                weight_grad,
+                bias_grad,
+                N,
+                BLOCK_SIZE=affine_block_size,
+                COMPUTE_DW=compute_dw,
+                COMPUTE_DB=compute_db,
+            )
+    return in_grad, weight_grad, bias_grad
+
+
+def _launch_fused_layer_norm_backward(
+    grad_out,
+    input,
+    mean,
+    rstd,
+    weight,
+    bias,
+    output_mask,
+    M,
+    N,
+):
+    config = _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias)
+    if config is None:
+        return None
+
+    return _launch_layer_norm_backward_resident(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight,
+        bias,
+        M,
+        N,
+        *config,
+    )
+
+
+@libentry()
 @triton.autotune(
     configs=runtime.get_tuned_config("weight_bias_backward"),
     key=["N"],
@@ -421,15 +708,33 @@ def layer_norm_backward(
 ):
     logger.debug("GEMS LAYERNORM BACKWARD")
 
-    grad_out = grad_out.contiguous()
-    input = input.contiguous()
-    mean = mean.contiguous()
-    rstd = rstd.contiguous()
-    weight = None if weight is None else weight.contiguous()
-    bias = None if bias is None else bias.contiguous()
+    grad_out = grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+    input = input if input.is_contiguous() else input.contiguous()
+    mean = mean if mean.is_contiguous() else mean.contiguous()
+    rstd = rstd if rstd.is_contiguous() else rstd.contiguous()
+    if weight is not None and not weight.is_contiguous():
+        weight = weight.contiguous()
+    if bias is not None and not bias.is_contiguous():
+        bias = bias.contiguous()
 
-    M = input.shape[0]
-    N = input.numel() // M
+    # LayerNorm flattens all leading dimensions into M and normalizes over N.
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    # Unsupported shapes or backends without heuristics keep the upstream path.
+    fused_grads = _launch_fused_layer_norm_backward(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight,
+        bias,
+        output_mask,
+        M,
+        N,
+    )
+    if fused_grads is not None:
+        return fused_grads
 
     if output_mask[0]:
         in_grad = torch.empty_like(input)
@@ -444,10 +749,10 @@ def layer_norm_backward(
     if output_mask[1] is False and output_mask[2] is False:
         return in_grad, None, None
 
-    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
     weight_grad = torch.empty_like(weight) if output_mask[1] else None
     bias_grad = torch.empty_like(bias) if output_mask[2] else None
     with torch_device_fn.device(input.device):
+        grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
         weight_bias_backward_kernel[grid](
             grad_out, input, mean, rstd, weight_grad, bias_grad, M, N
         )

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -55,6 +55,13 @@ def _layer_norm_parallel_units(device_index):
     return None
 
 
+@functools.lru_cache(maxsize=None)
+def _layer_norm_device_name(device_index):
+    props = torch_device_fn.get_device_properties(device_index)
+    name = props.get("name") if isinstance(props, dict) else getattr(props, "name", "")
+    return str(name)
+
+
 def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
     if output_mask is None or M <= 0 or N <= 0:
         return None
@@ -70,11 +77,13 @@ def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
         return None
 
     tile_n = triton.next_power_of_2(N)
+    device_index = torch_device_fn.current_device()
     args = {
         "M": M,
         "N": N,
         "TILE_N": tile_n,
         "IS_LOW_PRECISION": input.dtype != torch.float32,
+        "DEVICE_NAME": _layer_norm_device_name(device_index),
     }
     # Backends opt in to the resident path by providing this heuristic group.
     fused_heuristics = runtime.get_heuristic_config("layer_norm_backward_fused")
@@ -86,7 +95,7 @@ def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
     if tile_n > max_resident_n or not enough_work:
         return None
 
-    parallel_units = _layer_norm_parallel_units(torch_device_fn.current_device())
+    parallel_units = _layer_norm_parallel_units(device_index)
     if parallel_units is None:
         return None
 

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -55,13 +55,6 @@ def _layer_norm_parallel_units(device_index):
     return None
 
 
-@functools.lru_cache(maxsize=None)
-def _layer_norm_device_name(device_index):
-    props = torch_device_fn.get_device_properties(device_index)
-    name = props.get("name") if isinstance(props, dict) else getattr(props, "name", "")
-    return str(name)
-
-
 def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
     if output_mask is None or M <= 0 or N <= 0:
         return None
@@ -77,13 +70,11 @@ def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
         return None
 
     tile_n = triton.next_power_of_2(N)
-    device_index = torch_device_fn.current_device()
     args = {
         "M": M,
         "N": N,
         "TILE_N": tile_n,
         "IS_LOW_PRECISION": input.dtype != torch.float32,
-        "DEVICE_NAME": _layer_norm_device_name(device_index),
     }
     # Backends opt in to the resident path by providing this heuristic group.
     fused_heuristics = runtime.get_heuristic_config("layer_norm_backward_fused")
@@ -95,7 +86,7 @@ def _fused_layer_norm_backward_config(input, output_mask, M, N, weight, bias):
     if tile_n > max_resident_n or not enough_work:
         return None
 
-    parallel_units = _layer_norm_parallel_units(device_index)
+    parallel_units = _layer_norm_parallel_units(torch_device_fn.current_device())
     if parallel_units is None:
         return None
 

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -185,6 +185,30 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
+def layer_norm_heur_fused_min_elements(_args):
+    return 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(_args):
+    return 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(_args):
+    return 1
+
+
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -303,6 +327,14 @@ HEURISTICS_CONFIGS = {
     "softmax_backward_inner": {
         "TILE_M": softmax_heur_tile_m,
         "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "uniform": {
         "BLOCK": uniform_heur_block,

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -194,7 +194,8 @@ def layer_norm_heur_fused_max_resident_n(_args):
 
 
 def layer_norm_heur_fused_tile_elements(_args):
-    return 4096
+    # Bound BLOCK_M * TILE_N to a stable two-dimensional reduction tile.
+    return 2048
 
 
 def layer_norm_heur_fused_max_block_m(_args):

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -189,10 +189,7 @@ def layer_norm_heur_fused_min_elements(_args):
     return 1024 * 1024
 
 
-def layer_norm_heur_fused_max_resident_n(args):
-    # CANN 8.5 on 910B miscompiles the resident two-dimensional reduction.
-    if "910B" in args["DEVICE_NAME"]:
-        return 0
+def layer_norm_heur_fused_max_resident_n(_args):
     return 512
 
 

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -189,7 +189,10 @@ def layer_norm_heur_fused_min_elements(_args):
     return 1024 * 1024
 
 
-def layer_norm_heur_fused_max_resident_n(_args):
+def layer_norm_heur_fused_max_resident_n(args):
+    # CANN 8.5 on 910B miscompiles the resident two-dimensional reduction.
+    if "910B" in args["DEVICE_NAME"]:
+        return 0
     return 512
 
 

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -185,31 +185,6 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
-def layer_norm_heur_fused_min_elements(_args):
-    return 1024 * 1024
-
-
-def layer_norm_heur_fused_max_resident_n(_args):
-    return 512
-
-
-def layer_norm_heur_fused_tile_elements(_args):
-    # Bound BLOCK_M * TILE_N to a stable two-dimensional reduction tile.
-    return 2048
-
-
-def layer_norm_heur_fused_max_block_m(_args):
-    return 256
-
-
-def layer_norm_heur_fused_direct_lowp_atomic(_args):
-    return False
-
-
-def layer_norm_heur_fused_program_waves(_args):
-    return 1
-
-
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -330,12 +305,13 @@ HEURISTICS_CONFIGS = {
         "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
     },
     "layer_norm_backward_fused": {
-        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
-        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
-        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
-        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
-        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
-        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
+        "MIN_ELEMENTS": lambda _args: 1024 * 1024,
+        "MAX_RESIDENT_N": lambda _args: 512,
+        # Bound BLOCK_M * TILE_N to a stable two-dimensional reduction tile.
+        "TILE_ELEMENTS": lambda _args: 2048,
+        "MAX_BLOCK_M": lambda _args: 256,
+        "PROGRAM_WAVES": lambda _args: 1,
+        "DIRECT_LOWP_ATOMIC": lambda _args: False,
     },
     "uniform": {
         "BLOCK": uniform_heur_block,

--- a/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
@@ -317,9 +317,24 @@ layer_norm_backward:
   param_map:
     META:
       BLOCK_ROW_SIZE: block_r
-      BLOCK_COL_SIZE: 128
+      BLOCK_COL_SIZE: block_c
   block_r:
   - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  block_c:
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
 
 weight_bias_backward:
 - gen: true

--- a/src/flag_gems/runtime/backend/_hygon/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_hygon/heuristics_config_utils.py
@@ -195,6 +195,30 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
+def layer_norm_heur_fused_min_elements(args):
+    return 16 * 1024 * 1024 if args["IS_LOW_PRECISION"] else 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(args):
+    return 512 if args["IS_LOW_PRECISION"] else 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(args):
+    return 8 if args["IS_LOW_PRECISION"] else 1
+
+
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -303,6 +327,14 @@ HEURISTICS_CONFIGS = {
     "softmax_backward_inner": {
         "TILE_M": softmax_heur_tile_m,
         "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "uniform": {
         "BLOCK": uniform_heur_block,

--- a/src/flag_gems/runtime/backend/_hygon/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_hygon/heuristics_config_utils.py
@@ -195,30 +195,6 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
-def layer_norm_heur_fused_min_elements(args):
-    return 16 * 1024 * 1024 if args["IS_LOW_PRECISION"] else 1024 * 1024
-
-
-def layer_norm_heur_fused_max_resident_n(_args):
-    return 512
-
-
-def layer_norm_heur_fused_tile_elements(args):
-    return 512 if args["IS_LOW_PRECISION"] else 4096
-
-
-def layer_norm_heur_fused_max_block_m(_args):
-    return 256
-
-
-def layer_norm_heur_fused_direct_lowp_atomic(_args):
-    return False
-
-
-def layer_norm_heur_fused_program_waves(args):
-    return 8 if args["IS_LOW_PRECISION"] else 1
-
-
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -329,12 +305,14 @@ HEURISTICS_CONFIGS = {
         "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
     },
     "layer_norm_backward_fused": {
-        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
-        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
-        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
-        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
-        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
-        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
+        "MIN_ELEMENTS": lambda args: (
+            16 * 1024 * 1024 if args["IS_LOW_PRECISION"] else 1024 * 1024
+        ),
+        "MAX_RESIDENT_N": lambda _args: 512,
+        "TILE_ELEMENTS": lambda args: (512 if args["IS_LOW_PRECISION"] else 4096),
+        "MAX_BLOCK_M": lambda _args: 256,
+        "PROGRAM_WAVES": lambda args: 8 if args["IS_LOW_PRECISION"] else 1,
+        "DIRECT_LOWP_ATOMIC": lambda _args: False,
     },
     "uniform": {
         "BLOCK": uniform_heur_block,

--- a/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
@@ -754,7 +754,7 @@ layer_norm_backward:
   param_map:
     META:
       BLOCK_ROW_SIZE: block_r
-      BLOCK_COL_SIZE: 2048
+      BLOCK_COL_SIZE: block_c
     num_warps: warps
   warps:
   - 4
@@ -765,6 +765,15 @@ layer_norm_backward:
   - 2
   - 4
   - 8
+  block_c:
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
 weight_bias_backward:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -225,6 +225,30 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
+def layer_norm_heur_fused_min_elements(_args):
+    return 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(args):
+    return 512 if args["IS_LOW_PRECISION"] else 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(args):
+    return 8 if args["IS_LOW_PRECISION"] else 1
+
+
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -334,6 +358,14 @@ HEURISTICS_CONFIGS = {
     "index_select": {
         "BLOCK_M": index_select_heur_block_m,
         "BLOCK_N": index_select_heur_block_n,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "mm": {
         "EVEN_K": mm_heur_even_k,

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -326,6 +326,30 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
+def layer_norm_heur_fused_min_elements(_args):
+    return 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(args):
+    return 512 if args["IS_LOW_PRECISION"] else 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(args):
+    return 8 if args["IS_LOW_PRECISION"] else 1
+
+
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -443,6 +467,14 @@ HEURISTICS_CONFIGS = {
     "index_select": {
         "BLOCK_M": index_select_heur_block_m,
         "BLOCK_N": index_select_heur_block_n,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "mm": {
         "EVEN_K": mm_heur_even_k,

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -326,30 +326,6 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
-def layer_norm_heur_fused_min_elements(_args):
-    return 1024 * 1024
-
-
-def layer_norm_heur_fused_max_resident_n(_args):
-    return 512
-
-
-def layer_norm_heur_fused_tile_elements(args):
-    return 512 if args["IS_LOW_PRECISION"] else 4096
-
-
-def layer_norm_heur_fused_max_block_m(_args):
-    return 256
-
-
-def layer_norm_heur_fused_direct_lowp_atomic(_args):
-    return False
-
-
-def layer_norm_heur_fused_program_waves(args):
-    return 8 if args["IS_LOW_PRECISION"] else 1
-
-
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -469,12 +445,12 @@ HEURISTICS_CONFIGS = {
         "BLOCK_N": index_select_heur_block_n,
     },
     "layer_norm_backward_fused": {
-        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
-        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
-        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
-        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
-        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
-        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
+        "MIN_ELEMENTS": lambda _args: 1024 * 1024,
+        "MAX_RESIDENT_N": lambda _args: 512,
+        "TILE_ELEMENTS": lambda args: (512 if args["IS_LOW_PRECISION"] else 4096),
+        "MAX_BLOCK_M": lambda _args: 256,
+        "PROGRAM_WAVES": lambda args: 8 if args["IS_LOW_PRECISION"] else 1,
+        "DIRECT_LOWP_ATOMIC": lambda _args: False,
     },
     "mm": {
         "EVEN_K": mm_heur_even_k,

--- a/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
@@ -20,6 +20,7 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
+from flag_gems.ops.layernorm import _launch_fused_layer_norm_backward
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as ext
@@ -425,8 +426,22 @@ def layer_norm_backward(
     weight = None if weight is None else weight.contiguous()
     bias = None if bias is None else bias.contiguous()
 
-    M = input.shape[0]
-    N = input.numel() // M
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    fused_grads = _launch_fused_layer_norm_backward(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight,
+        bias,
+        output_mask,
+        M,
+        N,
+    )
+    if fused_grads is not None:
+        return fused_grads
 
     if output_mask[0]:
         in_grad = torch.empty_like(input)
@@ -441,9 +456,9 @@ def layer_norm_backward(
     if output_mask[1] is False and output_mask[2] is False:
         return in_grad, None, None
 
-    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
     weight_grad = torch.empty_like(weight) if output_mask[1] else None
     bias_grad = torch.empty_like(bias) if output_mask[2] else None
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
     with torch_device_fn.device(input.device):
         weight_bias_backward_kernel[grid](
             grad_out, input, mean, rstd, weight_grad, bias_grad, M, N

--- a/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
@@ -359,24 +359,8 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     rstd = torch.empty(M, dtype=input.dtype, device=input.device)
 
     with torch_device_fn.device(input.device):
-        if N <= 128:
-            TILE_N = triton.next_power_of_2(N)
-            TILE_M = triton.cdiv(1024, TILE_N)
-            grid = (triton.cdiv(M, TILE_M), 1, 1)
-            layer_norm_persistent_kernel_multiline[grid](
-                input,
-                y,
-                weight,
-                bias,
-                mean,
-                rstd,
-                M,
-                N,
-                eps,
-                TILE_M,
-                TILE_N,
-            )
-        elif N <= 4096:
+        # MetaX lowers the resident one-row layout reliably across this range.
+        if N <= 4096:
             TILE_N = triton.next_power_of_2(N)
             grid = (M, 1, 1)
             layer_norm_persistent_kernel[grid](

--- a/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/layernorm.py
@@ -102,27 +102,25 @@ def layer_norm_persistent_kernel_multiline(
     TILE_M: tl.constexpr,
     TILE_N: tl.constexpr,
 ):
-    # Map the program id to the row of X and Y it should compute.
-    pid = ext.program_id(0)
-    m_offsets = pid * TILE_M + tl.arange(0, TILE_M)
-    m_mask = m_offsets < M
+    # Keep the original multiline launch grouping while each program uses the
+    # one-dimensional layout supported by the MetaX lowering pipeline.
+    pid = ext.program_id(0) * TILE_M + ext.program_id(1)
+    m_mask = pid < M
 
-    n_offsets = tl.arange(0, TILE_N)[None, :]
+    n_offsets = tl.arange(0, TILE_N)
     n_mask = n_offsets < N
-    mask = m_mask[:, None] & n_mask
+    mask = m_mask & n_mask
 
-    x = tl.load(in_ptr + m_offsets[:, None] * N + n_offsets, mask, other=0.0).to(
-        tl.float32
-    )
-    m = tl.sum(x, axis=1) / N
-    d = x - m[:, None]  # deviation
+    x = tl.load(in_ptr + pid * N + n_offsets, mask, other=0.0).to(tl.float32)
+    m = tl.sum(x) / N
+    d = x - m  # deviation
     s = tl.where(mask, d * d, 0)
-    sum_square = tl.sum(s, axis=1)  # sum of square of deviation
+    sum_square = tl.sum(s)  # sum of square of deviation
     var = sum_square / N
     rstd = tl.math.rsqrt(var + eps)
 
-    tl.store(out_mean_ptr + m_offsets, m, mask=m_mask)
-    tl.store(out_rstd_ptr + m_offsets, rstd, mask=m_mask)
+    tl.store(out_mean_ptr + pid, m, mask=m_mask)
+    tl.store(out_rstd_ptr + pid, rstd, mask=m_mask)
 
     if weight_ptr is None:
         w = 1
@@ -132,9 +130,9 @@ def layer_norm_persistent_kernel_multiline(
         b = 0
     else:
         b = tl.load(bias_ptr + n_offsets, mask=n_mask)
-    out = (x - m[:, None]) * rstd[:, None] * w + b
+    out = (x - m) * rstd * w + b
 
-    tl.store(out_ptr + m_offsets[:, None] * N + n_offsets, out, mask=mask)
+    tl.store(out_ptr + pid * N + n_offsets, out, mask=mask)
 
 
 @libentry()
@@ -359,8 +357,24 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     rstd = torch.empty(M, dtype=input.dtype, device=input.device)
 
     with torch_device_fn.device(input.device):
-        # MetaX lowers the resident one-row layout reliably across this range.
-        if N <= 4096:
+        if N <= 128:
+            TILE_N = triton.next_power_of_2(N)
+            TILE_M = triton.cdiv(1024, TILE_N)
+            grid = (triton.cdiv(M, TILE_M), TILE_M, 1)
+            layer_norm_persistent_kernel_multiline[grid](
+                input,
+                y,
+                weight,
+                bias,
+                mean,
+                rstd,
+                M,
+                N,
+                eps,
+                TILE_M,
+                TILE_N,
+            )
+        elif N <= 4096:
             TILE_N = triton.next_power_of_2(N)
             grid = (M, 1, 1)
             layer_norm_persistent_kernel[grid](

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -717,7 +717,7 @@ layer_norm_backward:
   param_map:
     META:
       BLOCK_ROW_SIZE: block_r
-      BLOCK_COL_SIZE: 2048
+      BLOCK_COL_SIZE: block_c
     num_warps: warps
   warps:
   - 4
@@ -728,6 +728,15 @@ layer_norm_backward:
   - 2
   - 4
   - 8
+  block_c:
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
 weight_bias_backward:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -806,7 +806,7 @@ layer_norm_backward:
   param_map:
     META:
       BLOCK_ROW_SIZE: block_r
-      BLOCK_COL_SIZE: 2048
+      BLOCK_COL_SIZE: block_c
     num_warps: warps
   warps:
   - 4
@@ -817,6 +817,15 @@ layer_norm_backward:
   - 2
   - 4
   - 8
+  block_c:
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
+  - 2048
 weight_bias_backward:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_mthreads/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_mthreads/heuristics_config_utils.py
@@ -297,6 +297,40 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
+def layer_norm_heur_resident_dx_min_rows(_args):
+    return 32768
+
+
+def layer_norm_heur_resident_dx_max_n(_args):
+    return 512
+
+
+def layer_norm_heur_resident_dx_tile_elements(_args):
+    return 512
+
+
+def layer_norm_heur_resident_dx_program_waves(_args):
+    return 8
+
+
+def layer_norm_heur_resident_dx_full_row_grid(args):
+    return args["TILE_N"] >= 256
+
+
+def layer_norm_heur_affine_rows_per_program(_args):
+    return 256
+
+
+def layer_norm_heur_affine_block_col_size(args):
+    if args["N"] <= 16 or (args["IS_LOW_PRECISION"] and args["N"] <= 32):
+        return 16
+    return 32
+
+
+def layer_norm_heur_affine_min_row_groups(_args):
+    return 64
+
+
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -452,6 +486,18 @@ HEURISTICS_CONFIGS = {
     "index_add": {
         "BLOCK_M": index_add_heur_block_m,
         "BLOCK_N": index_add_heur_block_n,
+    },
+    "layer_norm_backward_resident_dx": {
+        "MIN_ROWS": layer_norm_heur_resident_dx_min_rows,
+        "MAX_RESIDENT_N": layer_norm_heur_resident_dx_max_n,
+        "TILE_ELEMENTS": layer_norm_heur_resident_dx_tile_elements,
+        "PROGRAM_WAVES": layer_norm_heur_resident_dx_program_waves,
+        "FULL_ROW_GRID": layer_norm_heur_resident_dx_full_row_grid,
+    },
+    "layer_norm_weight_bias_backward": {
+        "ROWS_PER_PROGRAM": layer_norm_heur_affine_rows_per_program,
+        "BLOCK_COL_SIZE": layer_norm_heur_affine_block_col_size,
+        "MIN_ROW_GROUPS": layer_norm_heur_affine_min_row_groups,
     },
     "mm": {
         "EVEN_K": mm_heur_even_k,

--- a/src/flag_gems/runtime/backend/_mthreads/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_mthreads/heuristics_config_utils.py
@@ -297,40 +297,6 @@ def softmax_heur_tile_m(args):
     return max(1, 1024 // args["TILE_N"])
 
 
-def layer_norm_heur_resident_dx_min_rows(_args):
-    return 32768
-
-
-def layer_norm_heur_resident_dx_max_n(_args):
-    return 512
-
-
-def layer_norm_heur_resident_dx_tile_elements(_args):
-    return 512
-
-
-def layer_norm_heur_resident_dx_program_waves(_args):
-    return 8
-
-
-def layer_norm_heur_resident_dx_full_row_grid(args):
-    return args["TILE_N"] >= 256
-
-
-def layer_norm_heur_affine_rows_per_program(_args):
-    return 256
-
-
-def layer_norm_heur_affine_block_col_size(args):
-    if args["N"] <= 16 or (args["IS_LOW_PRECISION"] and args["N"] <= 32):
-        return 16
-    return 32
-
-
-def layer_norm_heur_affine_min_row_groups(_args):
-    return 64
-
-
 def uniform_heur_block(args):
     if args["N"] <= 512:
         return 512
@@ -488,16 +454,20 @@ HEURISTICS_CONFIGS = {
         "BLOCK_N": index_add_heur_block_n,
     },
     "layer_norm_backward_resident_dx": {
-        "MIN_ROWS": layer_norm_heur_resident_dx_min_rows,
-        "MAX_RESIDENT_N": layer_norm_heur_resident_dx_max_n,
-        "TILE_ELEMENTS": layer_norm_heur_resident_dx_tile_elements,
-        "PROGRAM_WAVES": layer_norm_heur_resident_dx_program_waves,
-        "FULL_ROW_GRID": layer_norm_heur_resident_dx_full_row_grid,
+        "MIN_ROWS": lambda _args: 32768,
+        "MAX_RESIDENT_N": lambda _args: 512,
+        "TILE_ELEMENTS": lambda _args: 512,
+        "PROGRAM_WAVES": lambda _args: 8,
+        "FULL_ROW_GRID": lambda args: args["TILE_N"] >= 256,
     },
     "layer_norm_weight_bias_backward": {
-        "ROWS_PER_PROGRAM": layer_norm_heur_affine_rows_per_program,
-        "BLOCK_COL_SIZE": layer_norm_heur_affine_block_col_size,
-        "MIN_ROW_GROUPS": layer_norm_heur_affine_min_row_groups,
+        "ROWS_PER_PROGRAM": lambda _args: 256,
+        "BLOCK_COL_SIZE": lambda args: (
+            16
+            if args["N"] <= 16 or (args["IS_LOW_PRECISION"] and args["N"] <= 32)
+            else 32
+        ),
+        "MIN_ROW_GROUPS": lambda _args: 64,
     },
     "mm": {
         "EVEN_K": mm_heur_even_k,

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
+
 from torch_musa import current_device, get_device_capability
 
 from .all import all, all_dim, all_dims
@@ -27,6 +29,7 @@ from .gather import gather, gather_backward
 from .index_add import index_add, index_add_
 from .index_put import _index_put_impl_, index_put, index_put_
 from .index_select import index_select
+from .layernorm import layer_norm_backward
 from .log import log
 from .log10 import log10, log10_, log10_out
 from .log_softmax import (
@@ -58,9 +61,13 @@ from .resolve_conj import resolve_conj
 from .sort import sort, sort_stable
 from .tile import tile
 from .unique import _unique2
-from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
 from .zeros import zero_, zeros
 from .zeros_like import zeros_like
+
+# Older MUSA Triton releases do not provide tensor descriptor support.
+_HAS_TENSOR_DESCRIPTOR = (
+    importlib.util.find_spec("triton.tools.tensor_descriptor") is not None
+)
 
 __all__ = [
     "amax",
@@ -96,6 +103,7 @@ __all__ = [
     "log_softmax_backward",
     "log_softmax_backward_out",
     "log_softmax_out",
+    "layer_norm_backward",
     "max",
     "max_dim",
     "min",
@@ -121,30 +129,37 @@ __all__ = [
     "sort_stable",
     "tile",
     "_unique2",
-    "w8a8_block_fp8_matmul",
     "zero_",
     "zeros",
     "zeros_like",
 ]
 
 
+if _HAS_TENSOR_DESCRIPTOR:
+    from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul  # noqa: F401
+
+    __all__.append("w8a8_block_fp8_matmul")
+
+
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm, addmm_dtype, addmm_dtype_out  # noqa: F401
-    from .baddbmm import baddbmm  # noqa: F401
-    from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
-    from .mm import mm  # noqa: F401
     from .tanh import tanh  # noqa: F401
 
-    __all__.extend(
-        [
-            "addmm",
-            "addmm_dtype",
-            "addmm_dtype_out",
-            "baddbmm",
-            "bmm",
-            "gelu",
-            "mm",
-            "tanh",
-        ]
-    )
+    __all__.extend(["gelu", "tanh"])
+
+    if _HAS_TENSOR_DESCRIPTOR:
+        from .addmm import addmm, addmm_dtype, addmm_dtype_out  # noqa: F401
+        from .baddbmm import baddbmm  # noqa: F401
+        from .bmm import bmm  # noqa: F401
+        from .mm import mm  # noqa: F401
+
+        __all__.extend(
+            [
+                "addmm",
+                "addmm_dtype",
+                "addmm_dtype_out",
+                "baddbmm",
+                "bmm",
+                "mm",
+            ]
+        )

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
+
 from torch_musa import current_device, get_device_capability
 
 from .all import all, all_dim, all_dims
@@ -44,6 +46,7 @@ from .index_add import index_add, index_add_
 from .index_copy_ import index_copy, index_copy_
 from .index_put import _index_put_impl_, index_put, index_put_
 from .index_select import index_select
+from .layernorm import layer_norm_backward
 from .linalg_cholesky import linalg_cholesky
 from .log import log
 from .log10 import log10, log10_, log10_out
@@ -90,9 +93,13 @@ from .special_gammainc import special_gammainc
 from .tile import tile
 from .trunc import trunc, trunc_
 from .unique import _unique2
-from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
 from .zeros import zero_, zeros
 from .zeros_like import zeros_like
+
+# Older MUSA Triton releases do not provide tensor descriptor support.
+_HAS_TENSOR_DESCRIPTOR = (
+    importlib.util.find_spec("triton.tools.tensor_descriptor") is not None
+)
 
 __all__ = [
     "amax",
@@ -141,6 +148,7 @@ __all__ = [
     "log_softmax_backward",
     "log_softmax_backward_out",
     "log_softmax_out",
+    "layer_norm_backward",
     "max",
     "max_dim",
     "median",
@@ -194,32 +202,39 @@ __all__ = [
     "_unique2",
     "trunc",
     "trunc_",
-    "w8a8_block_fp8_matmul",
     "zero_",
     "zeros",
     "zeros_like",
 ]
 
 
+if _HAS_TENSOR_DESCRIPTOR:
+    from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul  # noqa: F401
+
+    __all__.append("w8a8_block_fp8_matmul")
+
+
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
-    from .baddbmm import baddbmm, baddbmm_out  # noqa: F401
-    from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
-    from .mm import mm  # noqa: F401
     from .tanh import tanh  # noqa: F401
 
-    __all__.extend(
-        [
-            "addmm",
-            "addmm_dtype",
-            "addmm_dtype_out",
-            "addmm_out",
-            "baddbmm",
-            "baddbmm_out",
-            "bmm",
-            "gelu",
-            "mm",
-            "tanh",
-        ]
-    )
+    __all__.extend(["gelu", "tanh"])
+
+    if _HAS_TENSOR_DESCRIPTOR:
+        from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
+        from .baddbmm import baddbmm, baddbmm_out  # noqa: F401
+        from .bmm import bmm  # noqa: F401
+        from .mm import mm  # noqa: F401
+
+        __all__.extend(
+            [
+                "addmm",
+                "addmm_dtype",
+                "addmm_dtype_out",
+                "addmm_out",
+                "baddbmm",
+                "baddbmm_out",
+                "bmm",
+                "mm",
+            ]
+        )

--- a/src/flag_gems/runtime/backend/_mthreads/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/layernorm.py
@@ -1,0 +1,323 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.ops.layernorm import (
+    _launch_layer_norm_backward_resident,
+    _layer_norm_parallel_units,
+    layer_norm_backward_kernel,
+    weight_bias_backward_kernel,
+)
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+
+def _layer_norm_backward_resident_dx_config(input, output_mask, M, N):
+    if output_mask is None or M <= 0 or N <= 0:
+        return None
+
+    compute_dx, compute_dw, compute_db = map(bool, output_mask)
+    # This dX launch is paired with the vendor affine reduction below.
+    if not compute_dx or not (compute_dw or compute_db):
+        return None
+    if input.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+        return None
+
+    heuristics = runtime.get_heuristic_config("layer_norm_backward_resident_dx")
+    if heuristics is None:
+        return None
+
+    tile_n = triton.next_power_of_2(N)
+    args = {
+        "M": M,
+        "N": N,
+        "TILE_N": tile_n,
+        "IS_LOW_PRECISION": input.dtype != torch.float32,
+    }
+    if M < heuristics["MIN_ROWS"](args):
+        return None
+    if tile_n > heuristics["MAX_RESIDENT_N"](args):
+        return None
+
+    parallel_units = _layer_norm_parallel_units(torch_device_fn.current_device())
+    if parallel_units is None:
+        return None
+
+    if heuristics["FULL_ROW_GRID"](args):
+        return 1, tile_n, M
+
+    block_m = max(1, heuristics["TILE_ELEMENTS"](args) // tile_n)
+    row_tiles = triton.cdiv(M, block_m)
+    program_count = min(
+        row_tiles,
+        parallel_units * heuristics["PROGRAM_WAVES"](args),
+    )
+    return block_m, tile_n, program_count
+
+
+# Stage 1: reduce one row group and one column tile into FP32 partials.
+@libentry()
+@triton.jit
+def weight_bias_backward_partial_kernel(
+    dY,
+    X,
+    Mean,
+    Rstd,
+    PartialW,
+    PartialB,
+    M,
+    N,
+    ROWS_PER_PROGRAM: tl.constexpr,
+    BLOCK_ROW_SIZE: tl.constexpr,
+    BLOCK_COL_SIZE: tl.constexpr,
+):
+    row_group = ext.program_id(0)
+    col_group = ext.program_id(1)
+    row_start = row_group * ROWS_PER_PROGRAM
+    cols = col_group * BLOCK_COL_SIZE + tl.arange(0, BLOCK_COL_SIZE)
+    col_mask = cols < N
+    acc_w = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+    acc_b = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+
+    for row_offset in range(0, ROWS_PER_PROGRAM, BLOCK_ROW_SIZE):
+        rows = row_start + row_offset + tl.arange(0, BLOCK_ROW_SIZE)[:, None]
+        mask = (rows < M) & col_mask[None, :]
+        offsets = rows * N + cols[None, :]
+        dy = tl.load(dY + offsets, mask=mask, other=0.0).to(tl.float32)
+        if PartialW is not None:
+            x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+            mean = tl.load(Mean + rows, mask=rows < M, other=0.0).to(tl.float32)
+            rstd = tl.load(Rstd + rows, mask=rows < M, other=0.0).to(tl.float32)
+            acc_w += tl.sum(dy * (x - mean) * rstd, axis=0)
+        if PartialB is not None:
+            acc_b += tl.sum(dy, axis=0)
+
+    partial_offsets = row_group * N + cols
+    if PartialW is not None:
+        tl.store(PartialW + partial_offsets, acc_w, mask=col_mask)
+    if PartialB is not None:
+        tl.store(PartialB + partial_offsets, acc_b, mask=col_mask)
+
+
+# Stage 2: reduce row-group partials into the final affine gradients.
+@libentry()
+@triton.jit
+def weight_bias_backward_reduce_kernel(
+    PartialW,
+    PartialB,
+    dW,
+    dB,
+    row_group_count,
+    N,
+    BLOCK_GROUP_SIZE: tl.constexpr,
+    BLOCK_COL_SIZE: tl.constexpr,
+):
+    cols = ext.program_id(0) * BLOCK_COL_SIZE + tl.arange(0, BLOCK_COL_SIZE)
+    col_mask = cols < N
+    acc_w = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+    acc_b = tl.zeros([BLOCK_COL_SIZE], dtype=tl.float32)
+
+    for group_offset in range(0, row_group_count, BLOCK_GROUP_SIZE):
+        groups = group_offset + tl.arange(0, BLOCK_GROUP_SIZE)[:, None]
+        mask = (groups < row_group_count) & col_mask[None, :]
+        offsets = groups * N + cols[None, :]
+        if PartialW is not None:
+            acc_w += tl.sum(tl.load(PartialW + offsets, mask=mask, other=0.0), axis=0)
+        if PartialB is not None:
+            acc_b += tl.sum(tl.load(PartialB + offsets, mask=mask, other=0.0), axis=0)
+
+    if dW is not None:
+        tl.store(dW + cols, acc_w, mask=col_mask)
+    if dB is not None:
+        tl.store(dB + cols, acc_b, mask=col_mask)
+
+
+def _weight_bias_backward_reduction_config(input, M, N):
+    heuristics = runtime.get_heuristic_config("layer_norm_weight_bias_backward")
+    if heuristics is None:
+        return None
+
+    args = {
+        "M": M,
+        "N": N,
+        "IS_LOW_PRECISION": input.dtype != torch.float32,
+    }
+    rows_per_program = heuristics["ROWS_PER_PROGRAM"](args)
+    row_group_count = triton.cdiv(M, rows_per_program)
+    # The temporary reduction buffer pays off only with enough row parallelism.
+    if row_group_count < heuristics["MIN_ROW_GROUPS"](args):
+        return None
+
+    block_row_size_fn = heuristics.get("BLOCK_ROW_SIZE")
+    block_group_size_fn = heuristics.get("BLOCK_GROUP_SIZE")
+    block_row_size = block_row_size_fn(args) if block_row_size_fn is not None else 32
+    block_group_size = (
+        block_group_size_fn(args) if block_group_size_fn is not None else 32
+    )
+    block_col_size = heuristics["BLOCK_COL_SIZE"](args)
+    return (
+        row_group_count,
+        rows_per_program,
+        block_row_size,
+        block_col_size,
+        block_group_size,
+    )
+
+
+def _launch_weight_bias_backward_reduction(
+    grad_out,
+    input,
+    mean,
+    rstd,
+    weight_grad,
+    bias_grad,
+    M,
+    N,
+):
+    config = _weight_bias_backward_reduction_config(input, M, N)
+    if config is None:
+        return False
+
+    (
+        row_group_count,
+        rows_per_program,
+        block_row_size,
+        block_col_size,
+        block_group_size,
+    ) = config
+    # Store inter-stage partials in FP32 so all dtypes use accumulation precision.
+    partial_weight = (
+        torch.empty((row_group_count, N), dtype=torch.float32, device=input.device)
+        if weight_grad is not None
+        else None
+    )
+    partial_bias = (
+        torch.empty((row_group_count, N), dtype=torch.float32, device=input.device)
+        if bias_grad is not None
+        else None
+    )
+
+    with torch_device_fn.device(input.device):
+        partial_grid = (row_group_count, triton.cdiv(N, block_col_size), 1)
+        weight_bias_backward_partial_kernel[partial_grid](
+            grad_out,
+            input,
+            mean,
+            rstd,
+            partial_weight,
+            partial_bias,
+            M,
+            N,
+            ROWS_PER_PROGRAM=rows_per_program,
+            BLOCK_ROW_SIZE=block_row_size,
+            BLOCK_COL_SIZE=block_col_size,
+        )
+        final_grid = (triton.cdiv(N, block_col_size), 1, 1)
+        weight_bias_backward_reduce_kernel[final_grid](
+            partial_weight,
+            partial_bias,
+            weight_grad,
+            bias_grad,
+            row_group_count,
+            N,
+            BLOCK_GROUP_SIZE=block_group_size,
+            BLOCK_COL_SIZE=block_col_size,
+        )
+    return True
+
+
+def layer_norm_backward(
+    grad_out,
+    input,
+    normalized_shape,
+    mean,
+    rstd,
+    weight=None,
+    bias=None,
+    output_mask=None,
+):
+    logger.debug("GEMS LAYERNORM BACKWARD")
+
+    grad_out = grad_out.contiguous()
+    input = input.contiguous()
+    mean = mean.contiguous()
+    rstd = rstd.contiguous()
+    weight = None if weight is None else weight.contiguous()
+    bias = None if bias is None else bias.contiguous()
+
+    # Match LayerNorm semantics when normalized_shape covers only an input suffix.
+    N = math.prod(normalized_shape)
+    M = input.numel() // N
+
+    # MThreads launches resident dX separately from the grouped affine reduction.
+    resident_config = _layer_norm_backward_resident_dx_config(input, output_mask, M, N)
+    if resident_config is None:
+        in_grad = None
+    else:
+        in_grad, _, _ = _launch_layer_norm_backward_resident(
+            grad_out,
+            input,
+            mean,
+            rstd,
+            weight,
+            bias,
+            M,
+            N,
+            *resident_config,
+            compute_dw=False,
+            compute_db=False,
+            use_fp32_scratch=False,
+        )
+
+    if output_mask[0] and in_grad is None:
+        in_grad = torch.empty_like(input)
+        grid = lambda meta: (triton.cdiv(M, meta["BLOCK_ROW_SIZE"]), 1, 1)
+        with torch_device_fn.device(input.device):
+            layer_norm_backward_kernel[grid](
+                grad_out, input, weight, mean, rstd, in_grad, M, N
+            )
+
+    if output_mask[1] is False and output_mask[2] is False:
+        return in_grad, None, None
+
+    weight_grad = torch.empty_like(weight) if output_mask[1] else None
+    bias_grad = torch.empty_like(bias) if output_mask[2] else None
+    used_grouped_reduction = _launch_weight_bias_backward_reduction(
+        grad_out,
+        input,
+        mean,
+        rstd,
+        weight_grad,
+        bias_grad,
+        M,
+        N,
+    )
+    if not used_grouped_reduction:
+        # Small reductions keep the common one-stage affine kernel.
+        grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
+        with torch_device_fn.device(input.device):
+            weight_bias_backward_kernel[grid](
+                grad_out, input, mean, rstd, weight_grad, bias_grad, M, N
+            )
+    return in_grad, weight_grad, bias_grad

--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -261,6 +261,28 @@ rms_norm_loop:
       - 4096
       - 8192
 layer_norm_backward:
+  # Keep at least two warps per row for the 2048-column tile on MUSA.
+  - gen: true
+    param_map:
+      META:
+        BLOCK_ROW_SIZE: block_r
+        BLOCK_COL_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 16
+    block_r:
+      - 8
+  - gen: true
+    param_map:
+      META:
+        BLOCK_ROW_SIZE: block_r
+        BLOCK_COL_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 8
+      - 16
+    block_r:
+      - 4
   - gen: true
     param_map:
       META:
@@ -274,8 +296,6 @@ layer_norm_backward:
     block_r:
       - 1
       - 2
-      - 4
-      - 8
 weight_bias_backward:
   - gen: true
     param_map:

--- a/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
@@ -181,6 +181,30 @@ def layer_norm_heur_block_row_size(args):
     return min(32, triton.next_power_of_2(args["row_count"]))
 
 
+def layer_norm_heur_fused_min_elements(_args):
+    return 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(_args):
+    return 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(_args):
+    return 1
+
+
 def batch_norm_heur_block_m(args):
     """Select BLOCK_M for batch normalization on PPU"""
     return min(2048, triton.next_power_of_2(args["batch_dim"]))
@@ -317,6 +341,14 @@ HEURISTICS_CONFIGS = {
     },
     "layer_norm_persistent": {
         "BLOCK_ROW_SIZE": layer_norm_heur_block_row_size,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "batch_norm": {
         "BLOCK_M": batch_norm_heur_block_m,

--- a/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
@@ -181,6 +181,30 @@ def layer_norm_heur_block_row_size(args):
     return min(32, triton.next_power_of_2(args["row_count"]))
 
 
+def layer_norm_heur_fused_min_elements(_args):
+    return 1024 * 1024
+
+
+def layer_norm_heur_fused_max_resident_n(_args):
+    return 512
+
+
+def layer_norm_heur_fused_tile_elements(_args):
+    return 4096
+
+
+def layer_norm_heur_fused_max_block_m(_args):
+    return 256
+
+
+def layer_norm_heur_fused_direct_lowp_atomic(_args):
+    return False
+
+
+def layer_norm_heur_fused_program_waves(_args):
+    return 1
+
+
 def batch_norm_heur_block_m(args):
     """Select BLOCK_M for batch normalization on PPU"""
     return min(2048, triton.next_power_of_2(args["batch_dim"]))
@@ -322,6 +346,14 @@ HEURISTICS_CONFIGS = {
     },
     "layer_norm_persistent": {
         "BLOCK_ROW_SIZE": layer_norm_heur_block_row_size,
+    },
+    "layer_norm_backward_fused": {
+        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
+        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
+        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
+        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
+        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
+        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
     },
     "batch_norm": {
         "BLOCK_M": batch_norm_heur_block_m,

--- a/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_thead/heuristics_config_utils.py
@@ -181,30 +181,6 @@ def layer_norm_heur_block_row_size(args):
     return min(32, triton.next_power_of_2(args["row_count"]))
 
 
-def layer_norm_heur_fused_min_elements(_args):
-    return 1024 * 1024
-
-
-def layer_norm_heur_fused_max_resident_n(_args):
-    return 512
-
-
-def layer_norm_heur_fused_tile_elements(_args):
-    return 4096
-
-
-def layer_norm_heur_fused_max_block_m(_args):
-    return 256
-
-
-def layer_norm_heur_fused_direct_lowp_atomic(_args):
-    return False
-
-
-def layer_norm_heur_fused_program_waves(_args):
-    return 1
-
-
 def batch_norm_heur_block_m(args):
     """Select BLOCK_M for batch normalization on PPU"""
     return min(2048, triton.next_power_of_2(args["batch_dim"]))
@@ -348,12 +324,12 @@ HEURISTICS_CONFIGS = {
         "BLOCK_ROW_SIZE": layer_norm_heur_block_row_size,
     },
     "layer_norm_backward_fused": {
-        "MIN_ELEMENTS": layer_norm_heur_fused_min_elements,
-        "MAX_RESIDENT_N": layer_norm_heur_fused_max_resident_n,
-        "TILE_ELEMENTS": layer_norm_heur_fused_tile_elements,
-        "MAX_BLOCK_M": layer_norm_heur_fused_max_block_m,
-        "PROGRAM_WAVES": layer_norm_heur_fused_program_waves,
-        "DIRECT_LOWP_ATOMIC": layer_norm_heur_fused_direct_lowp_atomic,
+        "MIN_ELEMENTS": lambda _args: 1024 * 1024,
+        "MAX_RESIDENT_N": lambda _args: 512,
+        "TILE_ELEMENTS": lambda _args: 4096,
+        "MAX_BLOCK_M": lambda _args: 256,
+        "PROGRAM_WAVES": lambda _args: 1,
+        "DIRECT_LOWP_ATOMIC": lambda _args: False,
     },
     "batch_norm": {
         "BLOCK_M": batch_norm_heur_block_m,

--- a/src/flag_gems/runtime/backend/_thead/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_thead/tune_configs.yaml
@@ -552,7 +552,7 @@ layer_norm_backward:
     param_map:
       META:
         BLOCK_ROW_SIZE: block_r
-        BLOCK_COL_SIZE: 2048
+        BLOCK_COL_SIZE: block_c
       num_warps: warps
     warps:
       - 4
@@ -563,6 +563,15 @@ layer_norm_backward:
       - 2
       - 4
       - 8
+    block_c:
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+      - 512
+      - 1024
+      - 2048
 weight_bias_backward:
   - gen: true
     param_map:

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import pytest
 import torch
 
@@ -23,9 +25,84 @@ from . import conftest as cfg
 if cfg.QUICK_MODE:
     FLOAT_DTYPES = [torch.float32]
     LAYER_NORM_SHAPES = [(1, 40999)]
+    LAYER_NORM_AUTOGRAD_CASES = [
+        ((2, 3, 512), (512,)),
+    ]
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES = [
+        pytest.param(
+            (64, 16, 64, 16),
+            (16,),
+            id="m65536-n16",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_STRUCTURE_SHAPES = []
+    LAYER_NORM_BACKWARD_OUTPUT_MASKS = [
+        pytest.param((True, True, False), id="dx-dw"),
+    ]
 else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
     LAYER_NORM_SHAPES = [(200, 36), (4096, 100), (1, 40999), (100, 40499), (4096, 256)]
+    LAYER_NORM_AUTOGRAD_CASES = [
+        ((2, 257, 512), (512,)),
+    ]
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES = [
+        pytest.param(
+            (64, 16, 64, 16),
+            (16,),
+            id="m65536-n16",
+        ),
+        pytest.param(
+            (128, 16, 16, 32),
+            (32,),
+            id="m32768-n32",
+        ),
+        pytest.param(
+            (32768, 128),
+            (128,),
+            id="m32768-n128",
+        ),
+        pytest.param(
+            (32768, 256),
+            (256,),
+            id="m32768-n256",
+        ),
+        pytest.param(
+            (32768, 257),
+            (257,),
+            id="m32768-n257-tail",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_STRUCTURE_SHAPES = [
+        pytest.param(
+            (128, 256, 4, 8),
+            (4, 8),
+            id="m32768-n32-multiaxis",
+        ),
+        pytest.param(
+            (32, 16, 32, 64),
+            (32, 64),
+            id="fallback-m512-n2048-multiaxis",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_OUTPUT_MASKS = [
+        pytest.param((True, True, False), id="dx-dw"),
+        pytest.param((True, False, True), id="dx-db"),
+        pytest.param((True, False, False), id="dx-only"),
+        pytest.param((False, True, True), id="affine-only"),
+    ]
+
+LAYER_NORM_BACKWARD_CASES = [(shape, shape[1:]) for shape in LAYER_NORM_SHAPES]
+# Dedicated backward tests cover the kernel shapes; one case is sufficient to
+# verify that autograd dispatches through the registered backward operator.
+LAYER_NORM_CONTROL_DTYPES = [torch.float32]
+
+
+@pytest.mark.layer_norm_backward
+def test_layer_norm_backward_mthreads_vendor_dispatch():
+    if flag_gems.vendor_name != "mthreads":
+        pytest.skip("MThreads vendor dispatch only")
+
+    assert flag_gems.layer_norm_backward.__module__.endswith("_mthreads.ops.layernorm")
 
 
 @pytest.mark.layer_norm
@@ -70,10 +147,10 @@ def test_layer_norm(shape, dtype, wb_none):
 
 
 @pytest.mark.layer_norm_backward
-@pytest.mark.parametrize("shape", LAYER_NORM_SHAPES)
+@pytest.mark.parametrize("shape,normalized_shape", LAYER_NORM_BACKWARD_CASES)
 @pytest.mark.parametrize("wb_none", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
+def test_layer_norm_backward(monkeypatch, shape, normalized_shape, dtype, wb_none):
     if flag_gems.vendor_name == "kunlunxin":
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0)
@@ -84,18 +161,23 @@ def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
 
     res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     res_grad = torch.randn_like(res_inp)
-    res_mean = torch.randn(shape[0], dtype=dtype, device=flag_gems.device)
-    res_rstd = torch.randn(shape[0], dtype=dtype, device=flag_gems.device)
+    M = res_inp.numel() // math.prod(normalized_shape)
     if wb_none:
         res_weight = None
         res_bias = None
         output_mask = [True, False, False]
     else:
-        res_weight = torch.randn(shape[1:], dtype=dtype, device=flag_gems.device)
-        res_bias = torch.randn(shape[1:], dtype=dtype, device=flag_gems.device)
+        res_weight = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+        res_bias = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
         output_mask = [True, True, True]
 
-    normalized_shape = shape[1:]
+    _, res_mean, res_rstd = torch.ops.aten.native_layer_norm(
+        res_inp,
+        normalized_shape,
+        res_weight,
+        res_bias,
+        1e-5,
+    )
 
     ref_inp = utils.to_reference(res_inp, True)
     ref_grad = utils.to_reference(res_grad, True)
@@ -136,9 +218,169 @@ def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
 
     utils.gems_assert_close(res_in_grad, ref_in_grad, dtype)
     if not wb_none:
-        utils.gems_assert_close(
-            res_weight_grad, ref_weight_grad, dtype, reduce_dim=shape[0]
+        utils.gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
+        utils.gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize(
+    "shape,normalized_shape",
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES + LAYER_NORM_BACKWARD_STRUCTURE_SHAPES,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_layer_norm_backward_large_m(monkeypatch, shape, normalized_shape, dtype):
+    _test_layer_norm_backward_case(
+        monkeypatch,
+        shape,
+        normalized_shape,
+        (True, True, True),
+        dtype,
+    )
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize("output_mask", LAYER_NORM_BACKWARD_OUTPUT_MASKS)
+@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+def test_layer_norm_backward_output_mask(monkeypatch, output_mask, dtype):
+    _test_layer_norm_backward_case(
+        monkeypatch,
+        (128, 16, 16, 32),
+        (32,),
+        output_mask,
+        dtype,
+    )
+
+
+def _test_layer_norm_backward_case(
+    monkeypatch, shape, normalized_shape, output_mask, dtype
+):
+    if flag_gems.vendor_name == "mthreads":
+        # Compatible with older versions of LLVM
+        monkeypatch.setenv("DISABLE_LLVM_OPT", "1")
+
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+    # output_mask controls returned gradients; dX still uses the forward weight.
+    res_weight = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+    res_bias = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+    _, res_mean, res_rstd = torch.ops.aten.native_layer_norm(
+        res_inp,
+        normalized_shape,
+        res_weight,
+        res_bias,
+        1e-5,
+    )
+
+    ref_inp = utils.to_reference(res_inp, True)
+    ref_grad = utils.to_reference(res_grad, True)
+    ref_mean = utils.to_reference(res_mean, True)
+    ref_rstd = utils.to_reference(res_rstd, True)
+    ref_weight = utils.to_reference(res_weight, True)
+    ref_bias = utils.to_reference(res_bias, True)
+    (
+        ref_in_grad,
+        ref_weight_grad,
+        ref_bias_grad,
+    ) = torch.ops.aten.native_layer_norm_backward(
+        ref_grad,
+        ref_inp,
+        normalized_shape,
+        ref_mean,
+        ref_rstd,
+        ref_weight,
+        ref_bias,
+        output_mask,
+    )
+    with flag_gems.use_gems():
+        (
+            res_in_grad,
+            res_weight_grad,
+            res_bias_grad,
+        ) = torch.ops.aten.native_layer_norm_backward(
+            res_grad,
+            res_inp,
+            normalized_shape,
+            res_mean,
+            res_rstd,
+            res_weight,
+            res_bias,
+            output_mask,
         )
-        utils.gems_assert_close(
-            res_bias_grad, ref_bias_grad, dtype, reduce_dim=shape[0]
+
+    M = res_inp.numel() // math.prod(normalized_shape)
+    if output_mask[0]:
+        utils.gems_assert_close(res_in_grad, ref_in_grad, dtype)
+    else:
+        assert res_in_grad is ref_in_grad is None
+    if output_mask[1]:
+        utils.gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
+    else:
+        assert res_weight_grad is ref_weight_grad is None
+    if output_mask[2]:
+        utils.gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
+    else:
+        assert res_bias_grad is ref_bias_grad is None
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize("shape,normalized_shape", LAYER_NORM_AUTOGRAD_CASES)
+@pytest.mark.parametrize("wb_none", [False, True])
+@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
+    res_inp = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    res_grad = torch.randn_like(res_inp)
+    if wb_none:
+        res_weight = None
+        res_bias = None
+    else:
+        res_weight = torch.randn(
+            normalized_shape,
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=True,
         )
+        res_bias = torch.randn(
+            normalized_shape,
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=True,
+        )
+
+    ref_inp = utils.to_reference(res_inp.detach().clone(), True).requires_grad_()
+    ref_grad = utils.to_reference(res_grad, True)
+    ref_weight = (
+        utils.to_reference(res_weight.detach().clone(), True).requires_grad_()
+        if res_weight is not None
+        else None
+    )
+    ref_bias = (
+        utils.to_reference(res_bias.detach().clone(), True).requires_grad_()
+        if res_bias is not None
+        else None
+    )
+
+    ref_out = torch.layer_norm(
+        ref_inp,
+        normalized_shape,
+        weight=ref_weight,
+        bias=ref_bias,
+    )
+    ref_out.backward(ref_grad)
+
+    with flag_gems.use_gems():
+        res_out = torch.layer_norm(
+            res_inp,
+            normalized_shape,
+            weight=res_weight,
+            bias=res_bias,
+        )
+        res_out.backward(res_grad)
+
+    M = res_inp.numel() // math.prod(normalized_shape)
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(res_inp.grad, ref_inp.grad, dtype)
+    if not wb_none:
+        utils.gems_assert_close(res_weight.grad, ref_weight.grad, dtype, reduce_dim=M)
+        utils.gems_assert_close(res_bias.grad, ref_bias.grad, dtype, reduce_dim=M)

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -26,6 +26,20 @@ if cfg.QUICK_MODE:
     FLOAT_DTYPES = [torch.float32]
     LAYER_NORM_SHAPES = [(1, 40999)]
     LAYER_NORM_MEDIUM_SHAPES = []
+    LAYER_NORM_AUTOGRAD_CASES = [
+        ((2, 3, 512), (512,)),
+    ]
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES = [
+        pytest.param(
+            (64, 16, 64, 16),
+            (16,),
+            id="m65536-n16",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_STRUCTURE_SHAPES = []
+    LAYER_NORM_BACKWARD_OUTPUT_MASKS = [
+        pytest.param((True, True, False), id="dx-dw"),
+    ]
 else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
     LAYER_NORM_SHAPES = [(200, 36), (4096, 100), (1, 40999), (100, 40499), (4096, 256)]
@@ -36,8 +50,60 @@ else:
         (2048, 1024),
         (1024, 2048),
     ]
+    LAYER_NORM_AUTOGRAD_CASES = [
+        ((2, 257, 512), (512,)),
+    ]
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES = [
+        pytest.param(
+            (64, 16, 64, 16),
+            (16,),
+            id="m65536-n16",
+        ),
+        pytest.param(
+            (128, 16, 16, 32),
+            (32,),
+            id="m32768-n32",
+        ),
+        pytest.param(
+            (32768, 128),
+            (128,),
+            id="m32768-n128",
+        ),
+        pytest.param(
+            (32768, 256),
+            (256,),
+            id="m32768-n256",
+        ),
+        pytest.param(
+            (32768, 257),
+            (257,),
+            id="m32768-n257-tail",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_STRUCTURE_SHAPES = [
+        pytest.param(
+            (128, 256, 4, 8),
+            (4, 8),
+            id="m32768-n32-multiaxis",
+        ),
+        pytest.param(
+            (32, 16, 32, 64),
+            (32, 64),
+            id="fallback-m512-n2048-multiaxis",
+        ),
+    ]
+    LAYER_NORM_BACKWARD_OUTPUT_MASKS = [
+        pytest.param((True, True, False), id="dx-dw"),
+        pytest.param((True, False, True), id="dx-db"),
+        pytest.param((True, False, False), id="dx-only"),
+        pytest.param((False, True, True), id="affine-only"),
+    ]
 
 LAYER_NORM_FORWARD_SHAPES = LAYER_NORM_SHAPES + LAYER_NORM_MEDIUM_SHAPES
+LAYER_NORM_BACKWARD_CASES = [(shape, shape[1:]) for shape in LAYER_NORM_SHAPES]
+# Dedicated backward tests cover the kernel shapes; one case is sufficient to
+# verify that autograd dispatches through the registered backward operator.
+LAYER_NORM_CONTROL_DTYPES = [torch.float32]
 
 
 @pytest.mark.native_layer_norm
@@ -76,6 +142,14 @@ def test_native_layer_norm(shape, normalized_shape, dtype, affine, caplog):
     assert len(result) == len(ref_result) == 3
     for actual, expected in zip(result, ref_result):
         utils.gems_assert_close(actual, expected, dtype)
+
+
+@pytest.mark.layer_norm_backward
+def test_layer_norm_backward_mthreads_vendor_dispatch():
+    if flag_gems.vendor_name != "mthreads":
+        pytest.skip("MThreads vendor dispatch only")
+
+    assert flag_gems.layer_norm_backward.__module__.endswith("_mthreads.ops.layernorm")
 
 
 @pytest.mark.layer_norm
@@ -154,10 +228,10 @@ def test_native_layer_norm_statistics(shape, dtype):
 
 
 @pytest.mark.layer_norm_backward
-@pytest.mark.parametrize("shape", LAYER_NORM_SHAPES)
+@pytest.mark.parametrize("shape,normalized_shape", LAYER_NORM_BACKWARD_CASES)
 @pytest.mark.parametrize("wb_none", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
+def test_layer_norm_backward(monkeypatch, shape, normalized_shape, dtype, wb_none):
     if flag_gems.vendor_name == "kunlunxin":
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0)
@@ -168,18 +242,23 @@ def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
 
     res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     res_grad = torch.randn_like(res_inp)
-    res_mean = torch.randn(shape[0], dtype=dtype, device=flag_gems.device)
-    res_rstd = torch.randn(shape[0], dtype=dtype, device=flag_gems.device)
+    M = res_inp.numel() // math.prod(normalized_shape)
     if wb_none:
         res_weight = None
         res_bias = None
         output_mask = [True, False, False]
     else:
-        res_weight = torch.randn(shape[1:], dtype=dtype, device=flag_gems.device)
-        res_bias = torch.randn(shape[1:], dtype=dtype, device=flag_gems.device)
+        res_weight = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+        res_bias = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
         output_mask = [True, True, True]
 
-    normalized_shape = shape[1:]
+    _, res_mean, res_rstd = torch.ops.aten.native_layer_norm(
+        res_inp,
+        normalized_shape,
+        res_weight,
+        res_bias,
+        1e-5,
+    )
 
     ref_inp = utils.to_reference(res_inp, True)
     ref_grad = utils.to_reference(res_grad, True)
@@ -220,9 +299,169 @@ def test_layer_norm_backward(monkeypatch, shape, dtype, wb_none):
 
     utils.gems_assert_close(res_in_grad, ref_in_grad, dtype)
     if not wb_none:
-        utils.gems_assert_close(
-            res_weight_grad, ref_weight_grad, dtype, reduce_dim=shape[0]
+        utils.gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
+        utils.gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize(
+    "shape,normalized_shape",
+    LAYER_NORM_BACKWARD_LARGE_M_SHAPES + LAYER_NORM_BACKWARD_STRUCTURE_SHAPES,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_layer_norm_backward_large_m(monkeypatch, shape, normalized_shape, dtype):
+    _test_layer_norm_backward_case(
+        monkeypatch,
+        shape,
+        normalized_shape,
+        (True, True, True),
+        dtype,
+    )
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize("output_mask", LAYER_NORM_BACKWARD_OUTPUT_MASKS)
+@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+def test_layer_norm_backward_output_mask(monkeypatch, output_mask, dtype):
+    _test_layer_norm_backward_case(
+        monkeypatch,
+        (128, 16, 16, 32),
+        (32,),
+        output_mask,
+        dtype,
+    )
+
+
+def _test_layer_norm_backward_case(
+    monkeypatch, shape, normalized_shape, output_mask, dtype
+):
+    if flag_gems.vendor_name == "mthreads":
+        # Compatible with older versions of LLVM
+        monkeypatch.setenv("DISABLE_LLVM_OPT", "1")
+
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+    # output_mask controls returned gradients; dX still uses the forward weight.
+    res_weight = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+    res_bias = torch.randn(normalized_shape, dtype=dtype, device=flag_gems.device)
+    _, res_mean, res_rstd = torch.ops.aten.native_layer_norm(
+        res_inp,
+        normalized_shape,
+        res_weight,
+        res_bias,
+        1e-5,
+    )
+
+    ref_inp = utils.to_reference(res_inp, True)
+    ref_grad = utils.to_reference(res_grad, True)
+    ref_mean = utils.to_reference(res_mean, True)
+    ref_rstd = utils.to_reference(res_rstd, True)
+    ref_weight = utils.to_reference(res_weight, True)
+    ref_bias = utils.to_reference(res_bias, True)
+    (
+        ref_in_grad,
+        ref_weight_grad,
+        ref_bias_grad,
+    ) = torch.ops.aten.native_layer_norm_backward(
+        ref_grad,
+        ref_inp,
+        normalized_shape,
+        ref_mean,
+        ref_rstd,
+        ref_weight,
+        ref_bias,
+        output_mask,
+    )
+    with flag_gems.use_gems():
+        (
+            res_in_grad,
+            res_weight_grad,
+            res_bias_grad,
+        ) = torch.ops.aten.native_layer_norm_backward(
+            res_grad,
+            res_inp,
+            normalized_shape,
+            res_mean,
+            res_rstd,
+            res_weight,
+            res_bias,
+            output_mask,
         )
-        utils.gems_assert_close(
-            res_bias_grad, ref_bias_grad, dtype, reduce_dim=shape[0]
+
+    M = res_inp.numel() // math.prod(normalized_shape)
+    if output_mask[0]:
+        utils.gems_assert_close(res_in_grad, ref_in_grad, dtype)
+    else:
+        assert res_in_grad is ref_in_grad is None
+    if output_mask[1]:
+        utils.gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
+    else:
+        assert res_weight_grad is ref_weight_grad is None
+    if output_mask[2]:
+        utils.gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
+    else:
+        assert res_bias_grad is ref_bias_grad is None
+
+
+@pytest.mark.layer_norm_backward
+@pytest.mark.parametrize("shape,normalized_shape", LAYER_NORM_AUTOGRAD_CASES)
+@pytest.mark.parametrize("wb_none", [False, True])
+@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
+    res_inp = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    res_grad = torch.randn_like(res_inp)
+    if wb_none:
+        res_weight = None
+        res_bias = None
+    else:
+        res_weight = torch.randn(
+            normalized_shape,
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=True,
         )
+        res_bias = torch.randn(
+            normalized_shape,
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=True,
+        )
+
+    ref_inp = utils.to_reference(res_inp.detach().clone(), True).requires_grad_()
+    ref_grad = utils.to_reference(res_grad, True)
+    ref_weight = (
+        utils.to_reference(res_weight.detach().clone(), True).requires_grad_()
+        if res_weight is not None
+        else None
+    )
+    ref_bias = (
+        utils.to_reference(res_bias.detach().clone(), True).requires_grad_()
+        if res_bias is not None
+        else None
+    )
+
+    ref_out = torch.layer_norm(
+        ref_inp,
+        normalized_shape,
+        weight=ref_weight,
+        bias=ref_bias,
+    )
+    ref_out.backward(ref_grad)
+
+    with flag_gems.use_gems():
+        res_out = torch.layer_norm(
+            res_inp,
+            normalized_shape,
+            weight=res_weight,
+            bias=res_bias,
+        )
+        res_out.backward(res_grad)
+
+    M = res_inp.numel() // math.prod(normalized_shape)
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(res_inp.grad, ref_inp.grad, dtype)
+    if not wb_none:
+        utils.gems_assert_close(res_weight.grad, ref_weight.grad, dtype, reduce_dim=M)
+        utils.gems_assert_close(res_bias.grad, ref_bias.grad, dtype, reduce_dim=M)

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -429,13 +429,17 @@ def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
     # Direct backward tests use an upcast reference with shared forward statistics.
     # Keep this end-to-end autograd reference in the input dtype so existing
     # forward rounding is not attributed to the backward implementation.
-    ref_inp = res_inp.detach().clone().requires_grad_()
-    ref_grad = res_grad.detach().clone()
+    ref_inp = utils.to_reference(res_inp.detach().clone()).requires_grad_()
+    ref_grad = utils.to_reference(res_grad)
     ref_weight = (
-        res_weight.detach().clone().requires_grad_() if res_weight is not None else None
+        utils.to_reference(res_weight.detach().clone()).requires_grad_()
+        if res_weight is not None
+        else None
     )
     ref_bias = (
-        res_bias.detach().clone().requires_grad_() if res_bias is not None else None
+        utils.to_reference(res_bias.detach().clone()).requires_grad_()
+        if res_bias is not None
+        else None
     )
 
     ref_out = torch.layer_norm(

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -101,9 +101,6 @@ else:
 
 LAYER_NORM_FORWARD_SHAPES = LAYER_NORM_SHAPES + LAYER_NORM_MEDIUM_SHAPES
 LAYER_NORM_BACKWARD_CASES = [(shape, shape[1:]) for shape in LAYER_NORM_SHAPES]
-# Dedicated backward tests cover the kernel shapes; one case is sufficient to
-# verify that autograd dispatches through the registered backward operator.
-LAYER_NORM_CONTROL_DTYPES = [torch.float32]
 
 
 @pytest.mark.native_layer_norm
@@ -321,7 +318,7 @@ def test_layer_norm_backward_large_m(monkeypatch, shape, normalized_shape, dtype
 
 @pytest.mark.layer_norm_backward
 @pytest.mark.parametrize("output_mask", LAYER_NORM_BACKWARD_OUTPUT_MASKS)
-@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_layer_norm_backward_output_mask(monkeypatch, output_mask, dtype):
     _test_layer_norm_backward_case(
         monkeypatch,
@@ -406,7 +403,7 @@ def _test_layer_norm_backward_case(
 @pytest.mark.layer_norm_backward
 @pytest.mark.parametrize("shape,normalized_shape", LAYER_NORM_AUTOGRAD_CASES)
 @pytest.mark.parametrize("wb_none", [False, True])
-@pytest.mark.parametrize("dtype", LAYER_NORM_CONTROL_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
     res_inp = torch.randn(
         shape, dtype=dtype, device=flag_gems.device, requires_grad=True

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -456,9 +456,10 @@ def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
         )
         res_out.backward(res_grad)
 
-    M = res_inp.numel() // math.prod(normalized_shape)
+    N = math.prod(normalized_shape)
+    M = res_inp.numel() // N
     utils.gems_assert_close(res_out, ref_out, dtype)
-    utils.gems_assert_close(res_inp.grad, ref_inp.grad, dtype)
+    utils.gems_assert_close(res_inp.grad, ref_inp.grad, dtype, reduce_dim=N)
     if not wb_none:
         utils.gems_assert_close(res_weight.grad, ref_weight.grad, dtype, reduce_dim=M)
         utils.gems_assert_close(res_bias.grad, ref_bias.grad, dtype, reduce_dim=M)

--- a/tests/test_layer_norm.py
+++ b/tests/test_layer_norm.py
@@ -51,7 +51,7 @@ else:
         (1024, 2048),
     ]
     LAYER_NORM_AUTOGRAD_CASES = [
-        ((2, 257, 512), (512,)),
+        ((32, 256, 512), (512,)),
     ]
     LAYER_NORM_BACKWARD_LARGE_M_SHAPES = [
         pytest.param(
@@ -426,17 +426,16 @@ def test_layer_norm_autograd(shape, normalized_shape, dtype, wb_none):
             requires_grad=True,
         )
 
-    ref_inp = utils.to_reference(res_inp.detach().clone(), True).requires_grad_()
-    ref_grad = utils.to_reference(res_grad, True)
+    # Direct backward tests use an upcast reference with shared forward statistics.
+    # Keep this end-to-end autograd reference in the input dtype so existing
+    # forward rounding is not attributed to the backward implementation.
+    ref_inp = res_inp.detach().clone().requires_grad_()
+    ref_grad = res_grad.detach().clone()
     ref_weight = (
-        utils.to_reference(res_weight.detach().clone(), True).requires_grad_()
-        if res_weight is not None
-        else None
+        res_weight.detach().clone().requires_grad_() if res_weight is not None else None
     )
     ref_bias = (
-        utils.to_reference(res_bias.detach().clone(), True).requires_grad_()
-        if res_bias is not None
-        else None
+        res_bias.detach().clone().requires_grad_() if res_bias is not None else None
     )
 
     ref_out = torch.layer_norm(


### PR DESCRIPTION
### PR Category

Operator, OP Test, Benchmark

### Type of Change

Bug Fix, Performance Optimization

### Description

The common LayerNorm backward path previously derived `M` from
`input.shape[0]`. This is incorrect when `normalized_shape` covers only a
suffix of a higher-rank input, and it also leaves the large-row affine
reduction mostly serial.

This PR:

- derives `N` from `normalized_shape` and flattens all preceding dimensions
  into `M = input.numel() / N`;
- adds a common resident backward kernel for large `M` and resident `N` that
  reuses the dX scan to accumulate dWeight/dBias partials;
- uses FP32 affine scratch for low-precision backends without direct FP16/BF16
  atomic accumulation;
- adds backend heuristics for Ascend, Hygon, T-Head, and MetaX while preserving
  the existing generic fallback outside the selected region;
- adds an MThreads vendor path with resident dX and a two-stage grouped affine
  reduction;
- lets the MetaX vendor backward reuse the common resident launcher;
- guards MThreads TensorDescriptor-dependent imports so older Triton stacks
  can still register the LayerNorm vendor implementation.

The common LayerNorm forward implementation is unchanged.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

The device results below were recorded before the September 16 master sync.
They are retained as historical evidence, not claimed as validation of the new HEAD.

Official and candidate trees were loaded in isolation. The candidate test set
keeps the 30 upstream backward cases and adds five large-M shapes in FP32,
FP16, and BF16, two multi-axis normalized shapes, four output-mask paths, one
[32,256,512] / [512] forward/backward composition shape (Torch autograd reference), and an MThreads
vendor-dispatch check.

The counts are not the same suite reported two ways. Official runs the 30
upstream cases (`5 shapes x 2 weight/bias states x 3 dtypes`). This PR retains
those 30 and adds 39 backend-neutral cases (`(5 large-M + 2 multi-axis) x 3
dtypes + (4 output masks x 3 dtypes) + (2 affine states x 3 dtypes)`) plus one MThreads-only dispatch check.
The dispatch check passes on S5000 and is skipped elsewhere.

| Platform | Backend path | Official | This PR |
|---|---|---:|---:|
| Ascend 910C | common | 30 passed | 69 passed, 1 skipped |
| Hygon BW1000 | common | 30 passed | 69 passed, 1 skipped |
| Moore Threads S5000 | `_mthreads/ops/layernorm.py` | 30 passed | 70 passed |
| T-Head 810E | common | 30 passed | 69 passed, 1 skipped |
| MetaX C550 | `_metax/ops/layernorm.py` | 30 passed | 69 passed, 1 skipped |

Thus S5000 reports `70 passed`; the other platforms collect the same 70 tests
and report `69 passed, 1 skipped` because the MThreads dispatch assertion does
not apply there.

On Ascend 910C/CANN 8.5, the previously validated source passed the complete
`tests/test_layer_norm.py` suite (`162 passed, 1 skipped`). The skipped test is
the MThreads-only vendor-dispatch assertion.

### Test Environment

| Platform | Python | PyTorch stack | Triton / device runtime |
|---|---:|---|---|
| Ascend 910C | 3.11.14 | torch 2.8.0+cpu / torch-npu 2.8.0.post2 | triton-ascend 3.2.0 / CANN 8.5.0 |
| Hygon BW1000 | 3.10.12 | torch 2.10.0 | Triton 3.5.0 / DTK-HIP 6.3.26093 |
| Moore Threads S5000 | 3.10.12 | torch 2.9.0 / torch-musa 2.9.0+0680da1 | Triton 3.1.0 / MUSA driver 3.3.5-server |
| T-Head 810E | 3.12.3 | torch 2.10.0 | Triton 3.5.0 / PPU CUDA-compatible runtime 13.0 |
| MetaX C550 | 3.12.11 | torch 2.8.0+metax3.3.0.2 | Triton 3.1.0 / MACA 3.7.1.5 / KMD 3.3.12 |

### Performance

Kernel-level benchmark with a 100 ms warmup and a 200 ms timed window.
`Speedup = Official Gems / This PR`. The tables report two directly comparable
two-dimensional shapes and one higher-rank suffix-normalization shape from the
previously validated candidate source. `[32768,128]` and `[32768,256]` cover common normalized
widths. For `[128,16,16,32]` with `normalized_shape=[32]`, the correct flattened
shape is `M=32768, N=32`; upstream Official derives the wrong `M`, so its timing
is marked `INVALID` and no speedup is claimed.

#### float32

| Platform | Input shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---|---:|---:|---:|---:|
| Ascend 910C | `[32768, 128]` | 0.020358 | 0.779836 | 0.028594 | 27.273x |
| Ascend 910C | `[32768, 256]` | 0.029890 | 1.288965 | 0.051702 | 24.931x |
| Ascend 910C | `[128, 16, 16, 32] / [32]` | 0.016925 | INVALID | 0.012589 | N/A |
| Hygon BW1000 | `[32768, 128]` | 0.225119 | 0.536479 | 0.083680 | 6.411x |
| Hygon BW1000 | `[32768, 256]` | 0.342720 | 0.555200 | 0.147840 | 3.755x |
| Hygon BW1000 | `[128, 16, 16, 32] / [32]` | 0.172160 | INVALID | 0.071200 | N/A |
| Moore Threads S5000 | `[32768, 128]` | 0.152320 | 0.708120 | 0.116720 | 6.067x |
| Moore Threads S5000 | `[32768, 256]` | 0.213040 | 0.784360 | 0.201440 | 3.894x |
| Moore Threads S5000 | `[128, 16, 16, 32] / [32]` | 0.095880 | INVALID | 0.066120 | N/A |
| T-Head 810E | `[32768, 128]` | 0.162360 | 0.247560 | 0.074720 | 3.313x |
| T-Head 810E | `[32768, 256]` | 0.247920 | 0.346320 | 0.136720 | 2.533x |
| T-Head 810E | `[128, 16, 16, 32] / [32]` | 0.125200 | INVALID | 0.022880 | N/A |
| MetaX C550 | `[32768, 128]` | 0.127488 | 7.217920 | 0.109568 | 65.876x |
| MetaX C550 | `[32768, 256]` | 0.156416 | 7.091712 | 0.155904 | 45.488x |
| MetaX C550 | `[128, 16, 16, 32] / [32]` | 0.287488 | INVALID | 0.044032 | N/A |

#### float16

| Platform | Input shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---|---:|---:|---:|---:|
| Ascend 910C | `[32768, 128]` | 0.022743 | 0.862272 | 0.020705 | 41.646x |
| Ascend 910C | `[32768, 256]` | 0.033001 | 1.800931 | 0.037291 | 48.294x |
| Ascend 910C | `[128, 16, 16, 32] / [32]` | 0.016591 | INVALID | 0.009351 | N/A |
| Hygon BW1000 | `[32768, 128]` | 0.189280 | 0.534240 | 0.158560 | 3.369x |
| Hygon BW1000 | `[32768, 256]` | 0.249120 | 0.551520 | 0.190080 | 2.902x |
| Hygon BW1000 | `[128, 16, 16, 32] / [32]` | 0.170560 | INVALID | 0.124960 | N/A |
| Moore Threads S5000 | `[32768, 128]` | 0.130600 | 0.628560 | 0.106400 | 5.908x |
| Moore Threads S5000 | `[32768, 256]` | 0.169600 | 0.656240 | 0.201160 | 3.262x |
| Moore Threads S5000 | `[128, 16, 16, 32] / [32]` | 0.098360 | INVALID | 0.056560 | N/A |
| T-Head 810E | `[32768, 128]` | 0.132960 | 0.250240 | 0.060720 | 4.121x |
| T-Head 810E | `[32768, 256]` | 0.140560 | 0.253900 | 0.154640 | 1.642x |
| T-Head 810E | `[128, 16, 16, 32] / [32]` | 0.130400 | INVALID | 0.020200 | N/A |
| MetaX C550 | `[32768, 128]` | 0.117504 | 7.058944 | 0.101120 | 69.808x |
| MetaX C550 | `[32768, 256]` | 0.128768 | 7.069440 | 0.172032 | 41.094x |
| MetaX C550 | `[128, 16, 16, 32] / [32]` | 0.308480 | INVALID | 0.042240 | N/A |

#### bfloat16

| Platform | Input shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---|---:|---:|---:|---:|
| Ascend 910C | `[32768, 128]` | 0.023518 | 0.902797 | 0.020808 | 43.387x |
| Ascend 910C | `[32768, 256]` | 0.036964 | 1.799592 | 0.037646 | 47.803x |
| Ascend 910C | `[128, 16, 16, 32] / [32]` | 0.020033 | INVALID | 0.009511 | N/A |
| Hygon BW1000 | `[32768, 128]` | 0.188960 | 0.528800 | 0.160960 | 3.285x |
| Hygon BW1000 | `[32768, 256]` | 0.251200 | 0.545040 | 0.192640 | 2.829x |
| Hygon BW1000 | `[128, 16, 16, 32] / [32]` | 0.168960 | INVALID | 0.128320 | N/A |
| Moore Threads S5000 | `[32768, 128]` | 0.133160 | 0.655280 | 0.106560 | 6.149x |
| Moore Threads S5000 | `[32768, 256]` | 0.172560 | 0.677280 | 0.202040 | 3.352x |
| Moore Threads S5000 | `[128, 16, 16, 32] / [32]` | 0.101760 | INVALID | 0.056440 | N/A |
| T-Head 810E | `[32768, 128]` | 0.132360 | 0.242120 | 0.059080 | 4.098x |
| T-Head 810E | `[32768, 256]` | 0.141040 | 0.244600 | 0.151600 | 1.613x |
| T-Head 810E | `[128, 16, 16, 32] / [32]` | 0.130200 | INVALID | 0.019920 | N/A |
| MetaX C550 | `[32768, 128]` | 0.125184 | 7.063552 | 0.101376 | 69.677x |
| MetaX C550 | `[32768, 256]` | 0.131328 | 7.145984 | 0.172800 | 41.354x |
| MetaX C550 | `[128, 16, 16, 32] / [32]` | 0.316672 | INVALID | 0.043008 | N/A |

The other higher-rank shape, `[64,16,64,16]` with `normalized_shape=[16]`
(`M=65536, N=16`), remains in the correctness suite. `[32768,257]` also remains
in the benchmark and tests to cover a non-power-of-two tail, but is omitted
from this concise performance table.

The upstream `NormBenchmark` ranges up to `[20,6,65536]` (7.86M elements).
The five added cases contain 1.05M to 8.42M elements, so the maximum is only
about 1.07x the existing upper bound. Their purpose is to change the layout to
large `M` and small-to-medium `N`, not to introduce an oversized stress case.

Two isolated S5000 runs reached a MUSA illegal-memory-access error while the
Official common LayerNorm kernel was autotuning. A later isolated rerun with a
fresh Triton cache, the same Official operator SHA256
`cb0a5cb9f656b210a62e649aa4c690716bbd9d80d800ecd0bc45f1dbc134d843`, and all
three dtypes completed successfully. The failure is therefore treated as an
intermittent autotune/runtime issue; the table uses the successful paired
Official/This-PR run rather than claiming that Official always fails.

### Related Pull Requests

- #5169 owns the standalone MetaX small-normalized-size forward compatibility
  fix. This PR temporarily mirrors that two-dimensional-grid compatibility
  change to preserve the original `N <= 128` branch under CI. #5169 should
  merge first; this PR will then rebase and drop the duplicate forward diff.
- #4903 has merged. Its Ascend-only LayerNorm forward scheduling optimization
  remains independent of this backward PR.

### Previous CI

Previously validated HEAD `62f5c28ac` passed the automatic code-style and unit-test workflow ([run 32712814061](https://github.com/flagos-ai/FlagGems/actions/runs/32712814061)).

| CI target | Full `tests/test_layer_norm.py` | Quick CPU | Benchmark |
|---|---:|---:|---:|
| Common, CANN 8.5, CANN 9.0, Hygon, MetaX 3.7/3.8, THead | 162 passed, 1 skipped | 14 passed, 2 skipped | 4 passed |
| MThreads | 163 passed | 15 passed, 1 skipped | 4 passed |

The backend-only skip is the MThreads dispatch assertion on non-MThreads platforms; the quick-CPU skips are existing backend/device-specific guards.

### September 16 Update

Updated head: `7f97e605a179b3017326f981f0da9e59e49e4df4`.

- Merged master `cb00658bc` and resolved the Ascend heuristic and MThreads export conflicts, preserving additions from both sides.
- The common, MThreads, and MetaX LayerNorm implementation files are byte-identical to approved head `62f5c28ac`. No kernel, launch/tile parameter, device restriction, or tolerance change was introduced by this update.
- Migrated `tests/test_layer_norm.py` to direct public `flag_gems` APIs, removing all `use_gems()` calls. The former autograd integration case now explicitly feeds native forward statistics into `flag_gems.layer_norm_backward` and compares output/gradients with Torch autograd. It is named `test_layer_norm_backward_from_forward` and does not claim dispatcher-autograd coverage.
- Preserved all test dtype/shape/affine/output-mask parametrization.
- The first new CI run exposed missing `for` metadata on the pre-existing `layer_norm` registry entry. Added `for: [native_layer_norm]` in `conf/operators.yaml`; reproduced the schema/ATen checks locally and verified they now pass. This is metadata only and does not change runtime registration.
- Local validation: full PR-file pre-commit, the official forbidden-`use_gems` check, Python syntax, master-relative diff check, and source/export/parametrization audits passed. No new GPU correctness or performance result is claimed; the workflows for this head must be evaluated separately.
- #5169 is still open, so its mirrored MetaX forward compatibility change remains until it lands. The obsolete MACA 3.7.2 trigger failure and the supported MACA 3.8.10 rerun request are documented [there](https://github.com/flagos-ai/FlagGems/pull/5169#issuecomment-5539713350).
