### PR TITLE
fix(group_norm): mask padding lanes when group size is not a power of two

### DIFF
--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -50,10 +50,12 @@ def group_norm_kernel(
     hw_offset = tl.arange(0, BLOCK_HW_SIZE)
 
     wb_offset = group * group_size + group_offset
-    wb_mask = wb_offset < C
+    # BLOCK_GROUP_SIZE is group_size rounded up to a power of two, so the tail
+    # lanes address channels of the *next* group: mask on group_size, not on C.
+    wb_mask = (group_offset < group_size) & (wb_offset < C)
 
     xy_offset = pid * num_elements + group_offset[:, None] * HW + hw_offset[None, :]
-    xy_mask = wb_offset[:, None] < C and hw_offset[None, :] < HW
+    xy_mask = wb_mask[:, None] & (hw_offset[None, :] < HW)
 
     Mean_ptr = Mean + pid
     Rstd_ptr = Rstd + pid
@@ -107,7 +109,9 @@ def group_norm_backward_kernel(
     group_offset = tl.arange(0, BLOCK_GROUP_SIZE)
     wb_offset = group * group_size + group_offset
 
-    wb_mask = wb_offset < C
+    # See group_norm_kernel: the padding lanes of BLOCK_GROUP_SIZE fall inside
+    # the next group, so bounding by C alone lets them through.
+    wb_mask = (group_offset < group_size) & (wb_offset < C)
 
     rstd = tl.load(Rstd + pid).to(tl.float32)
     mean = tl.load(Mean + pid).to(tl.float32)

--- a/tests/test_group_norm.py
+++ b/tests/test_group_norm.py
@@ -37,6 +37,10 @@ else:
         (1, 64, 32, 32, 16),
         (1, 64, 32, 32, 32),
         (1, 64, 32, 32, 64),
+        # group sizes that are not a power of two
+        (1, 48, 32, 32, 16),  # group_size = 3
+        (4, 24, 16, 16, 4),  # group_size = 6
+        (2, 60, 8, 8, 12),  # group_size = 5
     ],
 )
 @pytest.mark.parametrize("wb_none", [False, True])
@@ -82,6 +86,10 @@ def test_group_norm(N, C, H, W, num_groups, dtype, wb_none):
         (1, 64, 32, 32, 16),
         (1, 64, 32, 32, 32),
         (1, 64, 32, 32, 64),
+        # group sizes that are not a power of two
+        (1, 48, 32, 32, 16),  # group_size = 3
+        (4, 24, 16, 16, 4),  # group_size = 6
+        (2, 60, 8, 8, 12),  # group_size = 5
     ],
 )
 @pytest.mark.parametrize("wb_none", [False, True])


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

`group_norm` returned wrong results whenever the group size (`C // num_groups`) is not a power of two — e.g. `C=48, num_groups=16`. Both the output and the returned `mean`/`rstd` were affected, and `group_norm_backward` had the same defect.

Each Triton program normalizes one `(sample, group)` pair and loads all `group_size` channels in a single block. Triton block sizes must be powers of two, so the kernel is launched with `BLOCK_GROUP_SIZE = triton.next_power_of_2(group_size)` and the padding lanes have to be masked off. The mask only bounded the channel index by `C`:

```python
wb_offset = group * group_size + group_offset
wb_mask = wb_offset < C
```

The padding lanes of group `g` address the first channels of group `g+1`, which are still inside the tensor, so they passed the mask. Two consequences:

1. `mean` and `var` summed over `BLOCK_GROUP_SIZE * HW` elements while dividing by `num_elements = group_size * HW`, so every group's statistics mixed in data from the next group.
2. The `tl.store` used the same mask, so program `g` also wrote normalized values into channels owned by program `g+1` — two programs writing the same addresses, with no defined winner.

Only the last group escaped, because there the padding lanes really do exceed `C`. That is why the existing single-group case `(16, 3, 16, 16, 1)` passed while every multi-group case with a non-power-of-two group size failed.

The fix masks on the group instead of on `C`, in both `group_norm_kernel` and `group_norm_backward_kernel`:

```python
wb_mask = (group_offset < group_size) & (wb_offset < C)
xy_mask = wb_mask[:, None] & (hw_offset[None, :] < HW)
```

The `C` bound is kept as a safety net. The forward `xy_mask` also switches from Python `and` to `&`, matching the backward kernel.

### Issue

- Resolves #4984

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Test

`tests/test_group_norm.py` only covered a single group or power-of-two group sizes, so nothing exercised this path. This PR adds three non-power-of-two cases to both the forward and the backward parametrize lists:

```python
(1, 48, 32, 32, 16),  # group_size = 3
(4, 24, 16, 16, 4),   # group_size = 6
(2, 60, 8, 8, 12),    # group_size = 5
```

Before the fix, `test_group_norm[dtype0-False-1-48-32-32-16]` fails with 93% of elements mismatched (greatest absolute difference 1.17, tolerance 1e-4). After the fix the whole file passes — 120 tests on an NVIDIA H100 NVL, PyTorch 2.6.0+cu124 / Triton 3.2.0.
