### PR TITLE
[KernelGen][Nvidia] Add ne_ operator

### DIFF
--- a/benchmark/test_ne_.py
+++ b/benchmark/test_ne_.py
@@ -1,0 +1,46 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+def _scalar_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 0
+
+
+@pytest.mark.ne_
+def test_ne_():
+    bench = base.BinaryPointwiseBenchmark(
+        op_name="ne_",
+        torch_op=lambda a, b: torch.ops.aten.ne_.Tensor(a, b),
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.ne_scalar_
+def test_ne_scalar_():
+    bench = base.GenericBenchmark(
+        input_fn=_scalar_input_fn,
+        op_name="ne_scalar_",
+        torch_op=lambda a, b: torch.ops.aten.ne_.Scalar(a, b),
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6383,6 +6383,20 @@ ops:
       - Math
     stages:
       - stable: '2.0'
+  - id: ne_
+    description: |
+      Computes element-wise not-equal comparison in-place.
+    for:
+      - ne_.Tensor
+      - ne_.Scalar
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: neg
     description: Returns a new tensor with the negative of the elements of `input`.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -635,6 +635,8 @@ _FULL_CONFIG = (
     ("native_layer_norm_backward", layer_norm_backward),
     ("ne.Scalar", ne_scalar),
     ("ne.Tensor", ne),
+    ("ne_.Scalar", ne_scalar_),
+    ("ne_.Tensor", ne_),
     ("neg", neg),
     ("neg_", neg_),
     ("negative", negative),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -433,6 +433,7 @@ from flag_gems.ops.nansum import nansum, nansum_out
 from flag_gems.ops.narrow import narrow
 from flag_gems.ops.narrow_copy import narrow_copy
 from flag_gems.ops.ne import ne, ne_scalar
+from flag_gems.ops.ne_ import ne_, ne_scalar_
 from flag_gems.ops.neg import neg, neg_
 from flag_gems.ops.negative import negative
 from flag_gems.ops.new_full import new_full
@@ -1209,6 +1210,8 @@ __all__ = [
     "narrow_copy",
     "ne",
     "ne_scalar",
+    "ne_",
+    "ne_scalar_",
     "neg",
     "neg_",
     "negative",

--- a/src/flag_gems/ops/ne_.py
+++ b/src/flag_gems/ops/ne_.py
@@ -21,9 +21,11 @@ logger = logging.getLogger(__name__)
 
 def ne_(A, B):
     logger.debug("GEMS NE_")
-    return ne_func(A, B, out0=A)
+    ne_func(A, B, out0=A)
+    return A
 
 
 def ne_scalar_(A, B):
     logger.debug("GEMS NE_ SCALAR")
-    return ne_func_scalar(A, B, out0=A)
+    ne_func_scalar(A, B, out0=A)
+    return A

--- a/src/flag_gems/ops/ne_.py
+++ b/src/flag_gems/ops/ne_.py
@@ -1,0 +1,29 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from flag_gems.ops.ne import ne_func, ne_func_scalar
+
+logger = logging.getLogger(__name__)
+
+
+def ne_(A, B):
+    logger.debug("GEMS NE_")
+    return ne_func(A, B, out0=A)
+
+
+def ne_scalar_(A, B):
+    logger.debug("GEMS NE_ SCALAR")
+    return ne_func_scalar(A, B, out0=A)

--- a/tests/test_ne_.py
+++ b/tests/test_ne_.py
@@ -34,8 +34,8 @@ def test_ne_(shape, dtype):
     with flag_gems.use_gems():
         res_out = torch.ops.aten.ne_.Tensor(inp1, inp2)
 
-    utils.gems_assert_equal(res_out, ref_out)
-    utils.gems_assert_equal(inp1, ref_inp1)
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(inp1, ref_inp1, dtype)
     assert res_out is inp1
 
 
@@ -52,6 +52,6 @@ def test_ne_scalar_(shape, dtype):
     with flag_gems.use_gems():
         res_out = torch.ops.aten.ne_.Scalar(inp, scalar)
 
-    utils.gems_assert_equal(res_out, ref_out)
-    utils.gems_assert_equal(inp, ref_inp)
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(inp, ref_inp, dtype)
     assert res_out is inp

--- a/tests/test_ne_.py
+++ b/tests/test_ne_.py
@@ -1,0 +1,57 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.ne_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_ne_(shape, dtype):
+    inp1 = torch.randint(0, 10, shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randint(0, 10, shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp1 = utils.to_reference(inp1.clone(), True)
+    ref_inp2 = utils.to_reference(inp2, True)
+    ref_out = ref_inp1.ne_(ref_inp2)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.ne_.Tensor(inp1, inp2)
+
+    utils.gems_assert_equal(res_out, ref_out)
+    utils.gems_assert_equal(inp1, ref_inp1)
+    assert res_out is inp1
+
+
+@pytest.mark.ne_scalar_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_ne_scalar_(shape, dtype):
+    inp = torch.randint(0, 10, shape, dtype=dtype, device=flag_gems.device)
+    scalar = 0
+
+    ref_inp = utils.to_reference(inp.clone(), True)
+    ref_out = ref_inp.ne_(scalar)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.ne_.Scalar(inp, scalar)
+
+    utils.gems_assert_equal(res_out, ref_out)
+    utils.gems_assert_equal(inp, ref_inp)
+    assert res_out is inp


### PR DESCRIPTION
## Local validation summary (NVIDIA H20)

I ran the PR checks locally on the current PR head `27e27850f5d5c9a275620d8c113714db8419511d` without modifying the PR code.

### Comment status
- GitHub review comments: 0
- GitHub PR-level comments: 0
- GitHub reviews: 0

### Commands run
- `python /root/baai-internship/skills/flaggems-pr-submit/scripts/check_operator.py ne_ --repo-dir /root/FlagGems --strict`
- `CUDA_VISIBLE_DEVICES=0 pytest tests/test_ne_.py -q`
- `CUDA_VISIBLE_DEVICES=0 pytest benchmark/test_ne_.py --level core -s`

### Results
- Accuracy: PASS (`36 passed in 1.99s`)
- Benchmark: PASS (`2 passed in 49.60s`)
- Strict operator check: FAIL (`3 errors`, `2 warnings`)

### Strict checker failures to address
- Kernel file is missing the required copyright/license header or KernelGen comment.
- Current branch cannot merge cleanly with `upstream/master` because of unrelated histories.
- `__all__` exports `ne_scalar_`, but `operators.yaml` is missing `id: ne_scalar_`.

### Strict checker warnings
- `ops/__init__.py` import order may need isort.
- YAML includes `ne_.Scalar`, but `_FULL_CONFIG` does not register it.

### Benchmark data

#### ne_ (in-place)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup | TFLOPS |
|---|---|---:|---:|---:|---:|
| float16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 7.166256 | 1.950016 | 3.675x | 1.101 |
| float16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007840 | 0.019840 | 0.395x | 0.000 |
| float16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.117376 | 0.036320 | 3.232x | 0.924 |
| float16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.117408 | 0.035296 | 3.326x | 0.951 |
| float16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 7.166560 | 1.666640 | 4.300x | 1.289 |
| float32 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 5.589184 | 3.060064 | 1.826x | 0.702 |
| float32 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007712 | 0.019968 | 0.386x | 0.000 |
| float32 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.092544 | 0.053024 | 1.745x | 0.633 |
| float32 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.092480 | 0.052368 | 1.766x | 0.641 |
| float32 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 5.590048 | 3.058240 | 1.828x | 0.702 |
| bfloat16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 8.921376 | 1.695952 | 5.260x | 1.266 |
| bfloat16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.008800 | 0.021568 | 0.408x | 0.000 |
| bfloat16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.145728 | 0.036672 | 3.974x | 0.915 |
| bfloat16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.145696 | 0.036816 | 3.957x | 0.911 |
| bfloat16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 8.919328 | 1.677760 | 5.316x | 1.280 |

Arithmetic mean speedup: **2.759x**

#### ne_scalar_ (in-place)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|---|---|---:|---:|---:|
| float16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 3.670400 | 1.246816 | 2.944x |
| float16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007040 | 0.019392 | 0.363x |
| float16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.063648 | 0.027712 | 2.297x |
| float16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.063968 | 0.027488 | 2.327x |
| float16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 3.670448 | 1.246944 | 2.944x |
| float32 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 3.392576 | 2.149616 | 1.578x |
| float32 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007008 | 0.019968 | 0.351x |
| float32 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.058976 | 0.038432 | 1.535x |
| float32 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.059008 | 0.038480 | 1.533x |
| float32 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 3.392256 | 2.149728 | 1.578x |
| bfloat16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 5.764384 | 1.251040 | 4.608x |
| bfloat16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007552 | 0.019232 | 0.393x |
| bfloat16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.097568 | 0.027520 | 3.545x |
| bfloat16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.097248 | 0.027840 | 3.493x |
| bfloat16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 5.765344 | 1.251136 | 4.608x |

Arithmetic mean speedup: **2.246x**

### Multi-backend Testing
| Backend | Accuracy Test | Speedup (mean) | Notes |
|---|---|---:|---|
| Nvidia (H20) | PASS (36 cases) | ne_: 2.759x; ne_scalar_: 2.246x | Primary local run |
| Tianshu | N/A | — | Not run locally |
| Muxi | N/A | — | Not run locally |
| Ascend | N/A | — | Not run locally |
| Hygon | N/A | — | Not run locally |

### Files changed in this PR
- `src/flag_gems/ops/ne_.py`: Triton kernel implementation
- `tests/test_ne_.py`: Accuracy test
- `benchmark/test_ne_.py`: Performance benchmark
- `src/flag_gems/ops/__init__.py`: Register import and `__all__`
- `src/flag_gems/__init__.py`: Register to `_FULL_CONFIG`
- `conf/operators.yaml`: Add operator entry
