### PR TITLE
Fix special_log_softmax reducing the wrong axis for a non-innermost dim

### DIFF
--- a/src/flag_gems/ops/special_log_softmax.py
+++ b/src/flag_gems/ops/special_log_softmax.py
@@ -34,17 +34,20 @@ def small_n_log_softmax_kernel(
     input_ptr,
     M,
     N,
-    stride_m,
     BLOCK_N: tl.constexpr,
 ):
-    """Kernel for small N (N <= 1024): single warp, single pass scan."""
-    row_id = tl.program_id(0)
+    """Kernel for small N (N <= 1024) reduced over the innermost dim (K == 1).
+
+    Only launched when K == 1, so the N elements of a row are contiguous and
+    the row stride is exactly N.
+    """
+    row_id = tle.program_id(0)
     col_offsets = tl.arange(0, BLOCK_N)
     mask = col_offsets < N
 
     # Load the entire row in one go
     row = tl.load(
-        input_ptr + row_id * stride_m + col_offsets, mask=mask, other=-float("inf")
+        input_ptr + row_id * N + col_offsets, mask=mask, other=-float("inf")
     ).to(tl.float32)
 
     # Single pass: compute max, then exp and sum
@@ -56,7 +59,7 @@ def small_n_log_softmax_kernel(
     out = row_shifted - log_sum
 
     # Store result
-    tl.store(output_ptr + row_id * stride_m + col_offsets, out, mask=mask)
+    tl.store(output_ptr + row_id * N + col_offsets, out, mask=mask)
 
 
 @libentry()
@@ -129,28 +132,23 @@ def special_log_softmax(self, dim, dtype=None):
     out = torch.empty_like(inp, dtype=dtype)
     K = inp.numel() // M // N
 
-    # Dual-path: small N uses single-warp kernel, large N uses two-pass kernel
+    # Dual-path: a small N reduced over the innermost dim uses the single-warp
+    # kernel; everything else uses the two-pass kernel, which strides by K and
+    # so also handles reductions over a non-innermost dim (K > 1).
     with torch_device_fn.device(inp.device):
-        if N <= 1024:
-            # Small N: single warp kernel
-            # For dim=1 (most common case with contiguous tensor), stride is stride(0)
-            # For dim=0, stride is stride(1) which is the full row stride
+        if N <= 1024 and K == 1:
+            # Small N, innermost dim: single warp kernel over M contiguous rows
             BLOCK_N = triton.next_power_of_2(N)
-            grid = (M * K,)
-            # Get the stride of dimension that's one step after the reduction dim
-            # For contiguous tensor, this is inp.stride(dim - 1) when dim > 0
-            # For dim=1, this is inp.stride(0) = shape[1]
-            row_stride = inp.stride(dim - 1) if dim > 0 else inp.stride(inp.ndim - 1)
+            grid = (M,)
             small_n_log_softmax_kernel[grid](
                 out,
                 inp,
                 M,
                 N,
-                row_stride,
                 BLOCK_N=BLOCK_N,
             )
         else:
-            # Large N: two-pass online softmax kernel with autotune
+            # Two-pass online softmax kernel with autotune
             grid = lambda meta: (
                 triton.cdiv(M, meta["BLOCK_M"]),
                 K,

--- a/tests/test_special_log_softmax.py
+++ b/tests/test_special_log_softmax.py
@@ -42,3 +42,41 @@ def test_special_log_softmax_large_n(dtype):
     with flag_gems.use_gems():
         res_out = torch.special.log_softmax(x, dim=1)
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# Reducing over a dim that is not the innermost one leaves K > 1 elements
+# between neighbouring values of the reduced axis. Both the small-N and the
+# large-N path must stride by K instead of assuming the row is contiguous.
+@pytest.mark.special_log_softmax
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize(
+    "shape, dim",
+    [
+        ((32, 64), 0),  # small N, K = 64
+        ((4, 8, 16), 0),  # small N, K = 128
+        ((4, 8, 16), 1),  # small N, K = 16
+        ((17, 33, 5), 1),  # small N, non-power-of-2 K
+        ((2, 3, 4, 5), 2),  # small N, 4-D
+        ((2048, 4), 0),  # large N, K = 4
+        ((4, 2048, 3), 1),  # large N, K = 3
+    ],
+)
+def test_special_log_softmax_non_inner_dim(shape, dim, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = utils.to_reference(x, True)
+    ref_out = torch.special.log_softmax(ref_x, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.special.log_softmax(x, dim=dim)
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.special_log_softmax
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("dim", [-1, -2, -3])
+def test_special_log_softmax_negative_dim(dim, dtype):
+    x = torch.randn(4, 8, 16, dtype=dtype, device=flag_gems.device)
+    ref_x = utils.to_reference(x, True)
+    ref_out = torch.special.log_softmax(ref_x, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.special.log_softmax(x, dim=dim)
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=x.shape[dim])


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

The small-N path of `special_log_softmax` indexed the input as `row_id * stride_m + col_offsets`, assuming the N reduced elements are contiguous. That only holds when the reduced dim is innermost (`K == 1`); for any other dim it reduced along the wrong axis. The mask only bounded columns, never rows, so programs also read and wrote past the end of the tensor and overlapped each other's output cells, making results non-deterministic.

This dispatches on `K == 1` instead — the same pattern `log_softmax.py` already uses — and sends every other case to the two-pass kernel in this file, which already strides by K correctly at any N. With `K == 1` the row stride on a contiguous tensor is exactly N, so the small-N kernel no longer needs a stride argument.

Also switches that kernel to `tle.program_id`, as the two-pass kernel in the same file already does. It returns int64, which keeps `row_id * N` from overflowing int32: a `(2**22, 1024)` fp16 input previously failed with an illegal memory access. This is a distinct defect from the wrong-axis one.

### Issue

- Fix #4995

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.