### PR TITLE
[KMCompiler][Nvidia] Add pairwise_distance operator with triton kernel.

### DIFF
--- a/benchmark/test_pairwise_distance.py
+++ b/benchmark/test_pairwise_distance.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts, utils
+
+
+def composed_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
+    if p == float("inf"):
+        diff = torch.abs(x1 - x2 + eps)
+        return torch.amax(diff, dim=-1, keepdim=keepdim)
+    elif p == float("-inf"):
+        diff = torch.abs(x1 - x2 + eps)
+        return torch.amin(diff, dim=-1, keepdim=keepdim)
+    elif p == 0.0 or p == 1.0 or p == 2.0:
+        return torch.pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
+    else:
+        diff = torch.abs(x1 - x2 + eps)
+        return torch.pow(
+            torch.sum(torch.pow(diff, p), dim=-1, keepdim=keepdim), 1.0 / p
+        ).to(x1.dtype)
+
+
+def pairwise_distance_input_fn(shape, dtype, device):
+    # x1 and x2 must be broadcastable. Use identical (M, N) shapes so that
+    # the op computes one p-distance per row -> M pairs of D-dim vectors,
+    # matching both torch.nn.functional.pairwise_distance and the gems kernel
+    # (which does N, D = x1.shape and reduces over D).
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    inp2 = utils.generate_tensor_input(shape, dtype, device)
+
+    if base.Config.bench_level == consts.BenchLevel.COMPREHENSIVE:
+        # Arbitrary real p is supported; sweep several p values plus eps.
+        for p in (float("-inf"), float("inf"), 0.0, 1.0, 2.0, 6.6):
+            yield inp1, inp2, {"p": p}
+    else:
+        yield inp1, inp2  # default p=2.0
+
+
+class PairwiseDistanceBenchmark(base.GenericBenchmark2DOnly):
+    def set_more_shapes(self):
+        # Keep the parent's large-N 2-D shapes, then add the small-N-large-D
+        # regime: one program per row => few rows => SM underutilization (the
+        # case a 2-D / split-K grid targets). (1, D) is equivalent to a 1-D
+        # single pair here (grid = 1 program).
+        shapes = super().set_more_shapes()
+        shapes += [(1, 65536), (8, 65536), (64, 65536), (1, 10000000)]
+        return shapes
+
+
+@pytest.mark.pairwise_distance
+def test_pairwise_distance():
+    safe_pairwise_distance = torch.pairwise_distance
+    if base.vendor_name == "ascend":
+        safe_pairwise_distance = composed_pairwise_distance
+    bench = PairwiseDistanceBenchmark(
+        op_name="pairwise_distance",
+        input_fn=pairwise_distance_input_fn,
+        torch_op=safe_pairwise_distance,
+        gems_op=flag_gems.pairwise_distance,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_pairwise_distance.py
+++ b/benchmark/test_pairwise_distance.py
@@ -30,12 +30,8 @@ def pairwise_distance_input_fn(shape, dtype, device):
     inp1 = utils.generate_tensor_input(shape, dtype, device)
     inp2 = utils.generate_tensor_input(shape, dtype, device)
 
-    if base.Config.bench_level == consts.BenchLevel.COMPREHENSIVE:
-        # Arbitrary real p is supported; sweep several p values plus eps.
-        for p in (float("-inf"), float("inf"), 0.0, 1.0, 2.0, 6.6):
-            yield inp1, inp2, {"p": p}
-    else:
-        yield inp1, inp2  # default p=2.0
+    for p in (float("-inf"), float("inf"), 0.0, 1.0, 2.0, 6.6):
+        yield inp1, inp2, {"p": p}
 
 
 class PairwiseDistanceBenchmark(base.GenericBenchmark2DOnly):

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6441,6 +6441,20 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '2.1'
+  - id: pairwise_distance
+    description: |
+      Computes the pairwise distance between input vectors, or between columns of input matrices.
+      Distances are computed using p-norm, with constant eps added to avoid division
+      by zero if p is negative.
+    for:
+      - pairwise_distance
+    labels:
+      - aten
+      - nn.functional
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: pdist
     description: |
       Computes the p-norm distance between every pair of row vectors in the input.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -623,6 +623,7 @@ _FULL_CONFIG = (
     ("ones", ones),
     ("ones_like", ones_like),
     ("pad", pad),
+    ("pairwise_distance", pairwise_distance),
     ("pdist", pdist),
     ("permute_copy", permute_copy),
     ("pixel_shuffle", pixel_shuffle),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -425,6 +425,7 @@ from flag_gems.ops.one_hot import one_hot
 from flag_gems.ops.ones import ones
 from flag_gems.ops.ones_like import ones_like
 from flag_gems.ops.pad import constant_pad_nd, pad
+from flag_gems.ops.pairwise_distance import pairwise_distance
 from flag_gems.ops.pdist import pdist
 from flag_gems.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
@@ -1155,6 +1156,7 @@ __all__ = [
     "ones",
     "ones_like",
     "pad",
+    "pairwise_distance",
     "pdist",
     "per_token_group_quant_fp8",
     "permute_copy",

--- a/src/flag_gems/ops/pairwise_distance.py
+++ b/src/flag_gems/ops/pairwise_distance.py
@@ -1,0 +1,428 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner, tl_extra_shim
+
+# x ** p is decomposed as exp2(p * log2(x)): tl_extra_shim.pow is too heavy
+exp2 = tl_extra_shim.exp2
+log2 = tl_extra_shim.log2
+logger = logging.getLogger(__name__)
+
+
+PAIRWISE_DISTANCE_CONFIGS = runtime.get_tuned_config("pairwise_distance")
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_general_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, p, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0), axis=1)
+    dist = exp2((1.0 / p) * log2(acc))
+    tl.store(out_ptr + pid, dist[:, None], row_mask)
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_p2_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, (diff * diff), 0.0), axis=1)
+
+    dist = tl.sqrt(acc)
+    tl.store(out_ptr + pid, dist[:, None], row_mask)
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_p1_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, diff, 0.0), axis=1)
+
+    tl.store(out_ptr + pid, acc[:, None], row_mask)
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_p0_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, (diff != 0).to(tl.float32), 0.0), axis=1)
+
+    tl.store(out_ptr + pid, acc[:, None], row_mask)
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_max_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    row_mask = pid < N
+    max_val = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        max_val = tl.maximum(
+            max_val, tl.max(tl.where(mask, diff, -float("inf")), axis=1)
+        )
+    tl.store(out_ptr + pid, max_val[:, None], row_mask)
+
+
+@libentry()
+@libtuner(configs=PAIRWISE_DISTANCE_CONFIGS, key=["D"])
+@triton.jit
+def pairwise_distance_min_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    min_val = tl.full([BLOCK_M], float("inf"), tl.float32)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        diff = tl.abs(a - b + eps)
+        min_val = tl.minimum(
+            min_val, tl.min(tl.where(mask, diff, float("inf")), axis=1)
+        )
+    tl.store(out_ptr + pid, min_val[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p2_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, diff * diff, 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p2_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sqrt(tl.sum(mid))
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p1_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, diff, 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p1_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sum(mid)
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p0_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, (diff != 0).to(tl.float32), 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p0_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sum(mid)
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_general_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_general_kernel_2(
+    mid_ptr, out_ptr, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = exp2((1 / p) * log2(tl.sum(mid)))
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_max_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.max(tl.where(mask, diff, -float("inf")))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_max_kernel_2(
+    mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    max_val = tl.max(tl.where(mask, mid, -float("inf")))
+
+    tl.store(out_ptr + pid, max_val)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_min_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    diff = tl.abs(a - b + eps)
+    mid = tl.min(tl.where(mask, diff, float("inf")))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_min_kernel_2(
+    mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    min_val = tl.min(tl.where(mask, mid, float("inf")))
+
+    tl.store(out_ptr + pid, min_val)
+
+
+def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
+    logger.debug("GEMS PAIRWISE_DISTANCE")
+    if x1.shape != x2.shape:
+        x1, x2 = torch.broadcast_tensors(x1, x2)
+    if not x1.is_contiguous():
+        x1 = x1.contiguous()
+    if not x2.is_contiguous():
+        x2 = x2.contiguous()
+    D = x1.shape[-1]
+
+    # Empty feature dim: torch returns 0 for finite p; inf/-inf have no identity
+    # element over an empty reduction and torch raises. Short-circuit here to
+    # also avoid the ZeroDivisionError in the split-K plumbing (BLOCK_SIZE == 0).
+    if D == 0:
+        if p == float("inf") or p == float("-inf"):
+            raise RuntimeError(
+                "pairwise_distance cannot compute the inf/-inf norm on an empty "
+                "reduction dimension (no identity element)"
+            )
+        out = torch.zeros(x1.shape[:-1], device=x1.device, dtype=x1.dtype)
+        if keepdim:
+            out = out.unsqueeze(-1)
+        return out
+
+    N = x1.numel() // D
+    out = torch.empty(x1.shape[:-1], device=x1.device, dtype=x1.dtype)
+    if keepdim:
+        out = out.unsqueeze(-1)
+
+    with torch_device_fn.device(x1.device):
+        grid = lambda meta: (triton.cdiv(N, meta["BLOCK_M"]),)
+
+        BLOCK_SIZE = min(triton.next_power_of_2(D), 4096)
+        MID_SIZE = triton.cdiv(D, BLOCK_SIZE)
+        use_split_k = (N <= 128) and (MID_SIZE >= 2)
+
+        if p == 2.0:
+            if not use_split_k:
+                pairwise_distance_p2_kernel[grid](x1, x2, out, N, D, eps)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_p2_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p2_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+        elif p == 1.0:
+            if not use_split_k:
+                pairwise_distance_p1_kernel[grid](x1, x2, out, N, D, eps)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_p1_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p1_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+        elif p == 0.0:
+            if not use_split_k:
+                pairwise_distance_p0_kernel[grid](x1, x2, out, N, D, eps)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_p0_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p0_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+        elif p == float("inf"):
+            if not use_split_k:
+                pairwise_distance_max_kernel[grid](x1, x2, out, N, D, eps)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_max_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_max_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+        elif p == float("-inf"):
+            if not use_split_k:
+                pairwise_distance_min_kernel[grid](x1, x2, out, N, D, eps)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_min_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_min_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+        else:
+            if not use_split_k:
+                pairwise_distance_general_kernel[grid](x1, x2, out, N, D, eps, p)
+            else:
+                BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                pairwise_distance_general_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, p, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_general_kernel_2[(N,)](
+                    mid, out, p, MID_SIZE, BLOCK_MID
+                )
+
+    return out

--- a/src/flag_gems/ops/pairwise_distance.py
+++ b/src/flag_gems/ops/pairwise_distance.py
@@ -23,15 +23,17 @@ PAIRWISE_DISTANCE_CONFIGS = runtime.get_tuned_config("pairwise_distance")
 def pairwise_distance_general_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, p, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
     row_mask = pid < N
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
         acc += tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0), axis=1)
     dist = exp2((1.0 / p) * log2(acc))
@@ -44,15 +46,16 @@ def pairwise_distance_general_kernel(
 def pairwise_distance_p2_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
     row_mask = pid < N
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
         acc += tl.sum(tl.where(mask, (diff * diff), 0.0), axis=1)
 
@@ -66,15 +69,16 @@ def pairwise_distance_p2_kernel(
 def pairwise_distance_p1_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
     row_mask = pid < N
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
         acc += tl.sum(tl.where(mask, diff, 0.0), axis=1)
 
@@ -87,17 +91,18 @@ def pairwise_distance_p1_kernel(
 def pairwise_distance_p0_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
     row_mask = pid < N
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
-        acc += tl.sum(tl.where(mask, (diff != 0).to(tl.float32), 0.0), axis=1)
+        acc += tl.sum(tl.where(mask, (diff != 0).to(acc_dtype), 0.0), axis=1)
 
     tl.store(out_ptr + pid, acc[:, None], row_mask)
 
@@ -108,15 +113,16 @@ def pairwise_distance_p0_kernel(
 def pairwise_distance_max_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     row_mask = pid < N
-    max_val = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    max_val = tl.full([BLOCK_M], -float("inf"), acc_dtype)
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
         max_val = tl.maximum(
             max_val, tl.max(tl.where(mask, diff, -float("inf")), axis=1)
@@ -130,15 +136,16 @@ def pairwise_distance_max_kernel(
 def pairwise_distance_min_kernel(
     x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    min_val = tl.full([BLOCK_M], float("inf"), tl.float32)
+    min_val = tl.full([BLOCK_M], float("inf"), acc_dtype)
     row_mask = pid < N
     for start in range(0, D, BLOCK_D):
         cols = start + tl.arange(0, BLOCK_D)[None, :]
         col_mask = cols < D
         mask = row_mask & col_mask
-        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
-        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(tl.float32)
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
         diff = tl.abs(a - b + eps)
         min_val = tl.minimum(
             min_val, tl.min(tl.where(mask, diff, float("inf")), axis=1)
@@ -151,13 +158,14 @@ def pairwise_distance_min_kernel(
 def pairwise_distance_p2_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
     mid = tl.sum(tl.where(mask, diff * diff, 0.0))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
@@ -180,13 +188,14 @@ def pairwise_distance_p2_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.con
 def pairwise_distance_p1_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
     mid = tl.sum(tl.where(mask, diff, 0.0))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
@@ -209,15 +218,16 @@ def pairwise_distance_p1_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.con
 def pairwise_distance_p0_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
-    mid = tl.sum(tl.where(mask, (diff != 0).to(tl.float32), 0.0))
+    mid = tl.sum(tl.where(mask, (diff != 0).to(acc_dtype), 0.0))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
 
 
@@ -238,13 +248,15 @@ def pairwise_distance_p0_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.con
 def pairwise_distance_general_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
     mid = tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
@@ -255,6 +267,8 @@ def pairwise_distance_general_kernel_1(
 def pairwise_distance_general_kernel_2(
     mid_ptr, out_ptr, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if mid_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
     pid = tl.program_id(0)
     offset = tl.arange(0, BLOCK_SIZE)
     mask = offset < MID_SIZE
@@ -269,13 +283,14 @@ def pairwise_distance_general_kernel_2(
 def pairwise_distance_max_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
     mid = tl.max(tl.where(mask, diff, -float("inf")))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
@@ -300,13 +315,14 @@ def pairwise_distance_max_kernel_2(
 def pairwise_distance_min_kernel_1(
     x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
 ):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
     pid_n = tl.program_id(0)
     pid_d = tl.program_id(1)
     offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     base = pid_n * D
     mask = offset < D
-    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
-    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(tl.float32)
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
     diff = tl.abs(a - b + eps)
     mid = tl.min(tl.where(mask, diff, float("inf")))
     tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
@@ -354,6 +370,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
     out = torch.empty(x1.shape[:-1], device=x1.device, dtype=x1.dtype)
     if keepdim:
         out = out.unsqueeze(-1)
+    mid_dtype = torch.float64 if x1.dtype == torch.float64 else torch.float32
 
     with torch_device_fn.device(x1.device):
         grid = lambda meta: (triton.cdiv(N, meta["BLOCK_M"]),)
@@ -367,7 +384,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_p2_kernel[grid](x1, x2, out, N, D, eps)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_p2_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
                 )
@@ -377,7 +394,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_p1_kernel[grid](x1, x2, out, N, D, eps)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_p1_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
                 )
@@ -387,7 +404,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_p0_kernel[grid](x1, x2, out, N, D, eps)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_p0_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
                 )
@@ -397,7 +414,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_max_kernel[grid](x1, x2, out, N, D, eps)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_max_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
                 )
@@ -407,7 +424,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_min_kernel[grid](x1, x2, out, N, D, eps)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_min_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
                 )
@@ -417,7 +434,7 @@ def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
                 pairwise_distance_general_kernel[grid](x1, x2, out, N, D, eps, p)
             else:
                 BLOCK_MID = triton.next_power_of_2(MID_SIZE)
-                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=torch.float32)
+                mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
                 pairwise_distance_general_kernel_1[(N, MID_SIZE)](
                     x1, x2, mid, D, eps, p, MID_SIZE, BLOCK_SIZE
                 )

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -2574,6 +2574,39 @@ fused_marlin_moe_mxfp4_gemm_silu:
     num_stages: 3
     maxnreg: 255
 
+pairwise_distance:
+  - gen: true
+    param_map:
+      META: {BLOCK_M: block_m, BLOCK_D: block_d}
+      num_warps: 4
+    block_m: [16, 32]
+    block_d: [1]
+  - gen: true
+    param_map:
+      META: {BLOCK_M: block_m, BLOCK_D: block_d}
+      num_warps: 4
+    block_m: [16]
+    block_d: [2, 4, 8]
+  - gen: true
+    param_map:
+      META: {BLOCK_M: block_m, BLOCK_D: block_d}
+      num_warps: warps
+    block_m: [4, 8]
+    block_d: [128, 256]
+    warps: [4, 8]
+  - gen: true
+    param_map:
+      META: {BLOCK_M: block_m, BLOCK_D: block_d}
+      num_warps: 4
+    block_m: [16]
+    block_d: [64, 128, 256]
+  - gen: true
+    param_map:
+      META: {BLOCK_M: block_m, BLOCK_D: block_d}
+      num_warps: 8
+    block_m: [1, 4, 8]
+    block_d: [1024, 4096]
+
 w8a8_block_fp8_bmm:
   - gen: true
     param_map:

--- a/tests/test_pairwise_distance.py
+++ b/tests/test_pairwise_distance.py
@@ -1,0 +1,177 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+
+def composed_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
+    """NPU-native pairwise_distance via basic torch ops (sub+abs+pow+sum).
+    Supports arbitrary p, unlike torch_npu's LpNormV2 which only accepts {0,1,2}.
+    Used as the reference when aten would crash on p not in {0,1,2,inf,-inf}."""
+    diff = torch.abs(x1 - x2 + eps)
+    if p == float("inf"):
+        return torch.amax(diff, dim=-1, keepdim=keepdim)
+    elif p == float("-inf"):
+        return torch.amin(diff, dim=-1, keepdim=keepdim)
+    elif p == 0.0:
+        return torch.sum(diff != 0, dim=-1, keepdim=keepdim, dtype=torch.float32).to(
+            x1.dtype
+        )
+    else:
+        return torch.pow(
+            torch.sum(torch.pow(diff, p), dim=-1, keepdim=keepdim), 1.0 / p
+        ).to(x1.dtype)
+
+
+# torch_npu's native pairwise_distance only supports p in {0, 1, 2} -- inf,
+# -inf, and arbitrary real p all crash (core dump). When the reference runs on
+# NPU (not CPU), use the composed version for any p outside {0, 1, 2}.
+_ATEN_SUPPORTED_P = (0.0, 1.0, 2.0)
+
+
+def _ref_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
+    if not cfg.TO_CPU and p not in _ATEN_SUPPORTED_P:
+        return composed_pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
+    return torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
+
+
+# torch.nn.functional.pairwise_distance computes ||x1 - x2 + eps||_p and accepts
+# any real p, including inf / -inf / 0. The gems kernel is expected to match torch
+# for all of these (inf -> max|diff|, -inf -> min|diff|, 0 -> nonzero count).
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    P_LIST = [2.0]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    P_LIST = [-1.1, 0, 1.0, 1.5, 2.0, 4.3]
+
+SHAPES = [
+    (7,),  # 1-D: a single pair of D-dim vectors -> scalar output
+    (64, 64),
+    (1024, 257),
+    (1, 10000000),
+    (8, 8192),
+    (64, 65536),
+    (100, 5000),
+    (128, 4097),
+]
+
+
+@pytest.mark.pairwise_distance
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("p", P_LIST + [float("inf"), float("-inf")])
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pairwise_distance_accuracy(shape, p, keepdim, dtype):
+    torch.manual_seed(0)
+    x1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x1 = utils.to_reference(x1, True)
+    ref_x2 = utils.to_reference(x2, True)
+
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.pairwise_distance(
+            x1, x2, p=p, eps=1e-6, keepdim=keepdim
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# (x1_shape, x2_shape) pairs exercising broadcasting: torch broadcasts x2 against
+# x1 before reducing over the last dim. Requires the op to broadcast internally.
+BROADCAST_SHAPES = [
+    ((4,), (1,)),  # 1-D vs single-element vector (e.g. [1,2,4,100] vs [3])
+    ((4,), (4,)),  # no broadcast (sanity)
+    ((3, 4), (4,)),  # 2-D vs trailing 1-D
+    ((3, 4), (1, 4)),  # 2-D vs row-broadcast
+    ((2, 8), (1,)),  # 2-D vs scalar-vector
+]
+
+
+@pytest.mark.pairwise_distance
+@pytest.mark.parametrize("x1_shape, x2_shape", BROADCAST_SHAPES)
+@pytest.mark.parametrize("p", P_LIST)
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pairwise_distance_broadcast(x1_shape, x2_shape, p, keepdim, dtype):
+    torch.manual_seed(0)
+    x1 = torch.randn(x1_shape, dtype=dtype, device=flag_gems.device)
+    x2 = torch.randn(x2_shape, dtype=dtype, device=flag_gems.device)
+    ref_x1 = utils.to_reference(x1, True)
+    ref_x2 = utils.to_reference(x2, True)
+
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.pairwise_distance(
+            x1, x2, p=p, eps=1e-6, keepdim=keepdim
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# ndim >= 3: torch reduces over the LAST dim and returns shape[:-1]
+# (shape[:-1] + (1,) with keepdim). The kernel must treat every leading dim as
+# batch rows (N = numel // D), not collapse the whole tensor to a single pair.
+NDIM_GE3_SHAPES = [
+    (2, 3, 4),  # 3-D -> out (2, 3)
+    (4, 8, 16),  # 3-D, larger
+    (2, 3, 4, 5),  # 4-D -> out (2, 3, 4)
+]
+
+
+@pytest.mark.pairwise_distance
+@pytest.mark.parametrize("shape", NDIM_GE3_SHAPES)
+@pytest.mark.parametrize("p", P_LIST)
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pairwise_distance_ndim3plus(shape, p, keepdim, dtype):
+    torch.manual_seed(0)
+    x1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x1 = utils.to_reference(x1, True)
+    ref_x2 = utils.to_reference(x2, True)
+
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.pairwise_distance(
+            x1, x2, p=p, eps=1e-6, keepdim=keepdim
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# Broadcasting where the broadcast result is ndim >= 3: x2 is broadcast against
+# x1 to a 3-D/4-D shape, then reduced over the last dim. Exercises the broadcast
+# path and the multi-row (numel // D) path together.
+BROADCAST_NDIM3_SHAPES = [
+    ((2, 3, 4), (3, 4)),  # -> out (2, 3)
+    ((2, 3, 4), (4,)),  # -> out (2, 3)
+    ((2, 3, 4), (1,)),  # -> out (2, 3)
+    ((2, 3, 4, 5), (4, 5)),  # -> out (2, 3, 4)
+    ((2, 3, 4, 5), (5,)),  # -> out (2, 3, 4)
+]
+
+
+@pytest.mark.pairwise_distance
+@pytest.mark.parametrize("x1_shape, x2_shape", BROADCAST_NDIM3_SHAPES)
+@pytest.mark.parametrize("p", P_LIST)
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pairwise_distance_broadcast_ndim3plus(x1_shape, x2_shape, p, keepdim, dtype):
+    torch.manual_seed(0)
+    x1 = torch.randn(x1_shape, dtype=dtype, device=flag_gems.device)
+    x2 = torch.randn(x2_shape, dtype=dtype, device=flag_gems.device)
+    ref_x1 = utils.to_reference(x1, True)
+    ref_x2 = utils.to_reference(x2, True)
+
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.pairwise_distance(
+            x1, x2, p=p, eps=1e-6, keepdim=keepdim
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_pairwise_distance.py
+++ b/tests/test_pairwise_distance.py
@@ -46,17 +46,14 @@ if cfg.QUICK_MODE:
     P_LIST = [2.0]
 else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
-    P_LIST = [-1.1, 0, 1.0, 1.5, 2.0, 4.3]
+    P_LIST = [0, 1.0, 1.5, 2.0]
 
 SHAPES = [
     (7,),  # 1-D: a single pair of D-dim vectors -> scalar output
     (64, 64),
     (1024, 257),
+    (64, 65536),  # split-K (small N, large D)
     (1, 10000000),
-    (8, 8192),
-    (64, 65536),
-    (100, 5000),
-    (128, 4097),
 ]
 
 
@@ -84,31 +81,26 @@ def test_pairwise_distance_accuracy(shape, p, keepdim, dtype):
 # (x1_shape, x2_shape) pairs exercising broadcasting: torch broadcasts x2 against
 # x1 before reducing over the last dim. Requires the op to broadcast internally.
 BROADCAST_SHAPES = [
-    ((4,), (1,)),  # 1-D vs single-element vector (e.g. [1,2,4,100] vs [3])
-    ((4,), (4,)),  # no broadcast (sanity)
+    ((4,), (1,)),  # 1-D vs single-element vector
     ((3, 4), (4,)),  # 2-D vs trailing 1-D
     ((3, 4), (1, 4)),  # 2-D vs row-broadcast
-    ((2, 8), (1,)),  # 2-D vs scalar-vector
 ]
 
 
 @pytest.mark.pairwise_distance
 @pytest.mark.parametrize("x1_shape, x2_shape", BROADCAST_SHAPES)
 @pytest.mark.parametrize("p", P_LIST)
-@pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_pairwise_distance_broadcast(x1_shape, x2_shape, p, keepdim, dtype):
+def test_pairwise_distance_broadcast(x1_shape, x2_shape, p, dtype):
     torch.manual_seed(0)
     x1 = torch.randn(x1_shape, dtype=dtype, device=flag_gems.device)
     x2 = torch.randn(x2_shape, dtype=dtype, device=flag_gems.device)
     ref_x1 = utils.to_reference(x1, True)
     ref_x2 = utils.to_reference(x2, True)
 
-    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6)
     with flag_gems.use_gems():
-        res_out = torch.nn.functional.pairwise_distance(
-            x1, x2, p=p, eps=1e-6, keepdim=keepdim
-        )
+        res_out = torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=1e-6)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
 
@@ -118,7 +110,6 @@ def test_pairwise_distance_broadcast(x1_shape, x2_shape, p, keepdim, dtype):
 # batch rows (N = numel // D), not collapse the whole tensor to a single pair.
 NDIM_GE3_SHAPES = [
     (2, 3, 4),  # 3-D -> out (2, 3)
-    (4, 8, 16),  # 3-D, larger
     (2, 3, 4, 5),  # 4-D -> out (2, 3, 4)
 ]
 
@@ -126,20 +117,17 @@ NDIM_GE3_SHAPES = [
 @pytest.mark.pairwise_distance
 @pytest.mark.parametrize("shape", NDIM_GE3_SHAPES)
 @pytest.mark.parametrize("p", P_LIST)
-@pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_pairwise_distance_ndim3plus(shape, p, keepdim, dtype):
+def test_pairwise_distance_ndim3plus(shape, p, dtype):
     torch.manual_seed(0)
     x1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     x2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x1 = utils.to_reference(x1, True)
     ref_x2 = utils.to_reference(x2, True)
 
-    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6)
     with flag_gems.use_gems():
-        res_out = torch.nn.functional.pairwise_distance(
-            x1, x2, p=p, eps=1e-6, keepdim=keepdim
-        )
+        res_out = torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=1e-6)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
 
@@ -148,30 +136,50 @@ def test_pairwise_distance_ndim3plus(shape, p, keepdim, dtype):
 # x1 to a 3-D/4-D shape, then reduced over the last dim. Exercises the broadcast
 # path and the multi-row (numel // D) path together.
 BROADCAST_NDIM3_SHAPES = [
-    ((2, 3, 4), (3, 4)),  # -> out (2, 3)
-    ((2, 3, 4), (4,)),  # -> out (2, 3)
-    ((2, 3, 4), (1,)),  # -> out (2, 3)
-    ((2, 3, 4, 5), (4, 5)),  # -> out (2, 3, 4)
-    ((2, 3, 4, 5), (5,)),  # -> out (2, 3, 4)
+    ((2, 3, 4), (3, 4)),  # 3-D broadcast -> out (2, 3)
+    ((2, 3, 4, 5), (5,)),  # 4-D broadcast -> out (2, 3, 4)
 ]
 
 
 @pytest.mark.pairwise_distance
 @pytest.mark.parametrize("x1_shape, x2_shape", BROADCAST_NDIM3_SHAPES)
 @pytest.mark.parametrize("p", P_LIST)
-@pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_pairwise_distance_broadcast_ndim3plus(x1_shape, x2_shape, p, keepdim, dtype):
+def test_pairwise_distance_broadcast_ndim3plus(x1_shape, x2_shape, p, dtype):
     torch.manual_seed(0)
     x1 = torch.randn(x1_shape, dtype=dtype, device=flag_gems.device)
     x2 = torch.randn(x2_shape, dtype=dtype, device=flag_gems.device)
     ref_x1 = utils.to_reference(x1, True)
     ref_x2 = utils.to_reference(x2, True)
 
-    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6, keepdim=keepdim)
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6)
     with flag_gems.use_gems():
-        res_out = torch.nn.functional.pairwise_distance(
-            x1, x2, p=p, eps=1e-6, keepdim=keepdim
-        )
+        res_out = torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=1e-6)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# float64 accuracy: verify fp64 inputs are accumulated in fp64 (not silently
+# downcast to fp32, which would lose ~9 digits of precision). Covers fast paths
+# (p=2/1/inf/-inf) + a general p (1.5), on a per-row and a split-K shape.
+FP64_P_LIST = [2.0, 1.0, 1.5, float("inf"), float("-inf")]
+FP64_SHAPES = [(64, 257), (8, 65536)]
+
+
+@pytest.mark.pairwise_distance
+@pytest.mark.parametrize("shape", FP64_SHAPES)
+@pytest.mark.parametrize("p", FP64_P_LIST)
+def test_pairwise_distance_fp64(shape, p):
+    if not utils.fp64_is_supported:
+        pytest.skip("fp64 not supported on this device")
+    torch.manual_seed(0)
+    x1 = torch.randn(shape, dtype=torch.float64, device=flag_gems.device)
+    x2 = torch.randn(shape, dtype=torch.float64, device=flag_gems.device)
+    ref_x1 = utils.to_reference(x1, True)
+    ref_x2 = utils.to_reference(x2, True)
+
+    ref_out = _ref_pairwise_distance(ref_x1, ref_x2, p=p, eps=1e-6)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=1e-6)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float64)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Other

### Description
Add pairwise_distance operator with triton kernel.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.5.0, anyio-4.12.1, hypothesis-6.130.8, flakefinder-1.1.0, rerunfailures-16.1, shard-0.1.2, xdist-3.8.0
collected 1 item
Running 1 items in this shard

benchmark/test_pairwise_distance.py 
Operator: pairwise_distance  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.010688            0.005312               2.012          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.010720            0.005216               2.055          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.009568            0.005120               1.869          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.009600            0.005344               1.796          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.009600            0.005376               1.786          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.011360            0.005600               2.029          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.010208            0.005440               1.876          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.010752            0.005472               1.965          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.010688            0.005536               1.931          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.011648            0.005696               2.045          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.011680            0.005664               2.062          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.013360            0.005792               2.307          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.014592            0.007712               1.892          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.015104            0.007552               2.000          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.015008            0.007552               1.987          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.015968            0.007744               2.062          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.015968            0.007552               2.114          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.021728            0.009216               2.358          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.069344            0.025728               2.695          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.069312            0.025888               2.677          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.069920            0.025888               2.701          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.069920            0.025760               2.714          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.069888            0.025824               2.706          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               0.148176            0.045888               3.229          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               0.277408            0.080032               3.466          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               0.294112            0.080224               3.666          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               0.272224            0.081232               3.351          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               0.273120            0.079744               3.425          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               0.257408            0.080288               3.206          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               0.494416            0.171440               2.884          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.011008            0.005184               2.123          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.011040            0.005184               2.130          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.011680            0.005376               2.173          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.010048            0.005376               1.869          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.009600            0.005216               1.840          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.009984            0.005344               1.868          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.022272            0.009184               2.425          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.021440            0.008992               2.384          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.021216            0.011072               1.916          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.022176            0.009248               2.398          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.022272            0.008992               2.477          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.034272            0.013312               2.575          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS               2.266848            0.660032               3.434          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS               2.244288            0.677504               3.313          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS               2.219456            0.635328               3.493          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS               2.202112            0.634048               3.473          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS               2.212832            0.633632               3.492          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS               4.474624            1.508448               2.966          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.016352            0.019296               0.847          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.017344            0.018432               0.941          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.015616            0.018304               0.853          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.015552            0.017984               0.865          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.016864            0.017856               0.944          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.040320            0.020224               1.994          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.018368            0.018496               0.993          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.019328            0.018320               1.055          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.019104            0.017984               1.062          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.018848            0.017760               1.061          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.019040            0.017536               1.086          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.042464            0.020896               2.032          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.026944            0.018656               1.444          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.029472            0.018528               1.591          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.027008            0.018432               1.465          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.027936            0.017632               1.584          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.026944            0.017568               1.534          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.052512            0.020544               2.556          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.045792            0.020672               2.215          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.046208            0.021024               2.198          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.045216            0.021088               2.144          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.044032            0.021344               2.063          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.043840            0.021440               2.045          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.087008            0.029888               2.911          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})


Operator: pairwise_distance  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.010752            0.005184               2.074          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.010784            0.005184               2.080          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.009792            0.005216               1.877          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.009376            0.005184               1.809          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.009408            0.005280               1.782          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.010048            0.005632               1.784          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.010816            0.005824               1.857          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.010816            0.005664               1.910          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.011776            0.005856               2.011          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.011776            0.005632               2.091          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.010304            0.005664               1.819          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.011936            0.006016               1.984          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.019008            0.008736               2.176          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.019008            0.008768               2.168          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.017824            0.008768               2.033          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.017824            0.008576               2.078          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.016416            0.008576               1.914          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.024736            0.009856               2.510          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.112800            0.042912               2.629          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.114176            0.043456               2.627          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.112608            0.044160               2.550          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.113984            0.043840               2.600          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.112608            0.044064               2.556          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               0.187168            0.056832               3.293          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               0.434336            0.145408               2.987          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               0.559104            0.145888               3.832          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               0.410144            0.143168               2.865          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               0.436192            0.142752               3.056          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               0.432160            0.143328               3.015          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               0.713792            0.231168               3.088          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.009248            0.005216               1.773          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.009696            0.005376               1.804          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.009920            0.005376               1.845          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.009696            0.005376               1.804          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.010624            0.005216               2.037          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.009248            0.005536               1.671          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.028768            0.023456               1.226          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.027744            0.012576               2.206          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.025440            0.023456               1.085          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.025824            0.012704               2.033          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.027936            0.012576               2.221          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.041536            0.016288               2.550          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS               3.922480            1.231616               3.185          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS               3.925040            1.231168               3.188          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS               3.902304            1.227104               3.180          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS               3.757280            1.226304               3.064          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS               3.899328            1.225088               3.183          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS               6.192944            1.886752               3.282          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.016864            0.018720               0.901          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.016896            0.018784               0.899          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.016384            0.017856               0.918          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.016320            0.017472               0.934          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.017216            0.017760               0.969          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.038944            0.020640               1.887          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.019744            0.018720               1.055          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.019264            0.017792               1.083          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.020192            0.017632               1.145          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.018752            0.017600               1.065          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.020192            0.010720               1.884          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.041824            0.011392               3.671          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.038848            0.018592               2.090          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.036768            0.018976               1.938          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.037216            0.019712               1.888          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.038400            0.019200               2.000          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.038400            0.018720               2.051          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.059040            0.024512               2.409          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.075712            0.032480               2.331          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.075936            0.032544               2.333          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.079168            0.034368               2.304          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.076560            0.033696               2.272          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.076448            0.032672               2.340          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.112512            0.043008               2.616          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})


Operator: pairwise_distance  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.009664            0.005344               1.808          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.009696            0.005056               1.918          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.010688            0.005312               2.012          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.009696            0.005312               1.825          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.010688            0.005056               2.114          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.009968            0.005376               1.854          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.010240            0.005632               1.818          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.011680            0.005632               2.074          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.010176            0.005440               1.871          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.010656            0.005632               1.892          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.010688            0.005440               1.965          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.012320            0.005664               2.175          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.015008            0.007680               1.954          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.016096            0.007712               2.087          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.016000            0.007680               2.083          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.015936            0.007648               2.084          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.015936            0.007680               2.075          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.020384            0.009472               2.152          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.070176            0.028416               2.470          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.071232            0.027808               2.562          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.069344            0.026144               2.652          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.069536            0.025824               2.693          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.068416            0.025984               2.633          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               0.148096            0.047968               3.087          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               0.243968            0.082912               2.942          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               0.244384            0.082688               2.955          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               0.242176            0.081760               2.962          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               0.242816            0.078912               3.077          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               0.244192            0.080832               3.021          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               0.500096            0.170560               2.932          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.009504            0.005280               1.800          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.010880            0.005280               2.061          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.010752            0.005152               2.087          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.009504            0.005152               1.845          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.009824            0.005344               1.838          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.010912            0.005504               1.983          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.021536            0.008992               2.395          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.021536            0.009152               2.353          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.020576            0.008992               2.288          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.020384            0.008960               2.275          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.020576            0.008992               2.288          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.034048            0.013568               2.509          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS               4.757088            0.631888               7.528          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS               4.853824            0.749152               6.479          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS               2.207680            0.606752               3.639          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS               4.748368            0.622272               7.631          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS               2.111584            0.609088               3.467          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS              12.467248            4.334800               2.876          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.016352            0.007584               2.156          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.016512            0.007648               2.159          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.015968            0.007328               2.179          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.015776            0.008096               1.949          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.015808            0.008128               1.945          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.039424            0.008800               4.480          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.018304            0.008544               2.142          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.017920            0.008544               2.097          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.019040            0.008384               2.271          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.018848            0.008960               2.104          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.017408            0.008992               1.936          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.041632            0.009856               4.224          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.027040            0.013344               2.026          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.029536            0.014336               2.060          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.029248            0.013888               2.106          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.029024            0.014048               2.066          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.027040            0.013984               1.934          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.051840            0.018624               2.784          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.047136            0.020544               2.294          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.047040            0.020544               2.290          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.044320            0.021184               2.092          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.043968            0.022208               1.980          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.043904            0.022336               1.966          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.087168            0.031168               2.797          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})

.

======================== 1 passed in 348.33s (0:05:48) =========================

```
