### PR TITLE
[KernelGen][Nvidia] Add atan2_ operator

### DIFF
--- a/benchmark/test_atan2_.py
+++ b/benchmark/test_atan2_.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-import torch
 
 import flag_gems
 

--- a/benchmark/test_atan2_.py
+++ b/benchmark/test_atan2_.py
@@ -1,0 +1,34 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+
+@pytest.mark.atan2_
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_atan2_():
+    bench = base.BinaryPointwiseBenchmark(
+        op_name="atan2_",
+        torch_op=lambda a, b: a.atan2_(b),
+        dtypes=consts.FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -962,6 +962,19 @@ ops:
       - Math
     stages:
       - beta: '5.3'
+  - id: atan2_
+    description: |
+      Computes the element-wise arctangent of input/other in-place.
+    for:
+      - atan2_
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: atan_
     description: The in-place version of `atan()`.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -246,6 +246,7 @@ _FULL_CONFIG = (
     ("atan", atan),
     ("atan2", atan2),
     ("atan2.out", atan2_out),
+    ("atan2_", atan2_),
     ("atan_", atan_),
     ("atanh", atanh),
     ("avg_pool2d", avg_pool2d),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -120,6 +120,7 @@ from flag_gems.ops.asinh_ import asinh_
 from flag_gems.ops.assert_async import _assert_async
 from flag_gems.ops.atan import atan, atan_
 from flag_gems.ops.atan2 import atan2, atan2_out
+from flag_gems.ops.atan2_ import atan2_
 from flag_gems.ops.atanh import atanh, atanh_
 from flag_gems.ops.attention import (
     ScaleDotProductAttention,
@@ -824,6 +825,7 @@ __all__ = [
     "atan",
     "atan2",
     "atan2_out",
+    "atan2_",
     "atan_",
     "atanh",
     "atanh_",

--- a/src/flag_gems/ops/atan2_.py
+++ b/src/flag_gems/ops/atan2_.py
@@ -1,0 +1,24 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from flag_gems.ops.atan2 import atan2_kernel
+
+logger = logging.getLogger(__name__)
+
+
+def atan2_(A, B):
+    logger.debug("GEMS ATAN2_")
+    return atan2_kernel(A, B, out0=A)

--- a/tests/test_atan2_.py
+++ b/tests/test_atan2_.py
@@ -1,0 +1,40 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.atan2_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_atan2_(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x.clone(), True)
+    ref_y = utils.to_reference(y, True)
+
+    ref_out = ref_x.atan2_(ref_y)
+
+    with flag_gems.use_gems():
+        res_out = x.atan2_(y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(x, ref_x, dtype)
+    assert res_out is x


### PR DESCRIPTION
## Local validation summary (NVIDIA H20)

I ran the PR checks locally on the current PR head `f1f2d20607e0c8819849f1661729f20c8181a85a` without modifying the PR code.

### Comment status
- GitHub review comments: 0
- GitHub PR-level comments: 0
- GitHub reviews: 0

### Commands run
- `python /root/baai-internship/skills/flaggems-pr-submit/scripts/check_operator.py atan2_ --repo-dir /root/FlagGems --strict`
- `CUDA_VISIBLE_DEVICES=0 pytest tests/test_atan2_.py -q`
- `CUDA_VISIBLE_DEVICES=0 pytest benchmark/test_atan2_.py --level core -s`

### Results
- Accuracy: PASS (`18 passed in 2.29s`)
- Benchmark: PASS (`1 passed in 34.39s`)
- Strict operator check: FAIL (`2 errors`, `2 warnings`)

### Strict checker failures to address
- Kernel file is missing the required copyright/license header or KernelGen comment.
- Branch merge check failed against `upstream/master` with `fatal: refusing to merge unrelated histories`.

### Strict checker warnings
- `ops/__init__.py` import order may need isort.
- In-place test `test_atan2_` only compares the returned value; the checker suggests also comparing the mutated input.

### Benchmark data

#### atan2_ (in-place)

| dtype | Size | Torch Latency (ms) | Gems Latency (ms) | Speedup | TFLOPS |
|---|---|---:|---:|---:|---:|
| float16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 4.306016 | 4.876688 | 0.883x | 0.440 |
| float16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.007040 | 0.018720 | 0.376x | 0.000 |
| float16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.073760 | 0.089184 | 0.827x | 0.376 |
| float16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.073760 | 0.089280 | 0.826x | 0.376 |
| float16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 4.274896 | 4.876528 | 0.877x | 0.440 |
| float32 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 9.267328 | 6.557376 | 1.413x | 0.327 |
| float32 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.008480 | 0.018864 | 0.450x | 0.000 |
| float32 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.152928 | 0.101824 | 1.502x | 0.330 |
| float32 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.153056 | 0.101728 | 1.505x | 0.330 |
| float32 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 9.259008 | 6.289504 | 1.472x | 0.341 |
| bfloat16 | `[torch.Size([1073741824]), torch.Size([1073741824])]` | 9.356288 | 6.247136 | 1.498x | 0.344 |
| bfloat16 | `[torch.Size([64, 64]), torch.Size([64, 64])]` | 0.008384 | 0.018528 | 0.453x | 0.000 |
| bfloat16 | `[torch.Size([4096, 4096]), torch.Size([4096, 4096])]` | 0.152640 | 0.105184 | 1.451x | 0.319 |
| bfloat16 | `[torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]` | 0.152704 | 0.105312 | 1.450x | 0.319 |
| bfloat16 | `[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]` | 9.363616 | 6.247168 | 1.499x | 0.344 |

Arithmetic mean speedup: **1.099x**

### Multi-backend Testing
| Backend | Accuracy Test | Speedup (mean) | Notes |
|---|---|---:|---|
| Nvidia (H20) | PASS (18 cases) | 1.099x | Primary local run |
| Tianshu | N/A | — | Not run locally |
| Muxi | N/A | — | Not run locally |
| Ascend | N/A | — | Not run locally |
| Hygon | N/A | — | Not run locally |

### Files changed in this PR
- `src/flag_gems/ops/atan2_.py`: Triton kernel implementation
- `tests/test_atan2_.py`: Accuracy test
- `benchmark/test_atan2_.py`: Performance benchmark
- `src/flag_gems/ops/__init__.py`: Register import and `__all__`
- `src/flag_gems/__init__.py`: Register to `_FULL_CONFIG`
- `conf/operators.yaml`: Add operator entry

