### PR TITLE
Optimize wna16 MoE main loop: one mma per K tile instead of eight

### DIFF
--- a/src/flag_gems/fused/fused_marlin_moe.py
+++ b/src/flag_gems/fused/fused_marlin_moe.py
@@ -692,6 +692,25 @@ def _dequant_fp4_bf16_fold(b, cs0, cs1, cs2, cs3):
 
 
 @triton.jit
+def _concat_k(bs, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, SWAP_AB: tl.constexpr):
+    # Concat the 8 dequant outputs along K; permute puts the sub-tile index ahead
+    # of the in-tile K coord so the reshape flattens to k = K_PACK * j + kp.
+    j0 = tl.join(bs[0], bs[1])
+    j1 = tl.join(bs[2], bs[3])
+    j2 = tl.join(bs[4], bs[5])
+    j3 = tl.join(bs[6], bs[7])
+    p0 = tl.join(j0, j1)
+    p1 = tl.join(j2, j3)
+    q = tl.join(p0, p1)
+    if SWAP_AB:
+        # bs[j] is (BLOCK_N, K_PACK) -> (BLOCK_N, 2, 2, 2, K_PACK) -> (BLOCK_N, BLOCK_K)
+        return tl.reshape(tl.permute(q, (0, 4, 3, 2, 1)), (BLOCK_N, BLOCK_K))
+    else:
+        # bs[j] is (K_PACK, BLOCK_N) -> (2, 2, 2, K_PACK, BLOCK_N) -> (BLOCK_K, BLOCK_N)
+        return tl.reshape(tl.permute(q, (4, 3, 2, 0, 1)), (BLOCK_K, BLOCK_N))
+
+
+@triton.jit
 def _dequant_fp4_fp16(b, s0, s1, s2, s3):
     x1, x2, x3, x4, x5, x6, x7, x8 = tl.inline_asm_elementwise(
         asm="""
@@ -904,7 +923,6 @@ def _w4a16_moe_gemm_kernel(
         return
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
-    offs_ak_pack = tl.arange(0, BLOCK_SIZE_K_PACK)
     offs_bk = tl.arange(0, BLOCK_SIZE_K_PACK)
 
     if SWAP_AB:
@@ -939,20 +957,18 @@ def _w4a16_moe_gemm_kernel(
             bs = _dequant_int4_bf16(b_packed, scale_bc)
 
         k_logical_base = k * BLOCK_SIZE_K
-        for j in tl.static_range(8):
-            k_off = k_logical_base + j * BLOCK_SIZE_K_PACK
-            if SWAP_AB:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[:, None]) * stride_ak
-                a_j = tl.load(
-                    a_j_ptrs, mask=token_mask[None, :], other=0.0
-                )  # (K_PACK, M)
-                accumulator = tl.dot(bs[j], a_j, acc=accumulator)  # (N, M)
-            else:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[None, :]) * stride_ak
-                a_j = tl.load(
-                    a_j_ptrs, mask=token_mask[:, None], other=0.0
-                )  # (M, K_PACK)
-                accumulator = tl.dot(a_j, bs[j], acc=accumulator)  # (M, N)
+        # One mma over the whole K tile; the activation is loaded once as a
+        # full tile instead of once per sub-tile.
+        bs_full = _concat_k(bs, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        offs_ak_full = tl.arange(0, BLOCK_SIZE_K)
+        if SWAP_AB:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[:, None]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[None, :], other=0.0)  # (K, M)
+            accumulator = tl.dot(bs_full, a_full, acc=accumulator)  # (N, M)
+        else:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[None, :]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[:, None], other=0.0)  # (M, K)
+            accumulator = tl.dot(a_full, bs_full, acc=accumulator)  # (M, N)
 
         b_ptrs += BLOCK_SIZE_K_PACK * stride_bk
 
@@ -1080,7 +1096,6 @@ def _w4a16_moe_gemm_silu_kernel(
 
     offs_bn_gate = offs_cn % N
     offs_bn_up = offs_bn_gate + N
-    offs_ak_pack = tl.arange(0, BLOCK_SIZE_K_PACK)
     offs_bk = tl.arange(0, BLOCK_SIZE_K_PACK)
 
     if SWAP_AB:
@@ -1136,18 +1151,21 @@ def _w4a16_moe_gemm_silu_kernel(
             bs_up = _dequant_int4_bf16(b_packed_up, scale_up_bc)
 
         k_logical_base = k * BLOCK_SIZE_K
-        for j in tl.static_range(8):
-            k_off = k_logical_base + j * BLOCK_SIZE_K_PACK
-            if SWAP_AB:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[:, None]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[None, :], other=0.0)
-                acc_gate = tl.dot(bs_gate[j], a_j, acc=acc_gate)
-                acc_up = tl.dot(bs_up[j], a_j, acc=acc_up)
-            else:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[None, :]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[:, None], other=0.0)
-                acc_gate = tl.dot(a_j, bs_gate[j], acc=acc_gate)
-                acc_up = tl.dot(a_j, bs_up[j], acc=acc_up)
+        # gate and up each get one mma; the activation is loaded once and
+        # shared by both.
+        bs_gate_full = _concat_k(bs_gate, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        bs_up_full = _concat_k(bs_up, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        offs_ak_full = tl.arange(0, BLOCK_SIZE_K)
+        if SWAP_AB:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[:, None]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[None, :], other=0.0)
+            acc_gate = tl.dot(bs_gate_full, a_full, acc=acc_gate)
+            acc_up = tl.dot(bs_up_full, a_full, acc=acc_up)
+        else:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[None, :]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[:, None], other=0.0)
+            acc_gate = tl.dot(a_full, bs_gate_full, acc=acc_gate)
+            acc_up = tl.dot(a_full, bs_up_full, acc=acc_up)
 
         b_ptrs_gate += BLOCK_SIZE_K_PACK * stride_bk
         b_ptrs_up += BLOCK_SIZE_K_PACK * stride_bk
@@ -1560,7 +1578,6 @@ def _mxfp4_moe_gemm_kernel(
         return
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
-    offs_ak_pack = tl.arange(0, BLOCK_SIZE_K_PACK)
     offs_bk = tl.arange(0, BLOCK_SIZE_K_PACK)
 
     if SWAP_AB:
@@ -1605,16 +1622,18 @@ def _mxfp4_moe_gemm_kernel(
             bs = _dequant_fp4_bf16(b_packed, s0, s1, s2, s3)
 
         k_logical_base = k * BLOCK_SIZE_K
-        for j in tl.static_range(8):
-            k_off = k_logical_base + j * BLOCK_SIZE_K_PACK
-            if SWAP_AB:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[:, None]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[None, :], other=0.0)
-                accumulator = tl.dot(bs[j], a_j, acc=accumulator)
-            else:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[None, :]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[:, None], other=0.0)
-                accumulator = tl.dot(a_j, bs[j], acc=accumulator)
+        # One mma over the whole K tile; the activation is loaded once as a
+        # full tile instead of once per sub-tile.
+        bs_full = _concat_k(bs, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        offs_ak_full = tl.arange(0, BLOCK_SIZE_K)
+        if SWAP_AB:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[:, None]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[None, :], other=0.0)  # (K, M)
+            accumulator = tl.dot(bs_full, a_full, acc=accumulator)  # (N, M)
+        else:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[None, :]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[:, None], other=0.0)  # (M, K)
+            accumulator = tl.dot(a_full, bs_full, acc=accumulator)  # (M, N)
 
         b_ptrs += BLOCK_SIZE_K_PACK * stride_bk
 
@@ -1719,7 +1738,6 @@ def _mxfp4_moe_gemm_silu_kernel(
 
     offs_bn_gate = offs_cn % N
     offs_bn_up = offs_bn_gate + N
-    offs_ak_pack = tl.arange(0, BLOCK_SIZE_K_PACK)
     offs_bk = tl.arange(0, BLOCK_SIZE_K_PACK)
 
     if SWAP_AB:
@@ -1808,18 +1826,21 @@ def _mxfp4_moe_gemm_silu_kernel(
             bs_up = _dequant_fp4_bf16(b_packed_up, su0, su1, su2, su3)
 
         k_logical_base = k * BLOCK_SIZE_K
-        for j in tl.static_range(8):
-            k_off = k_logical_base + j * BLOCK_SIZE_K_PACK
-            if SWAP_AB:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[:, None]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[None, :], other=0.0)
-                acc_gate = tl.dot(bs_gate[j], a_j, acc=acc_gate)
-                acc_up = tl.dot(bs_up[j], a_j, acc=acc_up)
-            else:
-                a_j_ptrs = a_base + (k_off + offs_ak_pack[None, :]) * stride_ak
-                a_j = tl.load(a_j_ptrs, mask=token_mask[:, None], other=0.0)
-                acc_gate = tl.dot(a_j, bs_gate[j], acc=acc_gate)
-                acc_up = tl.dot(a_j, bs_up[j], acc=acc_up)
+        # gate and up each get one mma; the activation is loaded once and
+        # shared by both.
+        bs_gate_full = _concat_k(bs_gate, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        bs_up_full = _concat_k(bs_up, BLOCK_SIZE_N, BLOCK_SIZE_K, SWAP_AB)
+        offs_ak_full = tl.arange(0, BLOCK_SIZE_K)
+        if SWAP_AB:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[:, None]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[None, :], other=0.0)
+            acc_gate = tl.dot(bs_gate_full, a_full, acc=acc_gate)
+            acc_up = tl.dot(bs_up_full, a_full, acc=acc_up)
+        else:
+            a_full_ptrs = a_base + (k_logical_base + offs_ak_full[None, :]) * stride_ak
+            a_full = tl.load(a_full_ptrs, mask=token_mask[:, None], other=0.0)
+            acc_gate = tl.dot(a_full, bs_gate_full, acc=acc_gate)
+            acc_up = tl.dot(a_full, bs_up_full, acc=acc_up)
 
         b_ptrs_gate += BLOCK_SIZE_K_PACK * stride_bk
         b_ptrs_up += BLOCK_SIZE_K_PACK * stride_bk


### PR DESCRIPTION
## PR Category

Operator

## Type of Change

Performance Optimization

## Description

A dequant call returns 8 sub-tiles that are adjacent along K but separate values, because one `int32` packs 8 nibbles and `_NIBBLE_PERM` spreads them at a `K_PACK` stride. `tl.dot` takes a single tensor per operand, so the main loop ran `tl.static_range(8)` and issued one mma per sub-tile, repeating the address arithmetic, the masked activation load and the operand staging eight times per K tile.

That overhead is fixed per iteration and does not shrink with the token count, so it dominates exactly where MoE decode shapes live: with E=256 and top_k=6 an expert averages well under one token, and the eight-way repetition is paid in full to feed mmas that are mostly empty.

This concatenates the sub-tiles along K and issues a single mma over the whole tile, with the activation loaded once as a full tile. `_concat_k` builds the ordered concatenation from a balanced `tl.join` tree plus a permute and a reshape: the join tree leaves the sub-tile index in the trailing dims and the permute moves it ahead of the in-tile K coordinate, so the reshape flattens to `k = K_PACK * j + kp`.

All four kernels share the packing and the dequant output shape, so all four change — the MXFP4 pair and the GPTQ INT4 pair, which is segmented the same way for the same reason. mma count per K tile goes 8 → 1 in the plain kernels and 16 → 2 in the fused silu ones, where gate and up now share a single activation load.

**Compiler dependency.** The merge is only free on a backend carrying `tritongpu-concat-dot-operand` (flagos-ai/FlagTree#892), which folds the join/permute/reshape chain into a per-thread register relabel. Without that pass the kernels are still correct, verified bit-identical below, but the concatenated operand round-trips through shared memory and the loop runs roughly half speed. The previous segmented path is not kept behind a switch.

The chain's shape is load-bearing and not obvious from reading it: the join tree must be balanced, the permute order differs between the `SWAP_AB` and transposed orientations, and the dequant output must already be the compute dtype — a cast before the `tl.dot` makes the fold fail silently and falls back to the slow path. Comments in `_concat_k` spell out the intended shape at each step.

## Issue

N/A

## Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

## Performance

Hardware: **H20-3e**, bf16, **CUDA Graph ON**, `return_mode=median`, `USE_FLAGTUNE=0`. Baseline = current `master`. `Speedup = T_vLLM(Marlin) / T_Gems`; `Δ%` is latency reduction, `(T_base − T_opt) / T_base`, averaged per shape unless stated otherwise.

Shapes: **53 deduped shapes from a real DeepSeek-V4-Flash trace** (`prefill=32768`), geometry `(M, E=256, H=4096, I=256, top_k=6)`, `M ∈ [1, 16384]`, `Count` = real call count.

| | Baseline | Optimized |
|---|---|---|
| Average speedup | 1.062 | **1.171** (+10.18%) |
| Call-weighted speedup | 1.110 | **1.210** (+9.04%) |
| Min / Max speedup | 0.894 / 1.769 | **1.015** / **1.812** |
| Shapes at or above parity | 43/53 | **53/53** |
| Average latency reduction | — | **+9.22%** |
| Call-weighted total latency | 8181.1 ms | **7792.9 ms** (−4.74%) |

The last two differ because `M=16384` alone is 63% of the call-weighted latency and gains the least (+2.42%), so it dominates the total while counting as one shape in the average.

Split by `block_m`, since the tile size sets how much of the per-segment overhead the merge removes:

| Group | Shapes | Baseline | Optimized | Avg Δ% | Min Δ% | Max Δ% |
|---|---|---|---|---|---|---|
| 8 (M=1..128) | 19 | 1.034 | **1.147** | **+9.87%** | +6.95% | +15.29% |
| 8, padding-cost tier (M=136..272) | 17 | 1.034 | **1.150** | **+10.14%** | +9.48% | +11.27% |
| 16 (M=288..368) | 6 | 1.141 | **1.285** | **+11.26%** | +10.89% | +11.47% |
| 32 (M=384..2048) | 10 | 1.047 | **1.117** | **+5.90%** | +4.82% | +11.45% |
| 64 (M=16384) | 1 | 1.769 | **1.812** | +2.42% | +2.42% | +2.42% |

Every shape improves; the worst is +2.42%. The ten shapes that were still below parity now clear it (0.963 → 1.044 on average), which is what closes the 43/53 gap. Gains shrink as `block_m` grows, as expected: the per-segment overhead is fixed per K tile, so it weighs less against a tile that routes more rows.

<details>
<summary><b>Full per-shape data</b> — 53 shapes, 10105 calls (click to expand)</summary>

| M | Count | block_m | vLLM (ms) | Baseline Gems (ms) | Baseline Speedup | Optimized Gems (ms) | Optimized Speedup | Δ% |
|---|---|---|---|---|---|---|---|---|
| 1 | 172 | 8 | 0.0316 | 0.0222 | 1.423 | 0.0204 | 1.550 | +8.18% |
| 2 | 172 | 8 | 0.0375 | 0.0420 | 0.894 | 0.0356 | 1.055 | +15.29% |
| 4 | 172 | 8 | 0.0535 | 0.0566 | 0.944 | 0.0527 | 1.015 | +6.95% |
| 8 | 172 | 8 | 0.0795 | 0.0838 | 0.949 | 0.0742 | 1.072 | +11.46% |
| 16 | 172 | 8 | 0.1260 | 0.1281 | 0.983 | 0.1141 | 1.104 | +10.96% |
| 24 | 172 | 8 | 0.1496 | 0.1495 | 1.001 | 0.1337 | 1.120 | +10.60% |
| 32 | 172 | 8 | 0.1847 | 0.1768 | 1.045 | 0.1589 | 1.162 | +10.11% |
| 40 | 172 | 8 | 0.2140 | 0.2127 | 1.006 | 0.1920 | 1.115 | +9.73% |
| 48 | 172 | 8 | 0.2361 | 0.2331 | 1.013 | 0.2120 | 1.114 | +9.05% |
| 56 | 172 | 8 | 0.2543 | 0.2407 | 1.056 | 0.2173 | 1.170 | +9.73% |
| 64 | 172 | 8 | 0.2596 | 0.2552 | 1.017 | 0.2303 | 1.127 | +9.75% |
| 72 | 172 | 8 | 0.2775 | 0.2636 | 1.053 | 0.2388 | 1.162 | +9.41% |
| 80 | 172 | 8 | 0.2876 | 0.2796 | 1.029 | 0.2527 | 1.138 | +9.62% |
| 88 | 172 | 8 | 0.2902 | 0.2825 | 1.027 | 0.2533 | 1.146 | +10.33% |
| 96 | 172 | 8 | 0.2988 | 0.2872 | 1.041 | 0.2619 | 1.141 | +8.80% |
| 104 | 172 | 8 | 0.2992 | 0.2876 | 1.040 | 0.2630 | 1.137 | +8.56% |
| 112 | 172 | 8 | 0.3098 | 0.3019 | 1.026 | 0.2724 | 1.137 | +9.76% |
| 120 | 172 | 8 | 0.3181 | 0.3044 | 1.045 | 0.2756 | 1.154 | +9.49% |
| 128 | 172 | 8 | 0.3262 | 0.3085 | 1.057 | 0.2786 | 1.171 | +9.67% |
| 136 | 172 | 8 | 0.3200 | 0.3094 | 1.034 | 0.2767 | 1.156 | +10.55% |
| 144 | 172 | 8 | 0.3268 | 0.3101 | 1.054 | 0.2807 | 1.164 | +9.48% |
| 152 | 172 | 8 | 0.3205 | 0.3086 | 1.039 | 0.2781 | 1.152 | +9.86% |
| 160 | 172 | 8 | 0.3262 | 0.3126 | 1.044 | 0.2829 | 1.153 | +9.49% |
| 168 | 172 | 8 | 0.3314 | 0.3251 | 1.019 | 0.2930 | 1.131 | +9.89% |
| 176 | 172 | 8 | 0.3404 | 0.3297 | 1.032 | 0.2978 | 1.143 | +9.68% |
| 184 | 172 | 8 | 0.3409 | 0.3318 | 1.028 | 0.2978 | 1.145 | +10.22% |
| 192 | 172 | 8 | 0.3425 | 0.3317 | 1.032 | 0.2999 | 1.142 | +9.59% |
| 200 | 172 | 8 | 0.3475 | 0.3332 | 1.043 | 0.3005 | 1.156 | +9.82% |
| 208 | 172 | 8 | 0.3525 | 0.3414 | 1.033 | 0.3030 | 1.164 | +11.27% |
| 216 | 172 | 8 | 0.3432 | 0.3355 | 1.023 | 0.3019 | 1.137 | +10.00% |
| 224 | 172 | 8 | 0.3537 | 0.3429 | 1.032 | 0.3061 | 1.155 | +10.73% |
| 232 | 172 | 8 | 0.3662 | 0.3552 | 1.031 | 0.3177 | 1.153 | +10.58% |
| 240 | 172 | 8 | 0.3657 | 0.3578 | 1.022 | 0.3194 | 1.145 | +10.73% |
| 248 | 172 | 8 | 0.3810 | 0.3720 | 1.024 | 0.3337 | 1.142 | +10.29% |
| 256 | 172 | 8 | 0.3761 | 0.3618 | 1.040 | 0.3253 | 1.156 | +10.09% |
| 272 | 172 | 8 | 0.3977 | 0.3807 | 1.045 | 0.3422 | 1.162 | +10.11% |
| 288 | 172 | 16 | 0.4169 | 0.3850 | 1.083 | 0.3422 | 1.218 | +11.10% |
| 304 | 172 | 16 | 0.4281 | 0.3866 | 1.107 | 0.3428 | 1.249 | +11.35% |
| 320 | 172 | 16 | 0.4496 | 0.3876 | 1.160 | 0.3436 | 1.308 | +11.33% |
| 336 | 172 | 16 | 0.4509 | 0.3867 | 1.166 | 0.3446 | 1.308 | +10.89% |
| 352 | 172 | 16 | 0.4529 | 0.3901 | 1.161 | 0.3453 | 1.311 | +11.47% |
| 368 | 172 | 16 | 0.4581 | 0.3925 | 1.167 | 0.3478 | 1.317 | +11.41% |
| 384 | 172 | 32 | 0.4652 | 0.4771 | 0.975 | 0.4520 | 1.029 | +5.25% |
| 400 | 172 | 32 | 0.4627 | 0.4784 | 0.967 | 0.4552 | 1.017 | +4.85% |
| 416 | 172 | 32 | 0.4585 | 0.4761 | 0.963 | 0.4491 | 1.021 | +5.67% |
| 432 | 172 | 32 | 0.4701 | 0.4782 | 0.983 | 0.4511 | 1.042 | +5.65% |
| 448 | 172 | 32 | 0.4656 | 0.4779 | 0.974 | 0.4528 | 1.028 | +5.25% |
| 464 | 172 | 32 | 0.4786 | 0.4793 | 0.998 | 0.4537 | 1.055 | +5.35% |
| 480 | 172 | 32 | 0.4892 | 0.4795 | 1.020 | 0.4537 | 1.078 | +5.38% |
| 496 | 344 | 32 | 0.4939 | 0.4807 | 1.028 | 0.4550 | 1.086 | +5.35% |
| 512 | 344 | 32 | 0.5011 | 0.4787 | 1.047 | 0.4557 | 1.100 | +4.82% |
| 2048 | 43 | 32 | 1.5334 | 1.0109 | 1.517 | 0.8951 | 1.713 | +11.45% |
| 16384 | 946 | 64 | 9.6669 | 5.4659 | 1.769 | 5.3336 | 1.812 | +2.42% |
| **avg** | 10105 | — | — | — | **1.062** | — | **1.171** | **+9.22%** |

</details>