### PR TITLE
Fix upsample_linear1d_backward dropping gradient terms with align_corners

### DIFF
--- a/src/flag_gems/ops/upsample_linear1d_backward.py
+++ b/src/flag_gems/ops/upsample_linear1d_backward.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import math
 
 import torch
 import triton
@@ -147,7 +148,15 @@ def upsample_linear1d_backward(
 
     BLOCK = 512
     WINDOW = 2
-    if out_w > 2 * in_w:
+    if align_corners and in_w > 1:
+        # With align_corners the input-to-output stretch is (out_w - 1) / (in_w - 1),
+        # not out_w / in_w, and it is the stretch that says how far an input pixel's
+        # contributions reach. An output position further away than WINDOW is never
+        # scanned, so its weight would be dropped from the gradient.
+        reach = (out_w - 1) / (in_w - 1)
+        if reach > 2:
+            WINDOW = math.ceil(reach) + 1
+    elif out_w > 2 * in_w:
         WINDOW = triton.cdiv(out_w, in_w) + 2
     grid = (triton.cdiv(n * c * in_w, BLOCK),)
 

--- a/tests/test_upsample_linear1d.py
+++ b/tests/test_upsample_linear1d.py
@@ -236,3 +236,35 @@ def test_upsample_linear1d_backward(
         reduce_dim = (out_w + input_w - 1) // input_w
 
     gems_assert_close(res_out, ref_out, dtype, atol=atol, reduce_dim=reduce_dim)
+
+
+# align_corners stretches the input-to-output mapping by (out_w - 1) / (in_w - 1),
+# which is larger than out_w / in_w. These ratios are the first ones past that
+# difference for each input width; the grid above stops at 4.0 and never reaches them.
+@pytest.mark.upsample_linear1d_backward
+@pytest.mark.parametrize("in_w, out_w", [(2, 10), (3, 24), (4, 44), (8, 200)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_upsample_linear1d_backward_align_corners_large_ratio(in_w, out_w, dtype):
+    shape = (1, 1, in_w)
+    # a constant gradient makes the shortfall exact: each input cell must collect
+    # the total weight of every output position that interpolates from it
+    res_grad = torch.ones((1, 1, out_w), dtype=dtype, device=flag_gems.device)
+    ref_grad = to_reference(res_grad)
+
+    ref_out = upsample_linear1d_backward_call(ref_grad, shape, True)
+    with flag_gems.use_gems():
+        res_out = upsample_linear1d_backward_call(res_grad, shape, True)
+
+    if dtype == torch.float32:
+        atol = 1e-4
+    elif dtype == torch.float16:
+        atol = 1e-2
+    else:
+        atol = 2e-2
+
+    gems_assert_close(
+        res_out, ref_out, dtype, atol=atol, reduce_dim=(out_w + in_w - 1) // in_w
+    )


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix upsample_linear1d_backward #5218
Changes:
- `src/flag_gems/ops/upsample_linear1d_backward.py`: when `align_corners` is set and `in_w > 1`, size the window from `(out_w - 1) / (in_w - 1)`. The `align_corners=False` path is untouched.
- `tests/test_upsample_linear1d.py`: add a backward test at large ratios with `align_corners=True`. The existing grid stops at `scale_factor=4.0`, one step below where the window first falls short.

Against eager `torch.ops.aten.upsample_linear1d_backward`, fp32, all-ones gradient so the shortfall is exact:

| in_w | out_w | before | after |
|---|---|---|---|
| 2 | 10 | 0.111 short | exact |
| 3 | 24 | 0.087 short | exact |
| 4 | 44 | 0.070 short | exact |
| 8 | 200 | 0.055 short | exact |

`F.interpolate(x, size=10, mode="linear", align_corners=True).backward(ones)` on a length-2 input returns `[4.889, 4.889]` before and `[5.0, 5.0]` after.

### Issue

Resolves #5218

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
