### PR TITLE
Fix out-of-bounds read past the input tail in bucketize kernel

### DIFF
--- a/src/flag_gems/ops/bucketize.py
+++ b/src/flag_gems/ops/bucketize.py
@@ -45,7 +45,7 @@ def bucketize_kernel(
 
     # Load input value directly using pointer arithmetic
     # For contiguous row-major tensors, offset i corresponds to element i
-    inp_val = tl.load(inp_ptr + offsets)
+    inp_val = tl.load(inp_ptr + offsets, mask=mask, other=0)
 
     # Binary search for each value
     # boundaries is a 1-D tensor of length n_boundaries


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`bucketize_kernel` computes the tail mask (`offsets < n_elements`) and applies it to the store but not to the input load. Whenever `input.numel()` is not a multiple of the hardcoded `BLOCK_SIZE = 1024`, the last program reads up to 1023 elements past the end of the input tensor. Results still come out correct (the store is masked), so the accuracy suite never sees it — but `compute-sanitizer --tool memcheck` reports the invalid reads, and when the overrun crosses into unmapped memory the launch fails outright with `CUDA error: unspecified launch failure`.

The fix masks the load exactly the way `searchsorted.py` in the same directory already does:

```python
inp_val = tl.load(inp_ptr + offsets, mask=mask, other=0)
```

Verification (5-element input, one 1024-wide program, `PYTORCH_NO_CUDA_MEMORY_CACHING=1`):

| | before | after |
|---|---|---|
| memcheck errors | 126 invalid `__global__` reads at `bucketize.py:48` (launch then dies with unspecified launch failure) | 0 errors |

No in-suite unit test can observe this defect: the masked store makes the output bit-identical with and without the fix, so the sanitizer run above stands as the regression check. `tests/test_bucketize.py` (66 tests, including ragged shapes such as `(20, 320, 15)`) passes with the fix.

### Issue

Resolves #5230

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

`triton.testing.do_bench`, float32 input, L40S, median of 3 interleaved runs per variant:

| numel | n_boundaries | before (ms) | after (ms) |
|---|---|---|---|
| 1048576 | 128 | 0.0194 | 0.0207 |
| 1048581 | 128 | 0.0195 | 0.0206 |
| 16777216 | 128 | 0.3098 | 0.3033 |
| 16777727 | 128 | 0.3136 | 0.3043 |
| 16777216 | 4096 | 0.3261 | 0.3258 |

The masked load costs about 1 µs at 1 Mi elements and is ~2% faster at 16 Mi; a clamp-based formulation (`tl.minimum(offsets, n_elements - 1)`) measured within the same few percent, so the mask was kept for consistency with `searchsorted.py`.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
