### PR TITLE
Fix _thnn_fused_lstm_cell: store post-activation gates in workspace, support hidden_size > BLOCK_SIZE

### DIFF
--- a/src/flag_gems/ops/_thnn_fused_lstm_cell.py
+++ b/src/flag_gems/ops/_thnn_fused_lstm_cell.py
@@ -42,11 +42,12 @@ def _thnn_fused_lstm_cell_kernel(
     has_hidden_bias: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    # Grid: (batch_size,)
+    # Grid: (batch_size, cdiv(hidden_size, BLOCK_SIZE))
     batch_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
 
-    # Each program (thread block) processes one batch element
-    # We use BLOCK_SIZE threads to process the hidden dimension
+    # Each program (thread block) processes a BLOCK_SIZE-wide slice of the
+    # hidden dimension for one batch element
 
     # Pointers for this batch
     ig_ptr = input_gates_ptr + batch_idx * 4 * hidden_size
@@ -57,7 +58,7 @@ def _thnn_fused_lstm_cell_kernel(
     ws_ptr = workspace_ptr + batch_idx * 4 * hidden_size
 
     # Offsets for this block
-    offsets = tl.arange(0, BLOCK_SIZE)
+    offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < hidden_size
 
     # Load cell state cx
@@ -96,27 +97,32 @@ def _thnn_fused_lstm_cell_kernel(
         # Sum gates
         g = ig + hg
 
-        # Store to workspace (needed for backward)
-        tl.store(
-            ws_ptr + gate_offset + offsets,
-            g.to(workspace_ptr.dtype.element_ty),
-            mask=mask,
-        )
-
-        # Apply activation based on gate type and store
+        # Apply activation based on gate type
         # gate_idx: 0=input, 1=forget, 2=cell, 3=output
         if gate_idx == 0:
             # Input gate - sigmoid
             i_gate = tl.sigmoid(g)
+            activated = i_gate
         elif gate_idx == 1:
             # Forget gate - sigmoid
             f_gate = tl.sigmoid(g)
+            activated = f_gate
         elif gate_idx == 2:
             # Cell gate - tanh
             g_gate = tl_extra_shim.tanh(g)
+            activated = g_gate
         else:  # gate_idx == 3
             # Output gate - sigmoid
             o_gate = tl.sigmoid(g)
+            activated = o_gate
+
+        # Store to workspace (needed for backward). The backward expects the
+        # post-activation gates, matching aten::_thnn_fused_lstm_cell.
+        tl.store(
+            ws_ptr + gate_offset + offsets,
+            activated.to(workspace_ptr.dtype.element_ty),
+            mask=mask,
+        )
 
     # Compute cy = f * cx + i * g
     cy_acc = f_gate * cx_vals + i_gate * g_gate
@@ -193,7 +199,7 @@ def _thnn_fused_lstm_cell(
     BLOCK_SIZE = max(32, min(BLOCK_SIZE, 128))
 
     # Launch kernel
-    grid = (batch_size,)
+    grid = (batch_size, triton.cdiv(hidden_size, BLOCK_SIZE))
     _thnn_fused_lstm_cell_kernel[grid](
         input_gates,
         hidden_gates,

--- a/tests/test_thnn_fused_lstm_cell.py
+++ b/tests/test_thnn_fused_lstm_cell.py
@@ -26,6 +26,9 @@ LSTM_SHAPES = [
     (8, 32),
     (16, 64),
     (32, 128),
+    # hidden_size larger than the kernel's BLOCK_SIZE, both power-of-2 and not
+    (4, 256),
+    (4, 300),
 ]
 
 
@@ -48,9 +51,9 @@ def test_thnn_fused_lstm_cell(shape, dtype):
     cx = torch.randn(batch_size, hidden_size, dtype=dtype, device=flag_gems.device)
 
     # Reference implementation using PyTorch
-    ref_input_gates = utils.to_reference(input_gates)
-    ref_hidden_gates = utils.to_reference(hidden_gates)
-    ref_cx = utils.to_reference(cx)
+    ref_input_gates = utils.to_reference(input_gates, upcast=True)
+    ref_hidden_gates = utils.to_reference(hidden_gates, upcast=True)
+    ref_cx = utils.to_reference(cx, upcast=True)
 
     # Compute reference
     ref_gates = ref_input_gates + ref_hidden_gates
@@ -61,6 +64,8 @@ def test_thnn_fused_lstm_cell(shape, dtype):
     o_ref = torch.sigmoid(o)
     ref_cy = f_ref * ref_cx + i_ref * g_ref
     ref_hy = o_ref * torch.tanh(ref_cy)
+    # The workspace holds the post-activation gates, as aten does
+    ref_workspace = torch.cat([i_ref, f_ref, g_ref, o_ref], dim=-1)
 
     # Compute with FlagGems
     with flag_gems.use_gems():
@@ -76,6 +81,7 @@ def test_thnn_fused_lstm_cell(shape, dtype):
     )
     utils.gems_assert_close(res_hy, ref_hy, dtype, atol=atol)
     utils.gems_assert_close(res_cy, ref_cy, dtype, atol=atol)
+    utils.gems_assert_close(res_workspace, ref_workspace, dtype, atol=atol)
 
 
 @pytest.mark.thnn_fused_lstm_cell
@@ -99,11 +105,11 @@ def test_thnn_fused_lstm_cell_with_bias(shape, dtype):
     hidden_bias = torch.randn(4 * hidden_size, dtype=dtype, device=flag_gems.device)
 
     # Reference implementation
-    ref_input_gates = utils.to_reference(input_gates)
-    ref_hidden_gates = utils.to_reference(hidden_gates)
-    ref_cx = utils.to_reference(cx)
-    ref_input_bias = utils.to_reference(input_bias)
-    ref_hidden_bias = utils.to_reference(hidden_bias)
+    ref_input_gates = utils.to_reference(input_gates, upcast=True)
+    ref_hidden_gates = utils.to_reference(hidden_gates, upcast=True)
+    ref_cx = utils.to_reference(cx, upcast=True)
+    ref_input_bias = utils.to_reference(input_bias, upcast=True)
+    ref_hidden_bias = utils.to_reference(hidden_bias, upcast=True)
 
     ref_gates = ref_input_gates + ref_hidden_gates + ref_input_bias + ref_hidden_bias
     i, f, g, o = ref_gates.chunk(4, dim=-1)
@@ -113,6 +119,8 @@ def test_thnn_fused_lstm_cell_with_bias(shape, dtype):
     o_ref = torch.sigmoid(o)
     ref_cy = f_ref * ref_cx + i_ref * g_ref
     ref_hy = o_ref * torch.tanh(ref_cy)
+    # The workspace holds the post-activation gates, as aten does
+    ref_workspace = torch.cat([i_ref, f_ref, g_ref, o_ref], dim=-1)
 
     # Compute with FlagGems
     with flag_gems.use_gems():
@@ -128,3 +136,4 @@ def test_thnn_fused_lstm_cell_with_bias(shape, dtype):
     )
     utils.gems_assert_close(res_hy, ref_hy, dtype, atol=atol)
     utils.gems_assert_close(res_cy, ref_cy, dtype, atol=atol)
+    utils.gems_assert_close(res_workspace, ref_workspace, dtype, atol=atol)

--- a/tests/test_thnn_fused_lstm_cell_backward_impl.py
+++ b/tests/test_thnn_fused_lstm_cell_backward_impl.py
@@ -26,6 +26,7 @@ LSTM_SHAPES = [
     (4, 16),  # batch=4, hidden=16
     (8, 32),  # batch=8, hidden=32
     (16, 64),  # batch=16, hidden=64
+    (4, 256),  # hidden larger than the forward kernel's BLOCK_SIZE
 ]
 
 
@@ -70,4 +71,50 @@ def test_thnn_fused_lstm_cell_backward_impl(shape, dtype):
         assert (
             res.dtype == ref.dtype
         ), f"Dtype mismatch at output[{i}]: {res.dtype} vs {ref.dtype}"
+        utils.gems_assert_close(res.cpu(), ref.cpu(), dtype, atol=5e-2)
+
+
+@pytest.mark.thnn_fused_lstm_cell_backward_impl
+@pytest.mark.parametrize("shape", LSTM_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_thnn_fused_lstm_cell_forward_backward_roundtrip(shape, dtype):
+    """Check the gems backward against the workspace the gems forward writes.
+
+    The two ops are registered as a pair, so in real use the backward always
+    reads a workspace produced by the gems forward. The test above feeds it an
+    aten workspace instead, which hides any disagreement between the pair about
+    what the workspace holds.
+    """
+    batch_size, hidden_size = shape
+    dev = flag_gems.device
+
+    input_gates = torch.randn(batch_size, 4 * hidden_size, dtype=dtype, device=dev)
+    hidden_gates = torch.randn(batch_size, 4 * hidden_size, dtype=dtype, device=dev)
+    cx = torch.randn(batch_size, hidden_size, dtype=dtype, device=dev)
+    input_bias = torch.randn(4 * hidden_size, dtype=dtype, device=dev)
+    hidden_bias = torch.randn(4 * hidden_size, dtype=dtype, device=dev)
+    grad_hy = torch.randn(batch_size, hidden_size, dtype=dtype, device=dev)
+    grad_cy = torch.randn(batch_size, hidden_size, dtype=dtype, device=dev)
+
+    # aten forward, then aten backward
+    _, ref_cy, ref_workspace = torch.ops.aten._thnn_fused_lstm_cell(
+        input_gates, hidden_gates, cx, input_bias, hidden_bias
+    )
+    ref_out = torch.ops.aten._thnn_fused_lstm_cell_backward_impl(
+        grad_hy, grad_cy, cx, ref_cy, ref_workspace, True
+    )
+
+    # gems forward, then gems backward
+    with flag_gems.use_gems():
+        _, res_cy, res_workspace = torch.ops.aten._thnn_fused_lstm_cell(
+            input_gates, hidden_gates, cx, input_bias, hidden_bias
+        )
+        res_out = torch.ops.aten._thnn_fused_lstm_cell_backward_impl(
+            grad_hy, grad_cy, cx, res_cy, res_workspace, True
+        )
+
+    for i, (ref, res) in enumerate(zip(ref_out, res_out)):
+        assert (
+            res.shape == ref.shape
+        ), f"Shape mismatch at output[{i}]: {res.shape} vs {ref.shape}"
         utils.gems_assert_close(res.cpu(), ref.cpu(), dtype, atol=5e-2)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

Fixes two correctness bugs in the `_thnn_fused_lstm_cell` forward kernel.

### Issue

- Resolves #5014

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No benchmark change is expected. The gate activations were already being computed; only the value written to the workspace changed. The grid is now 2D, which for `hidden_size <= 128` (every previously-correct case) is one program per batch element exactly as before, and for larger `hidden_size` adds the programs that were missing.
