### PR TITLE
[Runtime][AMD] Add RDNA4 autotune configs for layer_norm and rms_norm

### DIFF
--- a/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
@@ -20,10 +20,20 @@
 #
 # The candidates come from an exhaustive sweep of the tile/warp/stage space:
 # every configuration that won at least one benchmarked shape, plus a few
-# covering the sizes in between so the table does not overfit those shapes. The
-# space is bounded by the 64 KiB of LDS a workgroup may use, which caps
-# (BLOCK_M + BLOCK_N) * BLOCK_K; num_stages stays at 1-2 because deeper
-# pipelines ranked poorly throughout the sweep.
+# covering the sizes in between so the table does not overfit those shapes.
+#
+# For the GEMM kernels the space is bounded by the 64 KiB of LDS a workgroup may
+# use, which caps (BLOCK_M + BLOCK_N) * BLOCK_K; num_stages stays at 1-2 because
+# deeper pipelines ranked poorly throughout the sweep.
+#
+# The norm kernels hold whole TILE_N arrays in registers across their reduction
+# loop, so what bounds them instead is TILE_N / (num_warps * 32), the elements
+# each lane carries. A sweep of tiles 128..65536 against 1..32 warps and 1..5
+# stages, in all three dtypes, puts a cliff just past 64 elements per lane for
+# layer_norm: 128 elements cost it 3-27x depending on shape, and 1024 cost 86x
+# after a single config spent 29 minutes compiling. float32 doubles the registers
+# per element yet the cliff does not move, so one table serves every dtype.
+# rms_norm shows no such cliff, which is why its table reaches further.
 
 mm:
   - META:
@@ -183,3 +193,102 @@ bmm:
       GROUP_M: 2
     num_warps: 8
     num_stages: 1
+
+# Written out rather than generated, because the region above is not a rectangle
+# and a gen block over these tiles and warp counts would emit 20 entries. Entry
+# count matters beyond compile time: the official benchmark sizes its
+# operator-mode iteration count from a 5-call estimate whose first call includes
+# autotuning, so a longer autotune shrinks n_rep and skews the reported latency.
+# Holding at 12 entries, as before, costs nothing -- these reach the same config
+# the full 20 would have picked on every shape measured. num_stages stays at the
+# default 2; every value scored within noise of it.
+layer_norm_loop:
+  - META:
+      TILE_N: 1024
+    num_warps: 4
+  - META:
+      TILE_N: 1024
+    num_warps: 8
+  - META:
+      TILE_N: 2048
+    num_warps: 8
+  - META:
+      TILE_N: 2048
+    num_warps: 16
+  - META:
+      TILE_N: 4096
+    num_warps: 8
+  - META:
+      TILE_N: 4096
+    num_warps: 16
+  - META:
+      TILE_N: 4096
+    num_warps: 32
+  - META:
+      TILE_N: 8192
+    num_warps: 8
+  - META:
+      TILE_N: 8192
+    num_warps: 16
+  - META:
+      TILE_N: 8192
+    num_warps: 32
+  - META:
+      TILE_N: 16384
+    num_warps: 16
+  - META:
+      TILE_N: 16384
+    num_warps: 32
+
+# _amd/tune_configs.yaml has no rms_norm_loop, so without this key the kernel
+# runs on the _nvidia defaults, which stop at TILE_N 8192. This is the
+# layer_norm table with TILE_N 1024 traded for 65536, holding the entry count at
+# 12 so autotune takes as long as the fallback table's and the operator-mode
+# numbers stay comparable.
+#
+# The trade is measured, not assumed. This kernel only runs for N > 4096, and
+# across N = 4608, 6144 and 8192 the 1024 tiles trail the winner by 5.6-9.2%,
+# never placing. At N = 65536 a tile spanning N in a single pass beat every
+# smaller tile by 5.4%, over five repeats whose own spread was 0.2%. That win
+# needs 16 warps, which is 128 elements per lane, so 32 warps is listed beside it
+# as the variant that stays inside layer_norm's cliff and still lands within
+# 1.6%. Spanning N is not a rule that generalises -- at N = 32768 and 131072 it
+# trails a smaller tile, though by under 1% -- so these tiles cover the range
+# rather than encode a rule.
+rms_norm_loop:
+  - META:
+      TILE_N: 2048
+    num_warps: 8
+  - META:
+      TILE_N: 2048
+    num_warps: 16
+  - META:
+      TILE_N: 4096
+    num_warps: 8
+  - META:
+      TILE_N: 4096
+    num_warps: 16
+  - META:
+      TILE_N: 4096
+    num_warps: 32
+  - META:
+      TILE_N: 8192
+    num_warps: 8
+  - META:
+      TILE_N: 8192
+    num_warps: 16
+  - META:
+      TILE_N: 8192
+    num_warps: 32
+  - META:
+      TILE_N: 16384
+    num_warps: 16
+  - META:
+      TILE_N: 16384
+    num_warps: 32
+  - META:
+      TILE_N: 65536
+    num_warps: 16
+  - META:
+      TILE_N: 65536
+    num_warps: 32


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
Follow-up to #4991, which added the RDNA4 arch table for `mm` and `bmm`. This PR adds `layer_norm_loop` and `rms_norm_loop` candidates to the same file. Config only: no kernel or shared runtime code changes, and only `gfx1200` / `gfx1201` are affected.

These kernels are bounded by elements per lane, `TILE_N / (num_warps * 32)`, not by LDS. Sweeps in FP16, BF16 and FP32 all put a cliff just past 64 per lane for `layer_norm`; `rms_norm` has none, so its table reaches `TILE_N=65536`. Both
tables hold 12 entries, matching the fallback count, since a longer autotune shrinks operator-mode `n_rep` and skews its reported latency.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
| item | value |
|---|---|
| GPU | AMD Radeon, `gfx1201`, 32 CU |
| ROCm | 7.2.3 |
| PyTorch | 2.10.0+rocm7.2.3 |
| Triton | 3.6.0+rocm7.2.3 |
| Python / OS | 3.12.3 / Linux 6.17 x86_64 |

`--level core` shapes, three interleaved rounds on an idle GPU, median reported. Only `N > 4096` reaches these kernels, so one shape per op is affected; the other eight benchmarked ops read an identical table in both halves and shift 0.00% at
the median.

Correctness: `pytest tests/test_layer_norm.py tests/test_rms_norm.py -q --ref cpu`
gives 69 passed.

| op | dtype | shape | kernel | operator | vs PyTorch (kernel) | vs PyTorch (operator) |
|---|---|---|---|---|---|---|
| layer_norm | bfloat16 | `[20,6,65536]` | +9.0% | +18.1% | 2.543x -> 2.776x | 2.194x -> 2.592x |
| layer_norm | float16 | `[20,6,65536]` | +8.6% | +16.0% | 2.107x -> 2.280x | 1.530x -> 1.775x |
| rms_norm | bfloat16 | `[1024,65536]` | +11.7% | +5.7% | 1.091x -> 1.219x | 1.001x -> 1.059x |
| rms_norm | float16 | `[1024,65536]` | +9.7% | +5.6% | 1.086x -> 1.192x | 0.999x -> 1.055x |
