### PR TITLE
Fix elu: do not apply input_scale to the positive branch

### DIFF
--- a/src/flag_gems/ops/elu.py
+++ b/src/flag_gems/ops/elu.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def elu_forward_kernel(x, alpha, scale, input_scale):
     return tl.where(
         x > 0,
-        scale * input_scale * x,
+        scale * x,
         scale * alpha * (tl.exp(x.to(tl.float32) * input_scale) - 1),
     )
 
@@ -42,7 +42,7 @@ def elu_backward_kernel_with_self(grad_output, alpha, scale, input_scale, x):
     x_fp32 = x.to(tl.float32)
     grad_input = tl.where(
         x > 0,
-        grad_output * scale * input_scale,
+        grad_output * scale,
         grad_output * (scale * alpha * tl.exp(x_fp32 * input_scale) * input_scale),
     )
     return grad_input
@@ -55,7 +55,7 @@ def elu_backward_kernel_with_self(grad_output, alpha, scale, input_scale, x):
 def elu_backward_kernel_with_result(grad_output, alpha, scale, input_scale, y):
     grad_input = tl.where(
         y > 0,
-        grad_output * scale * input_scale,
+        grad_output * scale,
         grad_output * ((y + scale * alpha) * input_scale),
     )
     return grad_input

--- a/tests/test_elu.py
+++ b/tests/test_elu.py
@@ -23,15 +23,17 @@ from . import accuracy_utils as utils
 @pytest.mark.elu
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_elu(shape, dtype):
+@pytest.mark.parametrize("input_scale", [0.5, 1.0])
+def test_elu(shape, dtype, input_scale):
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     alpha = torch.rand(1).item()
+    scale = 1.0
 
     ref_inp = utils.to_reference(inp, True)
-    ref_out = torch.nn.functional.elu(ref_inp, alpha)
+    ref_out = torch.ops.aten.elu(ref_inp, alpha, scale, input_scale)
 
     with flag_gems.use_gems():
-        res_out = torch.nn.functional.elu(inp, alpha)
+        res_out = torch.ops.aten.elu(inp, alpha, scale, input_scale)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
 
@@ -58,10 +60,10 @@ def test_elu_(shape, dtype):
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.parametrize("is_result", [True, False])
-def test_elu_backward(shape, dtype, is_result):
+@pytest.mark.parametrize("input_scale", [0.5, 1.0])
+def test_elu_backward(shape, dtype, is_result, input_scale):
     alpha = torch.rand(1).item()
     scale = 1.0
-    input_scale = 1.0
 
     res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     res_grad_out = torch.randn_like(res_inp)


### PR DESCRIPTION
### PR Category

Operator, OP Test

### Type of Change

Bug Fix

### Description

`elu` applied `input_scale` to the positive branch of the forward kernel and of both backward kernels. ATen applies `input_scale` only to the negative branch — the positive branch uses `scale` alone:

```
forward:   x > 0 ? x * poscoef : expm1(x * negiptcoef) * negcoef
backward:  x > 0 ? grad * poscoef : grad * negiptcoef * negcoef * exp(x * negiptcoef)
```

(`poscoef = scale`, `negcoef = alpha * scale`, `negiptcoef = input_scale`.)

So `aten::elu` and `aten::elu_backward` returned wrong values for every positive element whenever `input_scale != 1`. On a standard-normal input with `input_scale = 0.5` the backward error reaches 0.5 — a real error, not a precision issue.

The fix drops the extra factor from the three positive branches in `src/flag_gems/ops/elu.py`. The negative branches were already correct and are untouched.

Why it went unnoticed: `tests/test_elu.py` hardcoded `input_scale = 1.0`, where the spurious factor is a no-op. `test_elu` also called `torch.nn.functional.elu`, which does not expose `input_scale` at all, so no existing case could reach the bug.

### Issue

- Resolves #4986

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact — the change removes one multiply from each positive branch; no launch config or memory access pattern changed.
