### PR TITLE
fix(mul): gate optimized path on active backend device, not hardcoded "cuda"

### DIFF
--- a/src/flag_gems/ops/mul.py
+++ b/src/flag_gems/ops/mul.py
@@ -19,11 +19,19 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.runtime import device as runtime_device
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils.shape_utils import volume
 
 logger = logging.getLogger(__name__)
+
+# Name of the active flag_gems backend device (e.g. "cuda", "musa"). The
+# optimized Triton path below runs on this device; tensors on other device
+# types (e.g. plain "cpu") fall through to the aten reference path. Gating on
+# the hardcoded literal "cuda" wrongly excluded backends whose device type is
+# not "cuda" (e.g. mthreads reports "musa") from the shared Triton path.
+_DEVICE_NAME = runtime_device.name
 
 _FALLBACK_KEYSET = torch._C.DispatchKeySet(
     torch._C.DispatchKey.CompositeExplicitAutograd
@@ -576,7 +584,7 @@ def mul_broadcast_func(a, b, out=None):
         raise TypeError("mul expects tensor or scalar inputs")
 
     device = _select_device(a, b)
-    if device.type != "cuda":
+    if device.type != _DEVICE_NAME:
         if out is not None:
             return torch.ops.aten.mul.out.redispatch(_FALLBACK_KEYSET, a, b, out=out)
         return torch.ops.aten.mul.Tensor.redispatch(_FALLBACK_KEYSET, a, b)
@@ -721,7 +729,7 @@ def _launch_complex_generic(
 
 def mul_complex_broadcast_func(a, b, out=None):
     device = _select_device(a, b)
-    if device.type != "cuda":
+    if device.type != _DEVICE_NAME:
         if out is not None:
             return torch.ops.aten.mul.out.redispatch(_FALLBACK_KEYSET, a, b, out=out)
         return torch.ops.aten.mul.Tensor.redispatch(_FALLBACK_KEYSET, a, b)


### PR DESCRIPTION
Fixes `mul` on backends whose device type is not literally `"cuda"`.

## Problem

`mul_broadcast_func` / `mul_complex_broadcast_func` gate the optimized Triton
path on `device.type != "cuda"`, falling through to an aten reference path
otherwise. mthreads reports `device.type == "musa"` (its `device_name` — the
only GPU backend whose name is not `"cuda"`), so **every** `mul` on mthreads
takes the fallback.

That fallback is also wrong for a scalar operand: it calls
`torch.ops.aten.mul.Tensor.redispatch(..., a, b)`, and `mul.Tensor` requires a
Tensor `other`. A python scalar (e.g. rope’s `1.0 / freqs` →
`Tensor.reciprocal() * 1.0`) raises:

```
RuntimeError: aten::mul.Tensor expected Tensor for 'other', found float
```

which crashes model load under vLLM on mthreads.

## Fix

Gate on the active backend’s device name (`runtime.device.name`) instead of the
hardcoded literal, matching the convention already used elsewhere (e.g.
`_upsample_bilinear2d_aa.py` compares `input.device.type` against `device.name`).

- Backends whose `device_name` is `"cuda"` (nvidia, metax, iluvatar, hygon, …)
  are unaffected.
- mthreads (`"musa"`) now takes the same optimized Triton path as everyone else.

## Verification (mthreads, MTT S5000, torch_musa 5.2.0)

- The Triton `mul` kernel produces correct results (max abs err 0 vs torch
  reference) across scalar / tensor×tensor / broadcast / fp16 / bf16 / int /
  `out=` / in-place / complex.
- `vllm serve` of a yarn-rope model reaches `Application startup complete` and
  returns coherent inference output, where it previously crashed at load with
  the error above.

This PR was written in part with the assistance of generative AI.