### PR TITLE
[KernelGen][Nvidia] Add xlogy_ operator

### DIFF
--- a/benchmark/test_xlogy_.py
+++ b/benchmark/test_xlogy_.py
@@ -1,0 +1,54 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from . import base, consts
+
+
+def xlogy_input_fn(shape, dtype, device):
+    inp1 = torch.randn(shape, dtype=dtype, device=device)
+    # keep ``other`` positive so ``log`` stays finite
+    inp2 = torch.rand(shape, dtype=dtype, device=device) * 5.0 + 0.01
+    yield inp1, inp2
+
+
+@pytest.mark.xlogy_
+def test_xlogy_():
+    bench = base.GenericBenchmark(
+        op_name="xlogy_",
+        torch_op=lambda a, b: a.xlogy_(b),
+        input_fn=xlogy_input_fn,
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()
+
+
+def xlogy_scalar_other_input_fn(shape, dtype, device):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    yield inp, 3.5
+
+
+@pytest.mark.xlogy_scalar_other_
+def test_xlogy_scalar_other_():
+    bench = base.GenericBenchmark(
+        op_name="xlogy_scalar_other_",
+        torch_op=lambda a, b: a.xlogy_(b),
+        input_fn=xlogy_scalar_other_input_fn,
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5378,6 +5378,20 @@ ops:
       - Math
     stages:
       - beta: '5.4'
+  - id: xlogy_
+    description: |
+      Computes x * log(y) element-wise in-place on x.
+    for:
+      - xlogy_.Tensor
+      - xlogy_.Scalar_Other
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: logaddexp
     description: Computes the element-wise logarithm of the sum of the exponentials of two input tensors.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -919,6 +919,8 @@ _FULL_CONFIG = (
     ("xlogy.Scalar_Other", xlogy_tensor_scalar),
     ("xlogy.Scalar_Self", xlogy_scalar_tensor),
     ("xlogy.Tensor", xlogy),
+    ("xlogy_.Scalar_Other", xlogy_tensor_scalar_),
+    ("xlogy_.Tensor", xlogy_),
     ("zero", zero),
     ("zero.out", zero_out),
     ("zero_", zero_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -697,6 +697,7 @@ from flag_gems.ops.xlogy import (
     xlogy_tensor_scalar,
     xlogy_tensor_scalar_out,
 )
+from flag_gems.ops.xlogy_ import xlogy_, xlogy_tensor_scalar_
 from flag_gems.ops.zero import zero, zero_out
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
@@ -1141,6 +1142,8 @@ __all__ = [
     "xlogy_tensor_scalar_out",
     "xlogy_scalar_tensor",
     "xlogy_scalar_tensor_out",
+    "xlogy_",
+    "xlogy_tensor_scalar_",
     "logical_and",
     "logical_and_",
     "logical_not",

--- a/src/flag_gems/ops/xlogy_.py
+++ b/src/flag_gems/ops/xlogy_.py
@@ -1,0 +1,29 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from flag_gems.ops.xlogy import xlogy_func, xlogy_func_tensor_scalar
+
+logger = logging.getLogger(__name__)
+
+
+def xlogy_(A, B):
+    logger.debug("GEMS XLOGY_")
+    return xlogy_func(A, B, out0=A)
+
+
+def xlogy_tensor_scalar_(A, B):
+    logger.debug("GEMS XLOGY_ TENSOR_SCALAR")
+    return xlogy_func_tensor_scalar(A, B, out0=A)

--- a/tests/test_xlogy_.py
+++ b/tests/test_xlogy_.py
@@ -1,0 +1,81 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.xlogy_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_xlogy_(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    # keep ``other`` positive so ``log`` stays finite for a clean comparison
+    y = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 5.0 + 0.01
+
+    ref_x = utils.to_reference(x.clone(), True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = ref_x.xlogy_(ref_y)
+
+    with flag_gems.use_gems():
+        res_out = x.xlogy_(y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(x, ref_x, dtype)
+    assert res_out is x
+
+
+@pytest.mark.xlogy_
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_xlogy_special_values_(dtype):
+    # Exercise the PyTorch precedence: NaN(other) -> NaN; x == 0 -> 0; else x*log(y)
+    x = torch.tensor([0.0, 0.0, 2.0, 3.0, 0.0], dtype=dtype, device=flag_gems.device)
+    y = torch.tensor(
+        [5.0, 0.0, 4.0, float("nan"), float("nan")],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+
+    ref_x = utils.to_reference(x.clone(), True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = ref_x.xlogy_(ref_y)
+
+    with flag_gems.use_gems():
+        res_out = x.xlogy_(y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+    utils.gems_assert_close(x, ref_x, dtype, equal_nan=True)
+    assert res_out is x
+
+
+@pytest.mark.xlogy_tensor_scalar_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_xlogy_tensor_scalar_(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    scalar = 3.5
+
+    ref_x = utils.to_reference(x.clone(), True)
+    ref_out = ref_x.xlogy_(scalar)
+
+    with flag_gems.use_gems():
+        res_out = x.xlogy_(scalar)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(x, ref_x, dtype)
+    assert res_out is x


### PR DESCRIPTION
## Local validation summary (NVIDIA H20)

I ran the PR checks locally on the current PR head `fd474c7b7d8d275bef2c78d09704a39e31d969e9` without modifying the PR code.

### Comment status
- GitHub review comments: 0
- GitHub PR-level comments: 0
- GitHub reviews: 0

### Commands run
- `python /root/baai-internship/skills/flaggems-pr-submit/scripts/check_operator.py xlogy_ --repo-dir /root/FlagGems --strict`
- `CUDA_VISIBLE_DEVICES=0 pytest tests/test_xlogy_.py -q`
- `CUDA_VISIBLE_DEVICES=0 pytest benchmark/test_xlogy_.py --level core -s`

### Results
- Accuracy: PASS (`39 passed in 3.01s`)
- Benchmark: PASS (`2 passed in 49.20s`)
- Strict operator check: FAIL (`4 errors`, `7 warnings`)

### Strict checker failures to address
- Kernel file is missing the required copyright/license header or KernelGen comment.
- `test_xlogy_special_values_` uses `@pytest.mark.xlogy_`; the checker expects `@pytest.mark.xlogy_special_values_`.
- Branch merge check failed against `upstream/master` with `fatal: refusing to merge unrelated histories`.
- `__all__` exports in-place function `xlogy_tensor_scalar_`, but YAML is missing `id: xlogy_tensor_scalar_`.

### Strict checker warnings
- `ops/__init__.py` import order may need isort.
- Benchmark contains extra pytest mark `xlogy_scalar_other_`; please confirm whether it belongs to this operator.
- YAML `for` contains `xlogy_.Scalar_Other`, but `_FULL_CONFIG` does not register it.
- `__all__` exports `xlogy_tensor_scalar_`, but benchmark is missing `test_xlogy_tensor_scalar_`.
- In-place tests `test_xlogy_`, `test_xlogy_special_values_`, and `test_xlogy_tensor_scalar_` only compare returned values; the checker suggests also comparing the mutated input.

### Benchmark data

#### xlogy_ (in-place)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|---|---|---:|---:|---:|
| float16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 3.531408 | 3.531648 | 1.000x |
| float16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.006048 | 0.015904 | 0.380x |
| float16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.047264 | 0.051680 | 0.915x |
| float16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.047328 | 0.051776 | 0.914x |
| float16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 2.688032 | 2.692224 | 0.998x |
| float32 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 3.639104 | 3.463520 | 1.051x |
| float32 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.005920 | 0.017504 | 0.338x |
| float32 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.055072 | 0.058640 | 0.939x |
| float32 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.054944 | 0.058624 | 0.937x |
| float32 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 3.468224 | 3.583808 | 0.968x |
| bfloat16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 2.850848 | 2.883808 | 0.989x |
| bfloat16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.005984 | 0.017632 | 0.339x |
| bfloat16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.048608 | 0.053536 | 0.908x |
| bfloat16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.048608 | 0.053888 | 0.902x |
| bfloat16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 2.837216 | 2.834704 | 1.001x |

Arithmetic mean speedup: **0.838x**

#### xlogy_scalar_other_ (in-place scalar-other)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|---|---|---:|---:|---:|
| float16 | `[torch.Size([1073741824]), 3.5]` | 2.357616 | 1.272480 | 1.853x |
| float16 | `[torch.Size([64, 64]), 3.5]` | 0.005632 | 0.017312 | 0.325x |
| float16 | `[torch.Size([4096, 4096]), 3.5]` | 0.042688 | 0.028320 | 1.507x |
| float16 | `[torch.Size([64, 512, 512]), 3.5]` | 0.042656 | 0.028256 | 1.510x |
| float16 | `[torch.Size([1024, 1024, 1024]), 3.5]` | 2.357728 | 1.272480 | 1.853x |
| float32 | `[torch.Size([1073741824]), 3.5]` | 2.093152 | 2.149024 | 0.974x |
| float32 | `[torch.Size([64, 64]), 3.5]` | 0.005664 | 0.015888 | 0.356x |
| float32 | `[torch.Size([4096, 4096]), 3.5]` | 0.037952 | 0.038368 | 0.989x |
| float32 | `[torch.Size([64, 512, 512]), 3.5]` | 0.037856 | 0.038352 | 0.987x |
| float32 | `[torch.Size([1024, 1024, 1024]), 3.5]` | 2.087648 | 2.149056 | 0.971x |
| bfloat16 | `[torch.Size([1073741824]), 3.5]` | 2.385760 | 1.289120 | 1.851x |
| bfloat16 | `[torch.Size([64, 64]), 3.5]` | 0.005728 | 0.016576 | 0.346x |
| bfloat16 | `[torch.Size([4096, 4096]), 3.5]` | 0.042784 | 0.028576 | 1.497x |
| bfloat16 | `[torch.Size([64, 512, 512]), 3.5]` | 0.042816 | 0.028544 | 1.500x |
| bfloat16 | `[torch.Size([1024, 1024, 1024]), 3.5]` | 2.381504 | 1.285696 | 1.852x |

Arithmetic mean speedup: **1.224x**

### Multi-backend Testing
| Backend | Accuracy Test | Speedup (mean) | Notes |
|---|---|---:|---|
| Nvidia (H20) | PASS (39 cases) | xlogy_: 0.838x; xlogy_scalar_other_: 1.224x | Primary local run |
| Tianshu | N/A | — | Not run locally |
| Muxi | N/A | — | Not run locally |
| Ascend | N/A | — | Not run locally |
| Hygon | N/A | — | Not run locally |

### Files changed in this PR
- `src/flag_gems/ops/xlogy_.py`: Triton kernel implementation
- `tests/test_xlogy_.py`: Accuracy test
- `benchmark/test_xlogy_.py`: Performance benchmark
- `src/flag_gems/ops/__init__.py`: Register import and `__all__`
- `src/flag_gems/__init__.py`: Register to `_FULL_CONFIG`
- `conf/operators.yaml`: Add operator entry

