### PR TITLE
[KernelGen][Nvidia] Add nan_to_num_ operator

### DIFF
--- a/benchmark/test_nan_to_num_.py
+++ b/benchmark/test_nan_to_num_.py
@@ -1,0 +1,41 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+def _input_fn(shape, cur_dtype, device):
+    inp = utils.generate_tensor_input(shape, cur_dtype, device)
+    inp.view(-1)[0] = float("nan")
+    if inp.numel() > 1:
+        inp.view(-1)[1] = float("inf")
+    if inp.numel() > 2:
+        inp.view(-1)[2] = float("-inf")
+
+    yield inp,
+
+
+@pytest.mark.nan_to_num_
+def test_nan_to_num_():
+    bench = base.GenericBenchmark(
+        op_name="nan_to_num_",
+        input_fn=_input_fn,
+        torch_op=lambda a: a.nan_to_num_(),
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/benchmark/test_nan_to_num_.py
+++ b/benchmark/test_nan_to_num_.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-import torch
 
 from . import base, consts, utils
 

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6253,6 +6253,19 @@ ops:
       - Math
     stages:
       - stable: '3.0'
+  - id: nan_to_num_
+    description: |
+      Replaces NaN, positive infinity, and negative infinity values in input in-place.
+    for:
+      - nan_to_num_
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: nanmedian
     description: Returns the median of the values in `input`, ignoring `NaN` values.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -617,6 +617,7 @@ _FULL_CONFIG = (
     ("mv", mv),
     ("mvlgamma_", mvlgamma_),
     ("nan_to_num", nan_to_num),
+    ("nan_to_num_", nan_to_num_),
     ("nanmedian", nanmedian),
     ("nanmedian.dim", nanmedian_dim),
     ("nanmedian.dim_values", nanmedian_dim_values),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -423,6 +423,7 @@ from flag_gems.ops.multiply_ import multiply_
 from flag_gems.ops.mv import mv
 from flag_gems.ops.mvlgamma_ import mvlgamma_
 from flag_gems.ops.nan_to_num import nan_to_num
+from flag_gems.ops.nan_to_num_ import nan_to_num_
 from flag_gems.ops.nanmedian import (
     nanmedian,
     nanmedian_dim,
@@ -1199,6 +1200,7 @@ __all__ = [
     "mv",
     "mvlgamma_",
     "nan_to_num",
+    "nan_to_num_",
     "nanmedian",
     "nanmedian_dim",
     "nanmedian_dim_values",

--- a/src/flag_gems/ops/nan_to_num_.py
+++ b/src/flag_gems/ops/nan_to_num_.py
@@ -1,0 +1,32 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+
+from flag_gems.ops.nan_to_num import nan_to_num_func
+
+logger = logging.getLogger(__name__)
+
+
+def nan_to_num_(A, nan=None, posinf=None, neginf=None):
+    logger.debug("GEMS NAN_TO_NUM_")
+    if posinf is None:
+        posinf = torch.finfo(A.dtype).max
+    if neginf is None:
+        neginf = torch.finfo(A.dtype).min
+    if nan is None:
+        nan = 0.0
+    return nan_to_num_func(A, nan, posinf, neginf, out0=A)

--- a/tests/test_nan_to_num_.py
+++ b/tests/test_nan_to_num_.py
@@ -1,0 +1,46 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.nan_to_num_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("nan", [None, 0.0, 2.3])
+@pytest.mark.parametrize("posinf", [None, 999.0])
+@pytest.mark.parametrize("neginf", [None, -999.0])
+def test_nan_to_num_(shape, dtype, nan, posinf, neginf):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    base.view(-1)[0] = float("nan")
+    if base.numel() > 1:
+        base.view(-1)[1] = float("inf")
+    if base.numel() > 2:
+        base.view(-1)[2] = float("-inf")
+
+    ref_input = utils.to_reference(base)
+    ref_out = ref_input.nan_to_num_(nan=nan, posinf=posinf, neginf=neginf)
+
+    inp1 = base.clone()
+    with flag_gems.use_gems():
+        res_out = inp1.nan_to_num_(nan=nan, posinf=posinf, neginf=neginf)
+
+    utils.gems_assert_equal(res_out, ref_out)
+    utils.gems_assert_equal(inp1, ref_input)
+    assert res_out is inp1


### PR DESCRIPTION
## Local validation summary (NVIDIA H20)

I ran the PR checks locally on the current PR head `9198f7cc306053a507bf1c8d94b6d8e95d9d1ad8` without modifying the PR code.

### Comment status
- GitHub review comments: 0
- GitHub PR-level comments: 0
- GitHub reviews: 0

### Commands run
- `python /root/baai-internship/skills/flaggems-pr-submit/scripts/check_operator.py nan_to_num_ --repo-dir /root/FlagGems --strict`
- `CUDA_VISIBLE_DEVICES=0 pytest tests/test_nan_to_num_.py -q`
- `CUDA_VISIBLE_DEVICES=0 pytest benchmark/test_nan_to_num_.py --level core -s`

### Results
- Accuracy: PASS (`216 passed in 3.82s`)
- Benchmark: PASS (`1 passed in 23.82s`)
- Strict operator check: FAIL (`3 errors`, `2 warnings`)

### Strict checker failures to address
- Kernel file is missing the required copyright/license header or KernelGen comment.
- Branch merge check failed against `upstream/master` with `fatal: refusing to merge unrelated histories`.
- Anti-hack Layer 2 failed: the kernel did not use Triton for actual computation.

### Strict checker warnings
- `ops/__init__.py` import order may need isort.
- NaN-related inputs were detected, but the tests did not use `equal_nan=True`.

### Benchmark data

#### nan_to_num_ (in-place)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|---|---|---:|---:|---:|
| float16 | `[torch.Size([1073741824])]` | 1.352672 | 1.703744 | 0.794x |
| float16 | `[torch.Size([64, 64])]` | 0.005280 | 0.023536 | 0.224x |
| float16 | `[torch.Size([4096, 4096])]` | 0.025280 | 0.031872 | 0.793x |
| float16 | `[torch.Size([64, 512, 512])]` | 0.025312 | 0.031600 | 0.801x |
| float16 | `[torch.Size([1024, 1024, 1024])]` | 1.393152 | 1.329856 | 1.048x |
| float32 | `[torch.Size([1073741824])]` | 2.048224 | 2.255552 | 0.908x |
| float32 | `[torch.Size([64, 64])]` | 0.005312 | 0.022848 | 0.232x |
| float32 | `[torch.Size([4096, 4096])]` | 0.036448 | 0.041408 | 0.880x |
| float32 | `[torch.Size([64, 512, 512])]` | 0.036448 | 0.041632 | 0.875x |
| float32 | `[torch.Size([1024, 1024, 1024])]` | 2.046608 | 2.205408 | 0.928x |
| bfloat16 | `[torch.Size([1073741824])]` | 1.371344 | 1.361584 | 1.007x |
| bfloat16 | `[torch.Size([64, 64])]` | 0.005344 | 0.022560 | 0.237x |
| bfloat16 | `[torch.Size([4096, 4096])]` | 0.025216 | 0.032192 | 0.783x |
| bfloat16 | `[torch.Size([64, 512, 512])]` | 0.025216 | 0.032096 | 0.786x |
| bfloat16 | `[torch.Size([1024, 1024, 1024])]` | 1.363264 | 1.330048 | 1.025x |

Arithmetic mean speedup: **0.755x**

### Multi-backend Testing
| Backend | Accuracy Test | Speedup (mean) | Notes |
|---|---|---:|---|
| Nvidia (H20) | PASS (216 cases) | 0.755x | Primary local run |
| Tianshu | N/A | — | Not run locally |
| Muxi | N/A | — | Not run locally |
| Ascend | N/A | — | Not run locally |
| Hygon | N/A | — | Not run locally |

### Files changed in this PR
- `src/flag_gems/ops/nan_to_num_.py`: Triton kernel implementation
- `tests/test_nan_to_num_.py`: Accuracy test
- `benchmark/test_nan_to_num_.py`: Performance benchmark
- `src/flag_gems/ops/__init__.py`: Register import and `__all__`
- `src/flag_gems/__init__.py`: Register to `_FULL_CONFIG`
- `conf/operators.yaml`: Add operator entry
