### PR TITLE
Use the explicit scale factor in upsample_bicubic2d

### DIFF
--- a/src/flag_gems/ops/upsample_bicubic2d.py
+++ b/src/flag_gems/ops/upsample_bicubic2d.py
@@ -212,8 +212,19 @@ def upsample_bicubic2d(
         scale_h = 0.0 if H_out <= 1 else (H_in - 1.0) / (H_out - 1.0)
         scale_w = 0.0 if W_out <= 1 else (W_in - 1.0) / (W_out - 1.0)
     else:
-        scale_h = float(H_in) / float(H_out)
-        scale_w = float(W_in) / float(W_out)
+        # An explicit scale factor wins over the size ratio, as in ATen's
+        # compute_scales_value (and in bicubic_reciprocal_scale next door in
+        # upsample_bicubic2d_aa.py). The two differ whenever the output size is
+        # not exactly H_in / scales_h, which is the usual case for a
+        # non-integral scale_factor.
+        if scales_h is not None and scales_h > 0:
+            scale_h = 1.0 / float(scales_h)
+        else:
+            scale_h = float(H_in) / float(H_out)
+        if scales_w is not None and scales_w > 0:
+            scale_w = 1.0 / float(scales_w)
+        else:
+            scale_w = float(W_in) / float(W_out)
 
     out = torch.empty((N, C, H_out, W_out), dtype=input.dtype, device=device)
 

--- a/tests/test_upsample_bicubic2d.py
+++ b/tests/test_upsample_bicubic2d.py
@@ -61,3 +61,24 @@ def test_upsample_bicubic2d(N, C, H, W, outH, outW, align_corners, use_scale, dt
         )
 
     utils.gems_assert_close(res_out.to(dtype=dtype), ref_out, dtype, reduce_dim=16)
+
+
+# The parametrized cases above always derive scale_factors as (outH / H, outW / W),
+# which makes 1 / scale equal to H / outH by construction -- the one case where using
+# the size ratio instead of the explicit scale factor happens to be right.
+@pytest.mark.upsample_bicubic2d
+@pytest.mark.parametrize("shape", [(1, 2, 3, 3), (1, 2, 5, 5), (2, 3, 7, 5)])
+@pytest.mark.parametrize("scale_factor", [1.5, 2.5])
+@pytest.mark.parametrize("dtype", UPSAMPLE_BICUBIC2D_DTYPES)
+def test_upsample_bicubic2d_explicit_scale_factor(shape, scale_factor, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    scale_factors = (scale_factor, scale_factor)
+
+    ref_x = utils.to_reference(x, True)
+    ref_out = torch._C._nn.upsample_bicubic2d(ref_x, None, False, scale_factors).to(
+        dtype=dtype
+    )
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_bicubic2d(x, None, False, scale_factors)
+
+    utils.gems_assert_close(res_out.to(dtype=dtype), ref_out, dtype, reduce_dim=16)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`upsample_bicubic2d` takes `scales_h` / `scales_w` and never reads them: the `align_corners=False` branch always computes the sampling scale as `input_size / output_size`. ATen's `compute_scales_value` prefers an explicit scale factor and uses `1.0 / scales`, and the two disagree whenever the output size is not exactly `input_size / scale_factor`.

`F.interpolate(x, scale_factor=s, mode="bicubic")` passes both the derived output size and `s`, so under `use_gems()` every bicubic resize by a non-integral scale factor samples at the wrong positions: different cubic weights, and at some output pixels a different source pixel.

Changes:

- `src/flag_gems/ops/upsample_bicubic2d.py`: in the `align_corners=False` branch, use `1.0 / scales` when a positive explicit scale is given, otherwise the size ratio — the same rule as `bicubic_reciprocal_scale` in `upsample_bicubic2d_aa.py`. The kernel and the `align_corners=True` branch are unchanged.
- `tests/test_upsample_bicubic2d.py`: add cases that pass a scale factor the output size does not reproduce.

Against eager `torch.ops.aten.upsample_bicubic2d`, fp32, `(1, 2, H, W)` inputs, `align_corners=False`:

| input → output | scales | before | after |
|---|---|---|---|
| 3x3 → 4x4 | 1.5 | max abs error 0.900 | 2e-06 |
| 5x5 → 7x7 | 1.5 | 1.109 | 2e-06 |
| 3x3 → 7x7 | 2.5 | 0.342 | 3e-06 |
| 7x5 → 10x7 | 1.5 | 1.957 | 2e-06 |

Unchanged, as expected: an exact ratio (4x4 → 6x6 at 1.5, where `4/6 == 1/1.5`), calls with no explicit scale, and the `align_corners=True` branch.

### Issue

Resolves #5216

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
