### PR TITLE
Optimize GLU forward with a Triton kernel

### DIFF
--- a/src/flag_gems/ops/glu.py
+++ b/src/flag_gems/ops/glu.py
@@ -18,10 +18,85 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, pointwise_dynamic, tl_extra_shim
 
 logger = logging.getLogger(__name__)
 exp = tl_extra_shim.exp
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("glu"),
+    key=["N_BUCKET", "D"],
+)
+@triton.jit
+def _glu_forward_kernel(
+    input_ptr,
+    output_ptr,
+    N,
+    N_BUCKET,
+    D: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+    rows = offsets // D
+    columns = offsets % D
+    input_offsets = rows * (2 * D) + columns
+    a = tl.load(input_ptr + input_offsets, mask=mask, other=0.0)
+    b = tl.load(input_ptr + input_offsets + D, mask=mask, other=0.0)
+    if input_ptr.dtype.element_ty == tl.float64:
+        sigmoid_b = 1.0 / (1.0 + exp(-b))
+    else:
+        sigmoid_b = 1.0 / (1.0 + exp(-b.to(tl.float32)))
+    result = a * sigmoid_b
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+def _can_use_triton_glu(input_tensor: torch.Tensor, dim: int) -> bool:
+    """Return whether the contiguous Triton kernel can process the input."""
+    if input_tensor.ndim == 0:
+        return False
+
+    normalized_dim = dim if dim >= 0 else dim + input_tensor.ndim
+    if normalized_dim != input_tensor.ndim - 1:
+        return False
+
+    last_dim = input_tensor.shape[-1]
+    return (
+        input_tensor.device.type not in ("cpu", "meta")
+        and input_tensor.layout == torch.strided
+        and input_tensor.is_contiguous()
+        and input_tensor.numel() > 0
+        and input_tensor.is_floating_point()
+        and last_dim % 2 == 0
+    )
+
+
+def _glu_triton_forward(input_tensor: torch.Tensor) -> torch.Tensor:
+    """Launch the contiguous pure Triton GLU kernel."""
+    last_dim = input_tensor.shape[-1]
+    half_dim = last_dim // 2
+    output = torch.empty(
+        (*input_tensor.shape[:-1], half_dim),
+        dtype=input_tensor.dtype,
+        device=input_tensor.device,
+    )
+    numel = output.numel()
+    # Reuse one autotune result for nearby sizes instead of every row count.
+    numel_bucket = triton.next_power_of_2(numel)
+    grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input_tensor.device):
+        _glu_forward_kernel[grid](
+            input_tensor,
+            output,
+            numel,
+            numel_bucket,
+            D=half_dim,
+        )
+    return output
 
 
 @pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
@@ -51,6 +126,9 @@ def glu_backward_kernel(grad_output, a, b):
 def glu(self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
     logger.debug("GLU FORWARD")
+    if _can_use_triton_glu(self, dim):
+        return _glu_triton_forward(self)
+
     # Split into a and b
     a, b = torch.chunk(self, 2, dim=dim)
     out = glu_kernel(a, b)

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -1799,6 +1799,36 @@ argmin_split_k:
         - 16
         - 32
 
+glu:
+  - META:
+      BLOCK_SIZE: 128
+    num_warps: 2
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 128
+    num_warps: 4
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 2
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 4
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 4
+    num_stages: 1
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 1
+
 gated_activation:
   - gen: true
     param_map:


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR optimizes the GLU forward path with a flat Triton kernel for contiguous tensors when GLU is applied along the last dimension.

The new kernel:

- Processes flattened output elements in parallel.
- Directly loads the corresponding values from both halves of the input.
- Uses the existing backend autotune infrastructure to tune `BLOCK_SIZE` and `num_warps`.
- Buckets the output size to avoid repeated autotuning for nearby tensor sizes.
- Keeps the existing pointwise implementation as the fallback for unsupported layouts and dimensions.
- Preserves the existing backward implementation.

The implementation is placed in the common operator path and does not contain vendor-specific dispatch logic. Backend-specific autotune configurations can override the default configuration when needed.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
