### PR TITLE
Fix nll_loss backward storing through the ignore_index sentinel

### DIFF
--- a/src/flag_gems/ops/nllloss.py
+++ b/src/flag_gems/ops/nllloss.py
@@ -97,11 +97,15 @@ def nll_loss_backward_kernel(
 
     tgt = tl.load(tgt_ptr + offsets_n, mask=mask_n, other=0)
     ignore_mask = not (tgt == ignore_index) and mask_n
+    # On an ignored row tgt holds ignore_index itself, which is allowed to be outside
+    # [0, C) -- torch's own default is -100. Keep that value out of every address we
+    # build, so an ignored row can never point at another row's cell.
+    safe_tgt = tl.where(ignore_mask, tgt, 0)
 
     if wgt_ptr is None:
         wgt_tgt = ignore_mask.to(tl.float32)
     else:
-        wgt_tgt = tl.load(wgt_ptr + tgt, mask=ignore_mask, other=0).to(tl.float32)
+        wgt_tgt = tl.load(wgt_ptr + safe_tgt, mask=ignore_mask, other=0).to(tl.float32)
 
     if reduction == 0:
         out_grad_ptrs = out_grad_ptr + offsets_n
@@ -114,8 +118,9 @@ def nll_loss_backward_kernel(
         total_w = 1
 
     inp_grad = tl.where(ignore_mask, -1 * out_grad * wgt_tgt / total_w, 0)
-    inp_grad_ptrs = inp_grad_ptr + offsets_n * C + tgt
-    tl.store(inp_grad_ptrs, inp_grad, mask=mask_n)
+    inp_grad_ptrs = inp_grad_ptr + offsets_n * C + safe_tgt
+    # grad_input is zero-initialised, so an ignored row needs no store at all.
+    tl.store(inp_grad_ptrs, inp_grad, mask=ignore_mask)
 
 
 @libentry()
@@ -200,11 +205,15 @@ def nll_loss2d_backward_kernel(
     tgt_ptrs = tgt_ptr + offset_n * D + offset_d
     tgt = tl.load(tgt_ptrs, mask=mask_block, other=0)
     ignore_mask = not (tgt == ignore_index) and mask_block
+    # On an ignored pixel tgt holds ignore_index itself, which is allowed to be outside
+    # [0, C) -- torch's own default is -100. Keep that value out of every address we
+    # build, so an ignored pixel can never point at another sample's cell.
+    safe_tgt = tl.where(ignore_mask, tgt, 0)
 
     if wgt_ptr is None:
         wgt_tgt = ignore_mask.to(tl.float32)
     else:
-        wgt_tgt = tl.load(wgt_ptr + tgt, mask=ignore_mask, other=0).to(tl.float32)
+        wgt_tgt = tl.load(wgt_ptr + safe_tgt, mask=ignore_mask, other=0).to(tl.float32)
 
     if reduction == 0:
         out_grad_ptrs = out_grad_ptr + offset_n * D + offset_d
@@ -217,8 +226,9 @@ def nll_loss2d_backward_kernel(
     else:
         total_w = 1
     inp_grad = tl.where(ignore_mask, -1 * out_grad * wgt_tgt / total_w, 0)
-    inp_grad_ptrs = inp_grad_ptr + offset_n * C * D + tgt * D + offset_d
-    tl.store(inp_grad_ptrs, inp_grad, mask=mask_block)
+    inp_grad_ptrs = inp_grad_ptr + offset_n * C * D + safe_tgt * D + offset_d
+    # grad_input is zero-initialised, so an ignored pixel needs no store at all.
+    tl.store(inp_grad_ptrs, inp_grad, mask=ignore_mask)
 
 
 # Negative Log Likelihood Loss (NLLLoss)

--- a/tests/test_nll_loss2d_backward.py
+++ b/tests/test_nll_loss2d_backward.py
@@ -76,3 +76,52 @@ def test_nll_loss2d_backward(shape, dtype, ignore_index, reduction, weight):
         (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
 
     utils.gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.nll_loss2d_backward
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("ignore_index", [-100, 4])
+def test_nll_loss2d_backward_ignore_index_out_of_range(
+    dtype, ignore_index, reduction, weight
+):
+    # Same hazard as the 1d case: an ignored pixel must not derive a store address from
+    # the sentinel. With C = 4, an ignored pixel of sample n addresses
+    # n * C * D + 4 * D + d, which is sample n + 1's class-0 gradient at the same pixel.
+    N, C, H, W = 2, 4, 2, 2
+    target = torch.tensor(
+        [[[ignore_index, 0], [1, ignore_index]], [[0, 0], [0, 2]]],
+        device=flag_gems.device,
+    )
+
+    inp = torch.randn(
+        (N, C, H, W), dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    if weight:
+        # strictly positive so the 'mean' reduction's total weight cannot land near
+        # zero and make the comparison flaky
+        weight = torch.rand(C, dtype=dtype, device=flag_gems.device) + 0.5
+    else:
+        weight = None
+
+    ref_inp = utils.to_reference(inp, True)
+    ref_target = utils.to_reference(target)
+    ref_weight = utils.to_reference(weight, True)
+
+    ref_out = torch.nn.functional.nll_loss(
+        ref_inp, ref_target, ref_weight, reduction=reduction, ignore_index=ignore_index
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.nll_loss(
+            inp, target, weight, reduction=reduction, ignore_index=ignore_index
+        )
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = utils.to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+
+    utils.gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=C)

--- a/tests/test_nll_loss_backward.py
+++ b/tests/test_nll_loss_backward.py
@@ -75,3 +75,52 @@ def test_nll_loss_backward(shape, dtype, ignore_index, reduction, weight):
         (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
 
     utils.gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.nll_loss_backward
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("ignore_index", [-100, 4])
+def test_nll_loss_backward_ignore_index_out_of_range(
+    dtype, ignore_index, reduction, weight
+):
+    # ignore_index may be outside [0, C) -- torch's own default is -100 -- and target
+    # then really does hold that sentinel on the ignored rows. The backward kernel must
+    # not derive a store address from it: with C = 4 and ignore_index = 4, ignored row n
+    # would address n * C + 4, which is row n + 1's own gradient cell.
+    N, C = 6, 4
+    valid = [0, 1, 3]
+    target = torch.tensor(
+        [ignore_index, valid[0], valid[1], ignore_index, valid[0], valid[2]],
+        device=flag_gems.device,
+    )
+
+    inp = torch.randn((N, C), dtype=dtype, device=flag_gems.device, requires_grad=True)
+    if weight:
+        # strictly positive so the 'mean' reduction's total weight cannot land near
+        # zero and make the comparison flaky
+        weight = torch.rand(C, dtype=dtype, device=flag_gems.device) + 0.5
+    else:
+        weight = None
+
+    ref_inp = utils.to_reference(inp, True)
+    ref_target = utils.to_reference(target)
+    ref_weight = utils.to_reference(weight, True)
+
+    ref_out = torch.nn.functional.nll_loss(
+        ref_inp, ref_target, ref_weight, reduction=reduction, ignore_index=ignore_index
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.nll_loss(
+            inp, target, weight, reduction=reduction, ignore_index=ignore_index
+        )
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = utils.to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+
+    utils.gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=C)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

`nll_loss_backward_kernel` and `nll_loss2d_backward_kernel` gate the gradient **value** on `ignore_mask`, but not the **address** they write it to, nor the store's mask:

```python
inp_grad = tl.where(ignore_mask, -1 * out_grad * wgt_tgt / total_w, 0)   # value: gated
inp_grad_ptrs = inp_grad_ptr + offsets_n * C + tgt                        # address: NOT gated
tl.store(inp_grad_ptrs, inp_grad, mask=mask_n)                            # mask: row-bound only
```

On an ignored row `tgt` holds `ignore_index` itself, which the file's own contract (line ~237) allows to be outside `[0, C)` — torch's default is `-100`. So an ignored row still computes an address from the sentinel and stores there. With `C = 4` and `ignore_index = 4`, ignored row `n` addresses `n*4 + 4`, which is row `n+1`'s cell 0: the two rows race, and the valid row's real gradient is silently replaced by the ignored row's 0. A negative sentinel instead writes outside `grad_input` entirely.

The fix keeps the sentinel out of the address arithmetic and predicates the store on `ignore_mask`:

```python
safe_tgt = tl.where(ignore_mask, tgt, 0)
inp_grad_ptrs = inp_grad_ptr + offsets_n * C + safe_tgt
tl.store(inp_grad_ptrs, inp_grad, mask=ignore_mask)
```

Skipping the store outright is correct because `grad_input` is `torch.zeros_like`-allocated, so an ignored row already holds the 0 the old code was writing. The weight load switches to `safe_tgt` too — behaviorally a no-op since it was already masked, but it keeps the sentinel out of every address the kernel builds.

This makes both kernels consistent with `nll_loss_nd_backward_kernel` in `ops/nll_loss_nd.py`, which already masks its store on target validity. That kernel needed no change.

**Before / after** on the issue's repro (`N=6, C=4, target=[4, 0, 1, 4, 0, 3], ignore_index=4`, `reduction="none"`):

| | row 1 | row 4 |
|---|---|---|
| torch | `-1` | `-1` |
| gems, before | `0` | `0` |
| gems, after | `-1` | `-1` |

`max abs diff` goes from `1.0` to `0.0`.

### Issue

- Resolves #5025

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.
