### PR TITLE
[KernelGen][Nvidia] Add in-place sign_ operator

### DIFF
--- a/benchmark/test_sign.py
+++ b/benchmark/test_sign.py
@@ -36,3 +36,14 @@ def test_sign_out():
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()
+
+
+@pytest.mark.sign_
+def test_sign_inplace():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="sign_",
+        torch_op=torch.Tensor.sign_,
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -8355,6 +8355,20 @@ ops:
       - Math
     stages:
       - alpha: '5.4'
+  - id: sign_
+    description: |
+      The in-place version of `sign()`, writing the element-wise sign back
+      into the input tensor.
+    for:
+      - sign_
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: signbit
     description: Tests if each element of `input` has its sign bit set or not.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -772,6 +772,7 @@ _FULL_CONFIG = (
     ("sigmoid_backward", sigmoid_backward),
     ("sign", sign),
     ("sign.out", sign_out),
+    ("sign_", sign_),
     ("signbit", signbit),
     ("signbit.out", signbit_out),
     ("silu", silu),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -551,7 +551,7 @@ from flag_gems.ops.selu_ import selu_
 from flag_gems.ops.sgn import sgn, sgn_out
 from flag_gems.ops.sgn_ import sgn_
 from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
-from flag_gems.ops.sign import sign, sign_out
+from flag_gems.ops.sign import sign, sign_, sign_out
 from flag_gems.ops.signbit import signbit, signbit_out
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
@@ -1349,6 +1349,7 @@ __all__ = [
     "sigmoid_",
     "sigmoid_backward",
     "sign",
+    "sign_",
     "sign_out",
     "signbit",
     "signbit_out",

--- a/src/flag_gems/ops/sign.py
+++ b/src/flag_gems/ops/sign.py
@@ -97,3 +97,8 @@ def sign(x: torch.Tensor):
 def sign_out(x: torch.Tensor, *, out: torch.Tensor):
     logger.debug("GEMS SIGN_OUT")
     return _sign_impl(x, out)
+
+
+def sign_(x: torch.Tensor):
+    logger.debug("GEMS SIGN_")
+    return _sign_impl(x, x)

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -63,6 +63,18 @@ def _assert_matches_torch(inp, out=None):
     utils.gems_assert_equal(result, ref_out, equal_nan=False)
 
 
+def _assert_inplace_matches_torch(inp):
+    ref_inp = _to_reference(inp.clone())
+    ref_out = ref_inp.sign_()
+    with flag_gems.use_gems():
+        result = inp.sign_()
+    assert result is inp
+    # torch.sign(nan) returns 0.0, not nan
+    utils.gems_assert_equal(result, ref_out, equal_nan=False)
+    # the input tensor itself must have been mutated in place
+    utils.gems_assert_equal(inp, ref_out, equal_nan=False)
+
+
 @pytest.mark.sign
 @pytest.mark.parametrize("dtype,shape", SIGN_CASES)
 def test_sign(dtype, shape):
@@ -76,6 +88,20 @@ def test_sign_out(dtype, shape):
     inp = _make_input(shape, dtype)
     out = torch.empty_like(inp)
     _assert_matches_torch(inp, out)
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("dtype,shape", SIGN_CASES)
+def test_sign_(dtype, shape):
+    inp = _make_input(shape, dtype)
+    _assert_inplace_matches_torch(inp)
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_sign__noncontiguous(dtype):
+    inp = _make_input((7, 11), dtype).transpose(0, 1)
+    _assert_inplace_matches_torch(inp)
 
 
 @pytest.mark.sign


### PR DESCRIPTION
## Summary

Adds the in-place `sign_` operator to complement the existing `sign` / `sign.out`
operators that were introduced in #5030. `sign_` writes the element-wise sign
back into the input tensor.

`aten::sign_` has only the `default` overload (`sign_(Tensor(a!) self) -> Tensor(a!)`),
mirroring the `abs` / `abs_` pairing. The implementation reuses the already-merged
`_sign_impl` kernel with `out == input`, so no new kernel logic is introduced.

## Changes

- `src/flag_gems/ops/sign.py`: add `sign_(x)` → `_sign_impl(x, x)`
- `src/flag_gems/ops/__init__.py`: export `sign_`
- `src/flag_gems/__init__.py`: register `("sign_", sign_)` in `_FULL_CONFIG`
- `conf/operators.yaml`: add `id: sign_` block
- `tests/test_sign.py`: `test_sign_` (all real dtypes + shapes) and a
  non-contiguous case; asserts the mutated input matches `torch`
- `benchmark/test_sign.py`: `test_sign_inplace`

## Testing

191 pytest cases pass against this worktree (isolated launcher verifying
`flag_gems` resolves to the worktree). Dispatch confirmed via `GEMS SIGN_`
debug log; verified same storage pointer (true in-place) and `NaN → 0`.
`sign_` supports all real dtypes including int / uint8 / bool; complex raises
`NotImplementedError`.
