### PR TITLE
Fix cudnn_batch_norm_backward treating the saved inverse std as a variance

### DIFF
--- a/src/flag_gems/ops/cudnn_batch_norm_backward.py
+++ b/src/flag_gems/ops/cudnn_batch_norm_backward.py
@@ -8,7 +8,7 @@ from torch import Tensor
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry, tl_extra_shim
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +69,10 @@ def cudnn_batch_norm_backward_kernel(
     feat_pid = tl.program_id(axis=0)
 
     mean = tl.load(feat_pid + mean_pointer).to(tl.float32)
-    var = tl.load(feat_pid + var_pointer).to(tl.float32)
-    inv_std = tl_extra_shim.rsqrt(var + eps)
+    # cudnn_batch_norm saves cuDNN's resultSaveInvVariance: the tensor handed
+    # here already is 1/sqrt(var + eps), so consume it directly — exactly as
+    # batch_norm.py's backward consumes its saved inv_std.
+    inv_std = tl.load(feat_pid + var_pointer).to(tl.float32)
 
     term1 = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
     term2 = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
@@ -202,7 +204,7 @@ def cudnn_batch_norm_backward(
             input_3d,
             weight,
             save_mean,
-            save_var,  # Pass variance
+            save_var,  # Saved inverse standard deviation from the forward
             input_grad,
             weight_grad,
             bias_grad,

--- a/tests/test_cudnn_batch_norm_backward.py
+++ b/tests/test_cudnn_batch_norm_backward.py
@@ -24,7 +24,10 @@ from . import accuracy_utils as utils
 def test_cudnn_batch_norm_backward(shape, dtype, affine):
     C = shape[1]
     # Create input and weight tensors (no requires_grad for backward kernel test)
-    res_inp = torch.randn(size=shape, dtype=dtype, device=flag_gems.device)
+    # Scale the input so the per-channel variance sits well away from 1.0:
+    # unit variance is the one fixed point where a kernel that re-applies
+    # rsqrt to the saved inverse std still returns the right answer.
+    res_inp = torch.randn(size=shape, dtype=dtype, device=flag_gems.device) * 3.0
     # Always create weight for cudnn_batch_norm_backward
     res_weight = torch.ones(size=(C,), dtype=dtype, device=flag_gems.device)
     # For bias, we always create one but only check gradients when affine=True
@@ -59,7 +62,10 @@ def test_cudnn_batch_norm_backward(shape, dtype, affine):
     ref_weight = utils.to_reference(res_weight, True)
     ref_save_mean = utils.to_reference(save_mean, True)
     ref_save_var = utils.to_reference(save_var, True)
-    ref_save_invstd = torch.rsqrt(ref_save_var + eps)
+    # cudnn_batch_norm returns cuDNN's resultSaveInvVariance: save_var already
+    # is 1/sqrt(var + eps) (PyTorch's own decomposition passes it straight into
+    # native_batch_norm_backward's save_invstd slot), so no transform here.
+    ref_save_invstd = ref_save_var
     # For native_batch_norm_backward, we still need to output all gradients
     output_mask = [True, True, True]
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`aten::cudnn_batch_norm` saves cuDNN's `resultSaveInvVariance` — already `1/sqrt(var + eps)` — and PyTorch's decomposition passes it straight into `native_batch_norm_backward`'s `save_invstd` slot. `cudnn_batch_norm_backward_kernel` treated that argument as a variance and applied `rsqrt(save_var + eps)` again, so `grad_input` (which carries `inv_std` cubed) and `grad_weight` came back wrong by multiples of the correct answer whenever the per-channel variance is away from 1.0. `grad_bias` never touches `inv_std` and was unaffected. Under `flag_gems.enable()`, any `nn.BatchNorm1d/2d/3d` backward on CUDA hits this: the forward stays real cuDNN (FlagGems does not override it), the backward runs this kernel.

Changes:

- `src/flag_gems/ops/cudnn_batch_norm_backward.py`: consume the saved value as `inv_std` directly — the same convention as `batch_norm.py`'s backward (which loads its saved `inv_std` with no second `rsqrt`) and `miopen_batch_norm_backward.py` (which documents `save_var` as the saved inverse std). The now-unused `tl_extra_shim` import and the misleading `# Pass variance` comment go with it; `eps` stays in the kernel signature.
- `tests/test_cudnn_batch_norm_backward.py`: the reference applied the identical wrong transform (`ref_save_invstd = torch.rsqrt(ref_save_var + eps)`), comparing the defect against itself — it now uses `ref_save_var` as the inverse std it is. The input is also scaled by 3 so the per-channel variance sits away from 1.0, the fixed point of the wrong transform where even a broken kernel returns the right answer.

Statistics from a real `cudnn_batch_norm` forward on a `(8, 4, 8, 8)` input with std 3, against eager `cudnn_batch_norm_backward`:

| | before | after |
|---|---|---|
| `grad_input` max abs err (peak true value 0.88) | 8.2 | 6e-08 |
| `grad_weight` max abs err (peak true value 38.7) | 159.2 | 4e-06 |
| `grad_bias` max abs err | 4e-06 | 8e-06 |

### Issue

Resolves #5222

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.