### PR TITLE
Fix adaptive_avg_pool2d wrong result on non-divisible ratios (floor vs ceil window end)

### DIFF
--- a/src/flag_gems/ops/adaptive_avg_pool2d.py
+++ b/src/flag_gems/ops/adaptive_avg_pool2d.py
@@ -68,12 +68,12 @@ def adaptive_avg_pool2d_kernel(
 
     # Adaptive pooling: compute adaptive windows
     # i_start = floor(i * in_h / out_h)
-    # i_end = floor((i + 1) * in_h / out_h)
+    # i_end = ceil((i + 1) * in_h / out_h)
     h_start = h_out_offsets[:, None] * in_h // out_h
-    h_end = ((h_out_offsets[:, None] + 1) * in_h) // out_h
+    h_end = ((h_out_offsets[:, None] + 1) * in_h + out_h - 1) // out_h
 
     w_start = w_out_offsets[None, :] * in_w // out_w
-    w_end = ((w_out_offsets[None, :] + 1) * in_w) // out_w
+    w_end = ((w_out_offsets[None, :] + 1) * in_w + out_w - 1) // out_w
 
     # For the last element, extend to the end of input
     h_end = tl.where(h_out_offsets[:, None] == out_h - 1, in_h, h_end)
@@ -92,8 +92,8 @@ def adaptive_avg_pool2d_kernel(
     input_base_ptr = input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
 
     # Find the maximum window size
-    max_win_h = (in_h + out_h - 1) // out_h
-    max_win_w = (in_w + out_w - 1) // out_w
+    max_win_h = (in_h + out_h - 1) // out_h + 1
+    max_win_w = (in_w + out_w - 1) // out_w + 1
 
     # Loop over all possible positions in the max window
     for kh in range(64):

--- a/tests/test_adaptive_avg_pool2d.py
+++ b/tests/test_adaptive_avg_pool2d.py
@@ -63,3 +63,35 @@ def test_accuracy_adaptive_avg_pool2d_forward(shape, output_size, dtype):
     res_out = flag_gems.adaptive_avg_pool2d(inp, output_size)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# Regression for issue #4915: adaptive_avg_pool2d gave wrong values on
+# non-divisible ratios because the pooling window end was computed with floor
+# instead of PyTorch's ceil, and the fixed tile-loop bound was one row/col too
+# small. Every config above uses exactly divisible sizes, so this path was
+# never covered. Windows here stay well under the kernel's 64-element loop cap.
+ADAPTIVE_AVGPOOL2D_NON_DIVISIBLE_CONFIGS = [
+    ((2, 3, 10, 10), (3, 3)),  # 10/3, the issue's primary repro
+    ((2, 8, 5, 5), (3, 3)),  # 5/3, exercises a q+2 window
+    ((2, 3, 10, 10), (3, 7)),  # H and W non-divisible by different ratios
+    ((4, 3, 7, 9), (3, 4)),  # small, both dims non-divisible
+    ((2, 3, 17, 17), (4, 4)),  # 17/4
+    ((2, 3, 32, 32), (5, 5)),  # 32/5
+    ((1, 4, 224, 224), (13, 13)),  # 224/13, the issue's second repro
+]
+
+
+@pytest.mark.adaptive_avg_pool2d
+@pytest.mark.parametrize("shape, output_size", ADAPTIVE_AVGPOOL2D_NON_DIVISIBLE_CONFIGS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_accuracy_adaptive_avg_pool2d_non_divisible(shape, output_size, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.ops.aten._adaptive_avg_pool2d(ref_inp, output_size)
+    res_out = flag_gems.adaptive_avg_pool2d(inp, output_size)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## PR Category

ops

## Type of Change

Bug Fix

## Description

Fixes #4915.

`adaptive_avg_pool2d` returned wrong values on non-divisible input/output ratios. The Triton kernel computed the pooling window end with floor, but PyTorch/ATen uses ceil, so most windows were one element short and the average was divided by the wrong window size (errors up to ~1.0 on standard-normal inputs, not a precision issue).

The fixed per-window tile-loop bound `max_win_h`/`max_win_w` also needed `+1`: with a ceil end, a window can be one row/col taller than `ceil(in/out)`, so the old bound could drop the last element of some windows.

## Tests

Added `test_accuracy_adaptive_avg_pool2d_non_divisible` with 7 non-divisible configs, including the issue's `10 -> 3` and `224 -> 13` repros and a `5 -> 3` case that exercises the taller window. Every pre-existing config used exactly divisible sizes, so this path was never covered.

Verified on a CI-aligned A100 (torch 2.11 / triton 3.6): the new cases fail before the fix and pass after (default mode 54 passed, quick-cpu 18 passed).

## Known limitation (pre-existing, out of scope)

The inner accumulation loop is hard-bounded at 64 (`for k in range(64)`), so an extreme downsample ratio `in/out` greater than ~63 (e.g. `191 -> 3`, window 65) can still truncate the window. This limit is independent of this fix and is not triggered by normal adaptive-pool usage.
