### PR TITLE
[Iluvatar] enable nanmedian radix select and use i32 atomic_min

### DIFF
--- a/src/flag_gems/ops/nanmedian.py
+++ b/src/flag_gems/ops/nanmedian.py
@@ -58,7 +58,7 @@ ASCEND_FLAT_SORT_DTYPES = (
     torch.int16,
     torch.int32,
 )
-IS_NVIDIA_BACKEND = runtime_device.vendor_name == "nvidia"
+USE_RADIX_SELECT = runtime_device.vendor_name in ("nvidia", "iluvatar")
 
 
 def _triton_version_at_least(major, minor):
@@ -778,7 +778,9 @@ def flat_radix_find_index_kernel(
 
         desired = tl.load(state + 0).to(utype)
         keys = _to_order_key(vals, valid)
-        local_idx = tl.min(tl.where(valid & (keys == desired), offsets, N), axis=0)
+        local_idx = tl.min(tl.where(valid & (keys == desired), offsets, N), axis=0).to(
+            tl.int32
+        )
         tl.atomic_min(result_idx, local_idx, sem="relaxed")
 
 
@@ -1036,11 +1038,11 @@ def _nanmedian_dim_impl(inp, dim, keepdim, out=None, use_ascend_float_select=Tru
 
     inp = dim_compress(inp, dim)
     is_cuda = inp.is_cuda
-    is_nvidia = IS_NVIDIA_BACKEND
+    use_radix_select = USE_RADIX_SELECT
     is_ascend = inp.device.type == "npu"
     in_radix_range = MAX_BLOCK_N < N <= LONG_RADIX_REDUCTION_N
     use_cuda_histogram = (
-        is_nvidia
+        use_radix_select
         and is_cuda
         and CUDA_SUPPORTS_MASKED_HISTOGRAM
         and N > MAX_BLOCK_N
@@ -1061,7 +1063,12 @@ def _nanmedian_dim_impl(inp, dim, keepdim, out=None, use_ascend_float_select=Tru
         and in_radix_range
     )
 
-    if is_nvidia and is_cuda and inp.dtype in RADIX_SELECT_DTYPES and in_radix_range:
+    if (
+        use_radix_select
+        and is_cuda
+        and inp.dtype in RADIX_SELECT_DTYPES
+        and in_radix_range
+    ):
         flat_values = values.reshape(M)
         flat_indices = indices.reshape(M)
         block_n = _radix_block_n(inp, N)
@@ -1259,7 +1266,7 @@ def _nanmedian_cuda_flat_radix_select(inp, out=None):
         out = torch.empty((), dtype=flat.dtype, device=flat.device)
     valid_count = torch.empty((), dtype=torch.int64, device=flat.device)
     state = torch.empty((3,), dtype=torch.int64, device=flat.device)
-    result_idx = torch.empty((), dtype=torch.int64, device=flat.device)
+    result_idx = torch.empty((), dtype=torch.int32, device=flat.device)
     block_n = min(triton.next_power_of_2(n), FLAT_RADIX_BLOCK_N)
     grid = (triton.cdiv(n, block_n),)
     nbits = flat.element_size() * 8
@@ -1337,7 +1344,7 @@ def _nanmedian_flat_impl(inp, out=None):
         return result
 
     if (
-        IS_NVIDIA_BACKEND
+        USE_RADIX_SELECT
         and inp.is_cuda
         and inp.dtype in RADIX_SELECT_DTYPES
         and LONG_RADIX_REDUCTION_N < n <= INT32_MAX

--- a/src/flag_gems/ops/nanmedian.py
+++ b/src/flag_gems/ops/nanmedian.py
@@ -72,7 +72,7 @@ ASCEND_FLAT_SORT_DTYPES = (
     torch.int16,
     torch.int32,
 )
-IS_NVIDIA_BACKEND = runtime_device.vendor_name == "nvidia"
+USE_RADIX_SELECT = runtime_device.vendor_name in ("nvidia", "iluvatar")
 
 
 def _triton_version_at_least(major, minor):
@@ -792,7 +792,9 @@ def flat_radix_find_index_kernel(
 
         desired = tl.load(state + 0).to(utype)
         keys = _to_order_key(vals, valid)
-        local_idx = tl.min(tl.where(valid & (keys == desired), offsets, N), axis=0)
+        local_idx = tl.min(tl.where(valid & (keys == desired), offsets, N), axis=0).to(
+            tl.int32
+        )
         tl.atomic_min(result_idx, local_idx, sem="relaxed")
 
 
@@ -1050,11 +1052,11 @@ def _nanmedian_dim_impl(inp, dim, keepdim, out=None, use_ascend_float_select=Tru
 
     inp = dim_compress(inp, dim)
     is_cuda = inp.is_cuda
-    is_nvidia = IS_NVIDIA_BACKEND
+    use_radix_select = USE_RADIX_SELECT
     is_ascend = inp.device.type == "npu"
     in_radix_range = MAX_BLOCK_N < N <= LONG_RADIX_REDUCTION_N
     use_cuda_histogram = (
-        is_nvidia
+        use_radix_select
         and is_cuda
         and CUDA_SUPPORTS_MASKED_HISTOGRAM
         and N > MAX_BLOCK_N
@@ -1075,7 +1077,12 @@ def _nanmedian_dim_impl(inp, dim, keepdim, out=None, use_ascend_float_select=Tru
         and in_radix_range
     )
 
-    if is_nvidia and is_cuda and inp.dtype in RADIX_SELECT_DTYPES and in_radix_range:
+    if (
+        use_radix_select
+        and is_cuda
+        and inp.dtype in RADIX_SELECT_DTYPES
+        and in_radix_range
+    ):
         flat_values = values.reshape(M)
         flat_indices = indices.reshape(M)
         block_n = _radix_block_n(inp, N)
@@ -1273,7 +1280,7 @@ def _nanmedian_cuda_flat_radix_select(inp, out=None):
         out = torch.empty((), dtype=flat.dtype, device=flat.device)
     valid_count = torch.empty((), dtype=torch.int64, device=flat.device)
     state = torch.empty((3,), dtype=torch.int64, device=flat.device)
-    result_idx = torch.empty((), dtype=torch.int64, device=flat.device)
+    result_idx = torch.empty((), dtype=torch.int32, device=flat.device)
     block_n = min(triton.next_power_of_2(n), FLAT_RADIX_BLOCK_N)
     grid = (triton.cdiv(n, block_n),)
     nbits = flat.element_size() * 8
@@ -1351,7 +1358,7 @@ def _nanmedian_flat_impl(inp, out=None):
         return result
 
     if (
-        IS_NVIDIA_BACKEND
+        USE_RADIX_SELECT
         and inp.is_cuda
         and inp.dtype in RADIX_SELECT_DTYPES
         and LONG_RADIX_REDUCTION_N < n <= INT32_MAX


### PR DESCRIPTION
Iluvatar was falling back to kthvalue/topk on large shapes and hanging in benchmark. Enable the CUDA-style radix path for iluvatar, and store flat result_idx as int32 so atomic_min lowers to a supported op. No functional change for NVIDIA: same radix path and n <= INT32_MAX bound; i32 result_idx is equivalent there and typically cheaper.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
