### PR TITLE
[AddMM] Optimize matrix layouts and bias epilogue

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -301,6 +301,24 @@ BlasBenchmark:
     - [16, 4096, 4096, 4096]
   shape_desc: "B, M, N, K"   # shapes are defined as (B, M, N, K)
 
+addmm_vector_bias:
+  shapes:
+    - [1, 64, 256, 184]
+    - [1, 128, 512, 512]
+    - [1, 256, 256, 1024]
+    - [1, 512, 1024, 1024]
+    - [1, 1024, 512, 1536]
+  shape_desc: "B, M, N, K"
+
+addmm_out_vector_bias:
+  shapes:
+    - [1, 64, 256, 184]
+    - [1, 128, 512, 512]
+    - [1, 256, 256, 1024]
+    - [1, 512, 1024, 1024]
+    - [1, 1024, 512, 1536]
+  shape_desc: "B, M, N, K"
+
 grouped_mm:
   shapes:
     - [16, 512, 2048]

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -29,11 +29,62 @@ def _input_fn(b, m, n, k, dtype, device, b_column_major):
         yield bias, inp1, inp2,
 
 
+class AddmmVectorBiasBenchmark(base.BlasBenchmark):
+    def set_more_shapes(self):
+        return []
+
+    def get_input_iter(self, dtype):
+        for b, m, n, k in self.shapes:
+            yield from self.input_fn(b, m, n, k, dtype, self.device, True)
+
+    def get_tflops(self, op, *args, **kwargs):
+        _, mat1, mat2 = args
+        return mat1.shape[0] * mat2.shape[1] * (2 * mat1.shape[1] + 1)
+
+    def record_shapes(self, bias, mat1, mat2, **kwargs):
+        return {
+            "bias": bias.size(),
+            "mat1": mat1.size(),
+            "mat2": mat2.size(),
+            "mat2_layout": ("column-major" if mat2.stride(0) == 1 else "row-major"),
+        }
+
+
+def _input_fn_vector_bias(b, m, n, k, dtype, device, b_column_major):
+    mat1 = torch.randn((m, k), dtype=dtype, device=device)
+    if b_column_major:
+        mat2 = torch.randn((n, k), dtype=dtype, device=device).t()
+    else:
+        mat2 = torch.randn((k, n), dtype=dtype, device=device)
+    bias = torch.randn((n,), dtype=dtype, device=device)
+    yield bias, mat1, mat2
+
+
+def _input_fn_vector_bias_out(b, m, n, k, dtype, device, b_column_major):
+    for bias, mat1, mat2 in _input_fn_vector_bias(
+        b, m, n, k, dtype, device, b_column_major
+    ):
+        out = torch.empty((m, n), dtype=dtype, device=device)
+        yield bias, mat1, mat2, {"out": out}
+
+
 @pytest.mark.addmm
 def test_addmm(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm",
         input_fn=_input_fn,
+        torch_op=torch.addmm,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+@pytest.mark.addmm
+def test_addmm_vector_bias(monkeypatch):
+    bench = AddmmVectorBiasBenchmark(
+        op_name="addmm_vector_bias",
+        input_fn=_input_fn_vector_bias,
         torch_op=torch.addmm,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -115,6 +166,18 @@ def test_addmm_out(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm_out",
         input_fn=_input_fn_out,
+        torch_op=torch.addmm,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+@pytest.mark.addmm_out
+def test_addmm_out_vector_bias(monkeypatch):
+    bench = AddmmVectorBiasBenchmark(
+        op_name="addmm_out_vector_bias",
+        input_fn=_input_fn_vector_bias_out,
         torch_op=torch.addmm,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -15,6 +15,8 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base, consts, utils
 
 
@@ -108,6 +110,10 @@ def _input_fn_dtype(b, m, n, k, dtype, device, b_column_major):
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype was added starting from 2.8.0",
 )
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "ascend",
+    reason="Ascend native torch.addmm benchmark does not support out_dtype.",
+)
 def test_addmm_dtype(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm_dtype",
@@ -135,6 +141,10 @@ def _input_fn_dtype_out(b, m, n, k, dtype, device, b_column_major):
 @pytest.mark.skipif(
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype_out was added starting from 2.8.0",
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "ascend",
+    reason="Ascend native torch.addmm benchmark does not support out_dtype.",
 )
 def test_addmm_dtype_out(monkeypatch):
     bench = base.BlasBenchmark(

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -15,6 +15,8 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base, consts, utils
 
 
@@ -108,6 +110,10 @@ def _input_fn_dtype(b, m, n, k, dtype, device, b_column_major):
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype was added starting from 2.8.0",
 )
+@pytest.mark.skipif(
+    flag_gems.vendor_name in ("ascend", "mthreads"),
+    reason="Native torch.addmm benchmark does not support out_dtype.",
+)
 def test_addmm_dtype(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm_dtype",
@@ -135,6 +141,10 @@ def _input_fn_dtype_out(b, m, n, k, dtype, device, b_column_major):
 @pytest.mark.skipif(
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype_out was added starting from 2.8.0",
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name in ("ascend", "mthreads"),
+    reason="Native torch.addmm benchmark does not support out_dtype.",
 )
 def test_addmm_dtype_out(monkeypatch):
     bench = base.BlasBenchmark(

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -26,11 +26,24 @@ from flag_gems.utils import triton_lang_extension as ext
 logger = logging.getLogger(__name__)
 
 
+@triton.jit
+def _accumulate_dot(
+    accumulator,
+    a,
+    b,
+    IS_FP64: tl.constexpr,
+):
+    if IS_FP64:
+        a = a.to(tl.float32)
+        b = b.to(tl.float32)
+    return accumulator + tl.dot(a, b, allow_tf32=False)
+
+
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
-    strategy=["align32", "align32", "align32"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
     warmup=5,
     rep=10,
     flagtune_op_name="addmm",
@@ -57,52 +70,64 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
+    HAS_K: tl.constexpr,
     IS_FP64: tl.constexpr = False,
 ):
     pid_m = ext.program_id(0)
     pid_n = ext.program_id(1)
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     if IS_FP64:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float64)
     else:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(
-            a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+    if HAS_K:
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            a = tl.load(
+                a_ptrs,
+                mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
+                other=0.0,
+            )
+            accumulator = _accumulate_dot(
+                accumulator,
+                a,
+                b,
+                IS_FP64,
+            )
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    mask = (offs_m < M)[:, None] & (offs_n < N)[None, :]
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            i_ptr + offs_n * stride_in,
+            mask=offs_n < N,
             other=0.0,
-        )
-        b = tl.load(
-            b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
-            other=0.0,
-        )
-        if IS_FP64:
-            a = a.to(tl.float32)
-            b = b.to(tl.float32)
-        accumulator += tl.dot(a, b, allow_tf32=False)
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
+        bias = tl.load(i_ptrs, mask=mask, other=0.0)
 
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
-
-    accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
+    result = accumulator * alpha + bias.to(accumulator.dtype) * beta
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, result.to(c_ptr.dtype.element_ty), mask=mask)
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -110,73 +135,29 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
     M, K = mat1.shape
     _, N = mat2.shape
 
-    logger.debug(
-        "GEMS ADDMM, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
-        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
-        M,
-        N,
-        K,
-        mat1.stride(0) == 1,
-        mat2.stride(0) == 1,
-        bias.stride(0) == 1,
-    )
-    mat1 = mat1.contiguous()
-    # mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape)
-
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
-    )
-    with torch_device_fn.device(mat1.device):
-        addmm_kernel[grid](
-            mat1,
-            mat2,
-            bias,
-            out,
-            alpha,
-            beta,
-            M,
-            N,
-            K,
-            mat1.stride(0),
-            mat1.stride(1),
-            mat2.stride(0),
-            mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
-            out.stride(0),
-            out.stride(1),
-            IS_FP64=mat1.dtype == torch.float64,
-        )
-    return out
-
-
-def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
-    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
-    assert broadcastable_to(
-        bias.shape, (mat1.shape[0], mat2.shape[1])
-    ), "Incompatible input shape"
-    M, K = mat1.shape
-    _, N = mat2.shape
+    # Preserve row- and column-contiguous matrices; materialize general views.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(0) > 1 and mat2.stride(1) > 1:
+        mat2 = mat2.contiguous()
     if out is None:
         out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
     else:
         assert out.shape == (M, N), "Incompatible output shape"
-    logger.debug(
-        "GEMS ADDMM_OUT, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
-        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
-        M,
-        N,
-        K,
-        mat1.stride(0) == 1,
-        mat2.stride(0) == 1,
-        bias.stride(0) == 1,
-    )
-    mat1 = mat1.contiguous()
-    bias = bias.broadcast_to(out.shape)
 
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape)
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]),
         triton.cdiv(N, META["BLOCK_SIZE_N"]),
@@ -196,13 +177,44 @@ def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
+            HAS_K=K > 0,
             IS_FP64=mat1.dtype == torch.float64,
         )
     return out
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug(
+        "GEMS ADDMM, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
+        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
+        mat1.shape[0],
+        mat2.shape[1],
+        mat1.shape[1],
+        mat1.stride(0) == 1,
+        mat2.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
+    )
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug(
+        "GEMS ADDMM_OUT, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
+        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
+        mat1.shape[0],
+        mat2.shape[1],
+        mat1.shape[1],
+        mat1.stride(0) == 1,
+        mat2.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
+    )
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
 
 
 def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
@@ -237,5 +249,6 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
     if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
         raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
 
+    # Write directly to the requested dtype instead of using an input-dtype temporary.
     bias_c = bias.to(out_dtype)
     return addmm_out(bias_c, mat1, mat2, beta=beta, alpha=alpha, out=out)

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .addmm import addmm
+from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
 from .all import all, all_dim, all_dims
 from .amax import amax
 from .angle import angle
@@ -106,6 +106,9 @@ __all__ = [
     "_unique2",
     "_upsample_bicubic2d_aa",
     "addmm",
+    "addmm_dtype",
+    "addmm_dtype_out",
+    "addmm_out",
     "all",
     "all_dim",
     "all_dims",

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .addmm import addmm
+from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
 from .all import all, all_dim, all_dims
 from .amax import amax
 from .angle import angle
@@ -105,6 +105,9 @@ __all__ = [
     "_unique2",
     "_upsample_bicubic2d_aa",
     "addmm",
+    "addmm_dtype",
+    "addmm_dtype_out",
+    "addmm_out",
     "all",
     "all_dim",
     "all_dims",

--- a/src/flag_gems/runtime/backend/_ascend/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/addmm.py
@@ -20,94 +20,129 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import broadcastable_to, libentry
-from flag_gems.utils import triton_lang_extension as ext
+from flag_gems.runtime.backend._ascend import heuristics_config_utils as _hcu
+from flag_gems.utils import broadcastable_to, libentry, libtuner
 
 logger = logging.getLogger(__name__)
 
 
 @libentry()
-@triton.autotune(
-    configs=runtime.get_tuned_config("addmm"),
+@libtuner(
+    configs=runtime.get_tuned_config("mm"),
     key=["M", "N", "K"],
 )
+@triton.heuristics(_hcu.HEURISTICS_CONFIGS["mm"])
 @triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_kernel(
-    a_ptr,
-    b_ptr,
-    i_ptr,
-    c_ptr,
+    A,
+    B,
+    bias,
+    C,
     alpha,
     beta,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_im,
-    stride_in,
-    stride_cm,
-    stride_cn,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_im: tl.constexpr,
+    stride_in: tl.constexpr,
+    stride_cm: tl.constexpr,
+    stride_cn: tl.constexpr,
+    dot_out_dtype: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
-    pid_m = ext.program_id(0)
-    pid_n = ext.program_id(1)
+    pid = tl.program_id(0)
+    pid_z = tl.program_id(1)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    # Visit neighboring M tiles before advancing N to improve B-tile reuse.
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    ram = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rbn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    rk = pid_z * BLOCK_K + tl.arange(0, BLOCK_K)
+    A += ram[:, None] * stride_am + rk[None, :] * stride_ak
+    B += rk[:, None] * stride_bk + rbn[None, :] * stride_bn
 
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(
-            a_ptrs,
-            mask=(offs_k[None, :] < K - k * BLOCK_SIZE_K),
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=dot_out_dtype)
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        if EVEN_K:
+            a = tl.load(A, mask=(ram < M)[:, None], other=0.0)
+            b = tl.load(B, mask=(rbn < N)[None, :], other=0.0)
+        else:
+            k_remaining = K - k * (BLOCK_K * SPLIT_K)
+            a = tl.load(
+                A,
+                mask=(ram < M)[:, None] & (rk < k_remaining)[None, :],
+                other=0.0,
+            )
+            b = tl.load(
+                B,
+                mask=(rk < k_remaining)[:, None] & (rbn < N)[None, :],
+                other=0.0,
+            )
+        acc += tl.dot(a, b, out_dtype=dot_out_dtype, allow_tf32=False)
+        A += BLOCK_K * SPLIT_K * stride_ak
+        B += BLOCK_K * SPLIT_K * stride_bk
+
+    C += ram[:, None] * stride_cm + rbn[None, :] * stride_cn
+    mask = (ram < M)[:, None] & (rbn < N)[None, :]
+    if BIAS_IS_VECTOR:
+        # Load a 1-D bias once per output-column tile.
+        bias_tile = tl.load(
+            bias + stride_in * rbn,
+            mask=rbn < N,
             other=0.0,
-        )
-        b = tl.load(
-            b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K),
-            other=0.0,
-        )
-        accumulator += tl.dot(a, b, allow_tf32=False)
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
-
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
-    bias1 = bias.to(accumulator.dtype)
-    accumulator = accumulator * alpha + bias1 * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias_tile = tl.load(bias)
+    else:
+        bias += stride_im * ram[:, None] + stride_in * rbn[None, :]
+        bias_tile = tl.load(bias, mask=mask, other=0.0)
+    acc = acc * alpha + bias_tile.to(acc.dtype) * beta
+    tl.store(C, acc.to(C.dtype.element_ty), mask=mask)
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("GEMS_ASCEND ADDMM")
-    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
-    assert broadcastable_to(
-        bias.shape, (mat1.shape[0], mat2.shape[1])
-    ), "Incompatible input shape"
+def _launch_addmm(bias, mat1, mat2, out, alpha, beta):
     M, K = mat1.shape
     _, N = mat2.shape
+    # Keep row- or column-contiguous views and materialize only general strides.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(0) > 1 and mat2.stride(1) > 1:
+        mat2 = mat2.contiguous()
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
-
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape)
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
+    dot_out_dtype = tl.float32
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        META.get("SPLIT_K", 1),
     )
     with torch_device_fn.device(mat1.device):
         addmm_kernel[grid](
@@ -124,9 +159,75 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            dot_out_dtype=dot_out_dtype,
+            GROUP_M=8,
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
         )
     return out
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_ASCEND ADDMM")
+    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
+    assert broadcastable_to(
+        bias.shape, (mat1.shape[0], mat2.shape[1])
+    ), "Incompatible input shape"
+    M = mat1.shape[0]
+    N = mat2.shape[1]
+    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    return _launch_addmm(bias, mat1, mat2, out, alpha, beta)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_ASCEND ADDMM_OUT")
+    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
+    assert broadcastable_to(
+        bias.shape, (mat1.shape[0], mat2.shape[1])
+    ), "Incompatible input shape"
+    M = mat1.shape[0]
+    N = mat2.shape[1]
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    return _launch_addmm(bias, mat1, mat2, out, alpha, beta)
+
+
+def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
+    logger.debug("GEMS_ASCEND ADDMM_DTYPE")
+    out = torch.empty(
+        (mat1.shape[0], mat2.shape[1]),
+        device=mat1.device,
+        dtype=out_dtype,
+    )
+    return addmm_dtype_out(bias, mat1, mat2, out_dtype, beta=beta, alpha=alpha, out=out)
+
+
+def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
+    logger.debug("GEMS_ASCEND ADDMM_DTYPE_OUT")
+    if mat1.dtype != mat2.dtype:
+        raise RuntimeError(
+            f"mat1 and mat2 must have the same dtype, but got {mat1.dtype} and {mat2.dtype}"
+        )
+    if out.dtype != out_dtype:
+        raise RuntimeError(
+            "out_dtype must be the same as the dtype of the provided out tensor"
+        )
+    if not (
+        out_dtype == mat1.dtype
+        or (
+            out_dtype == torch.float32 and mat1.dtype in (torch.float16, torch.bfloat16)
+        )
+    ):
+        raise RuntimeError(
+            "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs"
+        )
+    if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
+        raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
+
+    return _launch_addmm(bias.to(out_dtype), mat1, mat2, out, alpha, beta)

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -1,6 +1,6 @@
 from ._make_dep_token import _make_dep_token
 from ._nested_view_from_buffer_copy import _nested_view_from_buffer_copy
-from .addmm import addmm
+from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
 from .amax import amax
 from .arange import arange, arange_start
 from .batch_norm import batch_norm, batch_norm_backward
@@ -46,6 +46,9 @@ __all__ = [
     "_nested_view_from_buffer_copy",
     "_unique2",
     "addmm",
+    "addmm_dtype",
+    "addmm_dtype_out",
+    "addmm_out",
     "amax",
     "arange",
     "arange_start",

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -1,6 +1,6 @@
 from ._make_dep_token import _make_dep_token
 from ._nested_view_from_buffer_copy import _nested_view_from_buffer_copy
-from .addmm import addmm
+from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
 from .amax import amax
 from .arange import arange, arange_start
 from .bmm import bmm
@@ -48,6 +48,9 @@ __all__ = [
     "_nested_view_from_buffer_copy",
     "_unique2",
     "addmm",
+    "addmm_dtype",
+    "addmm_dtype_out",
+    "addmm_out",
     "amax",
     "arange",
     "arange_start",

--- a/src/flag_gems/runtime/backend/_metax/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/addmm.py
@@ -30,14 +30,35 @@ logger = logging.getLogger(__name__)
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=10,
 )
 @triton.heuristics(
     {
         "UPGRADE": lambda args: math.ceil(
             (args["M"] * args["N"]) / (args["BLOCK_SIZE_M"] * args["BLOCK_SIZE_N"])
         ).bit_length()
-        > 32,
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_A_OFFS": lambda args: math.ceil(args["M"] * args["K"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_B_OFFS": lambda args: math.ceil(args["K"] * args["N"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_C_OFFS": lambda args: math.ceil(args["M"] * args["N"]).bit_length()
+        > 31,
     }
 )
 @triton.jit(do_not_specialize=["alpha", "beta"])
@@ -62,51 +83,80 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
     UPGRADE: tl.constexpr,
+    UPGRADE_A_OFFS: tl.constexpr,
+    UPGRADE_B_OFFS: tl.constexpr,
+    UPGRADE_C_OFFS: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
     if UPGRADE:
-        pid_m = ext.program_id(0)
-        pid_n = ext.program_id(1)
+        pid = ext.program_id(0)
     else:
-        pid_m = tl.program_id(0)
-        pid_n = tl.program_id(1)
+        pid = tl.program_id(0)
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    grid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    # Visit neighboring M tiles before advancing N to improve B-tile reuse.
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    if UPGRADE_A_OFFS:
+        offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+    else:
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    if UPGRADE_B_OFFS:
+        offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(
             a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(
             b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
             other=0.0,
         )
         accumulator += tl.dot(a, b, allow_tf32=False)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
+    if UPGRADE_C_OFFS:
+        store_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+        store_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        store_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        store_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * store_m[:, None] + stride_cn * store_n[None, :]
+    mask = (store_m[:, None] < M) & (store_n[None, :] < N)
+    if BIAS_IS_VECTOR:
+        bias_tile = tl.load(
+            i_ptr + stride_in * store_n,
+            mask=store_n < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias_tile = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + stride_im * store_m[:, None] + stride_in * store_n[None, :]
+        bias_tile = tl.load(i_ptrs, mask=mask, other=0.0)
+    accumulator = accumulator * alpha + bias_tile.to(accumulator.dtype) * beta
+    tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=mask)
 
-    accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
 
-
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("GEMS_METAX ADDMM")
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -122,17 +172,33 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
         K,
         mat1.stride(0) == 1,
         mat2.stride(0) == 1,
-        bias.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
     )
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
-
+    # MetaX lowers the GEMM load efficiently when B is contiguous in N.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(1) != 1:
+        mat2 = mat2.contiguous()
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape)
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
     with torch_device_fn.device(mat1.device):
         addmm_kernel[grid](
@@ -149,9 +215,57 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            GROUP_M=8,
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
         )
     return out
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM")
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_METAX ADDMM_OUT")
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
+
+
+def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM_DTYPE")
+    out = torch.empty(
+        (mat1.shape[0], mat2.shape[1]),
+        device=mat1.device,
+        dtype=out_dtype,
+    )
+    return addmm_dtype_out(bias, mat1, mat2, out_dtype, beta=beta, alpha=alpha, out=out)
+
+
+def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
+    logger.debug("GEMS_METAX ADDMM_DTYPE_OUT")
+    if mat1.dtype != mat2.dtype:
+        raise RuntimeError(
+            f"mat1 and mat2 must have the same dtype, but got {mat1.dtype} and {mat2.dtype}"
+        )
+    if out.dtype != out_dtype:
+        raise RuntimeError(
+            "out_dtype must be the same as the dtype of the provided out tensor"
+        )
+    if not (
+        out_dtype == mat1.dtype
+        or (
+            out_dtype == torch.float32 and mat1.dtype in (torch.float16, torch.bfloat16)
+        )
+    ):
+        raise RuntimeError(
+            "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs"
+        )
+    if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
+        raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
+
+    return _addmm_impl(bias.to(out_dtype), mat1, mat2, out, beta, alpha)

--- a/src/flag_gems/runtime/backend/_metax/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/addmm.py
@@ -20,30 +20,46 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
+from flag_gems.ops.addmm import _addmm_impl as _common_addmm_impl
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import broadcastable_to, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
 
 logger = logging.getLogger(__name__)
 
-# DispatchKeySet to redispatch to the native ATen implementation,
-# bypassing our registered dispatch override (avoids recursion).
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeExplicitAutograd
-)
-
 
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=10,
 )
 @triton.heuristics(
     {
         "UPGRADE": lambda args: math.ceil(
             (args["M"] * args["N"]) / (args["BLOCK_SIZE_M"] * args["BLOCK_SIZE_N"])
         ).bit_length()
-        > 32,
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_A_OFFS": lambda args: math.ceil(args["M"] * args["K"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_B_OFFS": lambda args: math.ceil(args["K"] * args["N"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_C_OFFS": lambda args: math.ceil(args["M"] * args["N"]).bit_length()
+        > 31,
     }
 )
 @triton.jit(do_not_specialize=["alpha", "beta"])
@@ -68,51 +84,86 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
     UPGRADE: tl.constexpr,
+    UPGRADE_A_OFFS: tl.constexpr,
+    UPGRADE_B_OFFS: tl.constexpr,
+    UPGRADE_C_OFFS: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
     if UPGRADE:
-        pid_m = ext.program_id(0)
-        pid_n = ext.program_id(1)
+        pid = ext.program_id(0)
     else:
-        pid_m = tl.program_id(0)
-        pid_n = tl.program_id(1)
+        pid = tl.program_id(0)
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    grid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    # Visit neighboring M tiles before advancing N to improve B-tile reuse.
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    if UPGRADE_A_OFFS:
+        offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+    else:
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    if UPGRADE_B_OFFS:
+        offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(
             a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(
             b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
             other=0.0,
         )
         accumulator += tl.dot(a, b, allow_tf32=False)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
+    if UPGRADE_C_OFFS:
+        store_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+        store_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        store_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        store_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * store_m[:, None] + stride_cn * store_n[None, :]
+    mask = (store_m[:, None] < M) & (store_n[None, :] < N)
+    if BIAS_IS_VECTOR:
+        bias_tile = tl.load(
+            i_ptr + stride_in * store_n,
+            mask=store_n < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias_tile = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + stride_im * store_m[:, None] + stride_in * store_n[None, :]
+        bias_tile = tl.load(i_ptrs, mask=mask, other=0.0)
+    accumulator = accumulator * alpha + bias_tile.to(accumulator.dtype) * beta
+    tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=mask)
 
-    accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
+
+def _fallback_addmm(bias, mat1, mat2, out, beta, alpha):
+    # All addmm overloads are registered on MetaX, so redispatching would
+    # re-enter this vendor implementation. Call the common kernel directly.
+    return _common_addmm_impl(bias, mat1, mat2, out, beta, alpha)
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("GEMS_METAX ADDMM")
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -128,7 +179,7 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
         K,
         mat1.stride(0) == 1,
         mat2.stride(0) == 1,
-        bias.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
     )
 
     # MetaX workaround: fall back to torch for shapes that trigger genSwiMask
@@ -137,20 +188,38 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
     MIN_TILE = 32
     if M < MIN_TILE or N < MIN_TILE:
         logger.debug(
-            "GEMS_METAX ADDMM falling back to torch (small M=%s or N=%s)", M, N
+            "GEMS_METAX ADDMM falling back to common (small M=%s or N=%s)", M, N
         )
-        return torch.ops.aten.addmm.default.redispatch(
-            _FALLBACK_KEYSET, bias, mat1, mat2, beta=beta, alpha=alpha
-        )
+        return _fallback_addmm(bias, mat1, mat2, out, beta, alpha)
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
-
+    fallback_bias = bias
+    fallback_mat1 = mat1
+    fallback_mat2 = mat2
+    fallback_out = out
+    # MetaX lowers the GEMM load efficiently when B is contiguous in N.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(1) != 1:
+        mat2 = mat2.contiguous()
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape)
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
     try:
         with torch_device_fn.device(mat1.device):
@@ -168,24 +237,77 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
                 mat1.stride(1),
                 mat2.stride(0),
                 mat2.stride(1),
-                bias.stride(0),
-                bias.stride(1),
+                bias_stride_m,
+                bias_stride_n,
                 out.stride(0),
                 out.stride(1),
+                GROUP_M=8,
+                BIAS_IS_VECTOR=bias_is_vector,
+                BIAS_IS_SCALAR=bias_is_scalar,
             )
         return out
     except RuntimeError as e:
         # MetaX compiler may fail on certain shape/tile combinations
         # (e.g., genSwiMask assertion with async pipeline passes).
-        # Fall back to torch.addmm for correctness.
+        # Fall back to the common kernel for correctness.
         logger.warning(
             "GEMS_METAX ADDMM kernel compilation failed for shape (%s,%s,%s), "
-            "falling back to torch.addmm: %s",
+            "falling back to the common addmm kernel: %s",
             M,
             N,
             K,
             e,
         )
-        return torch.ops.aten.addmm.default.redispatch(
-            _FALLBACK_KEYSET, bias, mat1, mat2, beta=beta, alpha=alpha
+        return _fallback_addmm(
+            fallback_bias,
+            fallback_mat1,
+            fallback_mat2,
+            fallback_out,
+            beta,
+            alpha,
         )
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM")
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_METAX ADDMM_OUT")
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
+
+
+def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM_DTYPE")
+    out = torch.empty(
+        (mat1.shape[0], mat2.shape[1]),
+        device=mat1.device,
+        dtype=out_dtype,
+    )
+    return addmm_dtype_out(bias, mat1, mat2, out_dtype, beta=beta, alpha=alpha, out=out)
+
+
+def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
+    logger.debug("GEMS_METAX ADDMM_DTYPE_OUT")
+    if mat1.dtype != mat2.dtype:
+        raise RuntimeError(
+            f"mat1 and mat2 must have the same dtype, but got {mat1.dtype} and {mat2.dtype}"
+        )
+    if out.dtype != out_dtype:
+        raise RuntimeError(
+            "out_dtype must be the same as the dtype of the provided out tensor"
+        )
+    if not (
+        out_dtype == mat1.dtype
+        or (
+            out_dtype == torch.float32 and mat1.dtype in (torch.float16, torch.bfloat16)
+        )
+    ):
+        raise RuntimeError(
+            "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs"
+        )
+    if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
+        raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
+
+    return _addmm_impl(bias.to(out_dtype), mat1, mat2, out, beta, alpha)

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -470,27 +470,6 @@ max:
 addmm:
 - META:
     BLOCK_SIZE_M: 128
-    BLOCK_SIZE_N: 256
-    BLOCK_SIZE_K: 64
-    pipeline: "null"
-  num_stages: 3
-  num_warps: 8
-- META:
-    BLOCK_SIZE_M: 64
-    BLOCK_SIZE_N: 256
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 4
-  num_warps: 4
-- META:
-    BLOCK_SIZE_M: 128
-    BLOCK_SIZE_N: 128
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 4
-  num_warps: 4
-- META:
-    BLOCK_SIZE_M: 128
     BLOCK_SIZE_N: 64
     BLOCK_SIZE_K: 32
     pipeline: "null"
@@ -503,20 +482,6 @@ addmm:
     pipeline: "null"
   num_stages: 4
   num_warps: 4
-- META:
-    BLOCK_SIZE_M: 128
-    BLOCK_SIZE_N: 32
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 4
-  num_warps: 4
-- META:
-    BLOCK_SIZE_M: 64
-    BLOCK_SIZE_N: 32
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 5
-  num_warps: 2
 - META:
     BLOCK_SIZE_M: 32
     BLOCK_SIZE_N: 64
@@ -525,54 +490,12 @@ addmm:
   num_stages: 5
   num_warps: 2
 - META:
-    BLOCK_SIZE_M: 128
-    BLOCK_SIZE_N: 128
-    BLOCK_SIZE_K: 128
-    pipeline: "null"
-  num_stages: 2
-  num_warps: 8
-- META:
-    BLOCK_SIZE_M: 256
-    BLOCK_SIZE_N: 256
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 2
-  num_warps: 8
-- META:
     BLOCK_SIZE_M: 32
     BLOCK_SIZE_N: 32
     BLOCK_SIZE_K: 64
     pipeline: "null"
   num_stages: 2
   num_warps: 4
-- META:
-    BLOCK_SIZE_M: 32
-    BLOCK_SIZE_N: 64
-    BLOCK_SIZE_K: 64
-    pipeline: "null"
-  num_stages: 2
-  num_warps: 8
-- META:
-    BLOCK_SIZE_M: 64
-    BLOCK_SIZE_N: 32
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 2
-  num_warps: 8
-- META:
-    BLOCK_SIZE_M: 64
-    BLOCK_SIZE_N: 32
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 4
-  num_warps: 8
-- META:
-    BLOCK_SIZE_M: 64
-    BLOCK_SIZE_N: 64
-    BLOCK_SIZE_K: 32
-    pipeline: "null"
-  num_stages: 2
-  num_warps: 8
 - META:
     BLOCK_SIZE_M: 128
     BLOCK_SIZE_N: 128

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -129,7 +129,7 @@ __all__ = [
 
 
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm, addmm_dtype, addmm_dtype_out  # noqa: F401
+    from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
     from .baddbmm import baddbmm  # noqa: F401
     from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
@@ -141,6 +141,7 @@ if get_device_capability(current_device())[0] >= 3:
             "addmm",
             "addmm_dtype",
             "addmm_dtype_out",
+            "addmm_out",
             "baddbmm",
             "bmm",
             "gelu",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -150,7 +150,7 @@ __all__ = [
 
 
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm, addmm_dtype, addmm_dtype_out  # noqa: F401
+    from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
     from .baddbmm import baddbmm  # noqa: F401
     from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
@@ -162,6 +162,7 @@ if get_device_capability(current_device())[0] >= 3:
             "addmm",
             "addmm_dtype",
             "addmm_dtype_out",
+            "addmm_out",
             "baddbmm",
             "bmm",
             "gelu",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
@@ -47,15 +47,33 @@ def is_sqmma_compatible(a, b, N, K):
         and a.dtype in (torch.float16, torch.bfloat16)
         and is_supported_sqmma_layout(a)
         and is_supported_sqmma_layout(b)
+        and a.shape[0] > 0
+        and N > 0
+        and K > 0
         and N % 8 == 0
         and K % 8 == 0
     )
 
 
+def _prepare_bias(bias, out):
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == out.shape[1]
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        return bias, 0, bias.stride(0), True, False
+    if bias_is_scalar:
+        return bias, 0, 0, False, True
+    bias = bias.broadcast_to(out.shape)
+    return bias, bias.stride(0), bias.stride(1), False, False
+
+
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
 )
 @triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_kernel(
@@ -79,16 +97,17 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
     IS_FP64: tl.constexpr = False,
 ):
     pid_m = ext.program_id(0)
     pid_n = ext.program_id(1)
-
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     if IS_FP64:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float64)
@@ -97,12 +116,12 @@ def addmm_kernel(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(
             a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(
             b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
             other=0.0,
         )
         if IS_FP64:
@@ -116,15 +135,24 @@ def addmm_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            i_ptr + stride_in * offs_cn,
+            mask=offs_cn < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
+        bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
 
     accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
+    c = accumulator.to(c_ptr.dtype.element_ty)
     tl.store(c_ptrs, c, mask=c_mask)
 
 
-def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
+def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
     logger.debug("GEMS_MTHREADS ADDMM_FMA")
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
@@ -133,10 +161,31 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
     M, K = mat1.shape
     _, N = mat2.shape
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    mat2_k_contiguous = mat2.stride(0) == 1 and mat2.stride(1) > 1
+    # Direct K-contiguous loads win for small M. With more than eight 128-row
+    # tiles, a coalesced copy is amortized across enough reuse of the B matrix.
+    if (mat2_k_contiguous and M > 8 * 128) or (
+        mat2.stride(0) > 1 and mat2.stride(1) > 1
+    ):
+        mat2 = mat2.contiguous()
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape).contiguous()
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
 
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]),
@@ -157,10 +206,12 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
             IS_FP64=mat1.dtype == torch.float64,
         )
     return out
@@ -169,7 +220,6 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
 def addmm_sqmma_descriptor_pre_hook(nargs):
     nargs["a_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_K"]]
     nargs["b_desc"].block_shape = [nargs["BLOCK_SIZE_K"], nargs["BLOCK_SIZE_N"]]
-    nargs["bias_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
     nargs["c_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
 
 
@@ -196,17 +246,21 @@ def addmm_sqmma_descriptor_pre_hook(nargs):
 def addmm_sqmma_kernel(
     a_desc,
     b_desc,
-    bias_desc,
+    bias_ptr,
     c_desc,
     M,
     N,
     K,
     alpha,
     beta,
+    stride_im,
+    stride_in,
     DTYPE: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -222,12 +276,26 @@ def addmm_sqmma_kernel(
         b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
         accumulator = tl.dot(a, b, acc=accumulator)
         offs_k += BLOCK_SIZE_K
-    bias = tl.load_tensor_descriptor(bias_desc, [offs_am, offs_bn])
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            bias_ptr + offs_n * stride_in,
+            mask=offs_n < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(bias_ptr)
+    else:
+        bias_ptrs = bias_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
+        bias = tl.load(bias_ptrs, mask=mask, other=0.0)
     result = (alpha * accumulator + beta * bias).to(c_desc.dtype)
     tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], result)
 
 
-def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
+def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K, out=None):
     logger.debug("GEMS_MTHREADS ADDMM_SQMMA")
     device = mat1.device
     assert broadcastable_to(
@@ -241,12 +309,16 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
     b_type = mat2.dtype
     assert a_type == b_type, "Mat A and Mat B should have the same dtype"
     c_type = a_type
-    C = torch.empty((M, N), dtype=c_type, device=device)
-    bias = bias.broadcast_to(C.shape).contiguous()
+    if out is None:
+        out = torch.empty((M, N), dtype=c_type, device=device)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    bias, stride_im, stride_in, bias_is_vector, bias_is_scalar = _prepare_bias(
+        bias, out
+    )
     desc_a = TensorDescriptor.from_tensor(mat1, [1, 1])
     desc_b = TensorDescriptor.from_tensor(mat2, [1, 1])
-    desc_bias = TensorDescriptor.from_tensor(bias, [1, 1])
-    desc_c = TensorDescriptor.from_tensor(C, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(out, [1, 1])
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         1,
@@ -255,24 +327,38 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
     addmm_sqmma_kernel[grid](
         desc_a,
         desc_b,
-        desc_bias,
+        bias,
         desc_c,
         M,
         N,
         K,
         alpha,
         beta,
+        stride_im,
+        stride_in,
         str(a_type).split(".")[-1],
+        BIAS_IS_VECTOR=bias_is_vector,
+        BIAS_IS_SCALAR=bias_is_scalar,
     )
-    return C
+    return out
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
+    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
+    assert broadcastable_to(
+        bias.shape, (mat1.shape[0], mat2.shape[1])
+    ), "Incompatible input shape"
     a_dtype = mat1.dtype
     M, K = mat1.shape
     _, N = mat2.shape
+    if out is not None:
+        assert out.shape == (M, N), "Incompatible output shape"
 
-    if is_sqmma_compatible(mat1, mat2, N, K):
+    if (
+        is_sqmma_compatible(mat1, mat2, N, K)
+        and bias.dtype == a_dtype
+        and (out is None or out.is_contiguous())
+    ):
         return addmm_sqmma(
             mat1,
             mat2,
@@ -283,9 +369,19 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
             M,
             N,
             K,
+            out=out,
         )
-    else:
-        return addmm_fma(bias, mat1, mat2, alpha=alpha, beta=beta)
+    return addmm_fma(bias, mat1, mat2, alpha=alpha, beta=beta, out=out)
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_MTHREADS ADDMM")
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_MTHREADS ADDMM_OUT")
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
 
 
 def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
@@ -325,8 +421,13 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
     _, N = mat2.shape
     a_dtype = mat1.dtype
 
-    if is_sqmma_compatible(mat1, mat2, N, K):
-        result = addmm_sqmma(
+    # Keep dtype promotion on FMA so FP32 output has no low-precision intermediate.
+    if (
+        out_dtype == mat1.dtype
+        and out.is_contiguous()
+        and is_sqmma_compatible(mat1, mat2, N, K)
+    ):
+        return addmm_sqmma(
             mat1,
             mat2,
             bias_c,
@@ -336,8 +437,6 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
             M,
             N,
             K,
+            out=out,
         )
-    else:
-        result = addmm_fma(bias_c, mat1, mat2, alpha=alpha, beta=beta)
-    out.copy_(result)
-    return out
+    return addmm_fma(bias_c, mat1, mat2, alpha=alpha, beta=beta, out=out)

--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -103,6 +103,24 @@ addmm:
       BLOCK_SIZE_K: 32
     num_stages: 1
     num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 64
+    num_stages: 4
+    num_warps: 4
 linear:
   # The NVIDIA default's first config (BLOCK_SIZE 128x256x64, num_stages=3) fails to
   # compile for fp32 on MUSA (Triton Error [MUSA]: invalid argument during autotune).

--- a/src/flag_gems/runtime/backend/_thead/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_thead/tune_configs.yaml
@@ -443,6 +443,12 @@ addmm:
       BLOCK_SIZE_K: 32
     num_stages: 5
     num_warps: 2
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 64
+    num_stages: 3
+    num_warps: 8
 cross_entropy_loss:
   - META:
       BLOCK_C: 256

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -25,12 +25,20 @@ if QUICK_MODE:
     MNK_SHAPES = [
         (1, 1, 32),
     ]
+    VECTOR_BIAS_MNK_SHAPES = [(64, 256, 184)]
     FLOAT_DTYPES = [torch.float32]
 else:
     MNK_SHAPES = [
         (1, 1, 32),
         (15, 160, 1024),
         (495, 5333, 71),
+    ]
+    VECTOR_BIAS_MNK_SHAPES = [
+        (64, 256, 184),
+        (128, 512, 512),
+        (256, 256, 1024),
+        (512, 1024, 1024),
+        (1024, 512, 1536),
     ]
     FLOAT_DTYPES = utils.FLOAT_DTYPES
 
@@ -72,16 +80,91 @@ def test_addmm(monkeypatch, M, N, K, scalar, dtype, b_column_major):
     utils.gems_assert_close(res_out2, ref_out2, dtype, reduce_dim=K)
 
 
+@pytest.mark.addmm
+@pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_vector_bias_shapes(M, N, K, dtype, b_column_major):
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        result = torch.addmm(bias, mat1, mat2)
+
+    utils.gems_assert_close(result, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_scalar_bias(dtype, b_column_major):
+    M, N, K = 17, 29, 31
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((1, 1), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        result = torch.addmm(bias, mat1, mat2)
+
+    utils.gems_assert_close(result, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_padded_vector_bias(dtype, b_column_major):
+    M, N, K, padding = 64, 128, 64, 7
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        storage = torch.randn((N, K + padding), dtype=dtype, device=flag_gems.device)
+        mat2 = storage[:, :K].t()
+    else:
+        storage = torch.randn((K, N + padding), dtype=dtype, device=flag_gems.device)
+        mat2 = storage[:, :N]
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        result = torch.addmm(bias, mat1, mat2)
+
+    utils.gems_assert_close(result, ref_out, dtype, reduce_dim=K)
+
+
 @pytest.mark.addmm_out
 @pytest.mark.parametrize("M, N, K", MNK_SHAPES)
 @pytest.mark.parametrize("scalar", utils.SCALARS)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_addmm_out(M, N, K, scalar, dtype):
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_out(M, N, K, scalar, dtype, b_column_major):
     if flag_gems.vendor_name == "tsingmicro" and dtype == torch.float32:
         pytest.skip("Issue #3794: not working")
 
     mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
-    mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
     bias1 = torch.randn((N,), dtype=dtype, device=flag_gems.device)
     out = torch.empty((M, N), dtype=dtype, device=flag_gems.device)
     ref_mat1 = utils.to_reference(mat1, True)
@@ -103,6 +186,74 @@ def test_addmm_out(M, N, K, scalar, dtype):
     torch.addmm(ref_bias2, ref_mat1, ref_mat2, alpha=alpha, beta=beta, out=ref_out)
     with flag_gems.use_gems():
         torch.addmm(bias2, mat1, mat2, alpha=alpha, beta=beta, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm_out
+@pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_out_vector_bias_shapes(M, N, K, dtype, b_column_major):
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((M, N), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        torch.addmm(bias, mat1, mat2, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm_out
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_out_noncontiguous(dtype, b_column_major):
+    M, N, K = 15, 17, 32
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((N, M), dtype=dtype, device=flag_gems.device).t()
+
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_bias = utils.to_reference(bias, True)
+    ref_out = utils.to_reference(out, True)
+
+    torch.addmm(ref_bias, ref_mat1, ref_mat2, out=ref_out)
+    with flag_gems.use_gems():
+        torch.addmm(bias, mat1, mat2, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("bias_shape", [(), (1, 128), (128, 1)])
+def test_addmm_broadcast_bias(dtype, bias_shape):
+    M, N, K = 128, 128, 128
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    bias = torch.randn(bias_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_bias = utils.to_reference(bias, True)
+    ref_out = torch.addmm(ref_bias, ref_mat1, ref_mat2)
+    with flag_gems.use_gems():
+        out = torch.addmm(bias, mat1, mat2)
 
     utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
 


### PR DESCRIPTION

### PR Category

Operator, OP Test, Benchmark

### Type of Change

Performance Optimization

### Description

This PR optimizes `addmm`, `addmm.out`, `addmm.dtype`, and
`addmm.dtype_out` for common matrix layouts and bias forms while preserving the
existing AddMM numerical contract.

The implementation:

- shares one launch implementation across the four public AddMM APIs, including
  non-contiguous output strides;
- keeps row- and column-contiguous matrix views in their original layout and
  materializes only general non-contiguous views;
- loads vector bias once per output N tile, loads scalar bias once, and uses the
  broadcast view strides for other valid bias shapes instead of materializing a
  full `[M, N]` tensor;
- writes dtype overloads directly into the requested output tensor, avoiding an
  input-dtype intermediate for FP16/BF16-to-FP32 accumulation;
- preserves the upstream common two-dimensional program grid and masked K loop;
- aligns the Ascend implementation with the backend `mm` grouped ordering,
  tuning configuration, and heuristics;
- provides MThreads FMA and SQMMA paths with the same bias epilogue and output
  API support;
- uses one grouped MetaX kernel while retaining the latest upstream C550
  fallback and tuning behavior;
- adds backend tuning entries for MThreads and T-Head without introducing a
  cross-backend precision policy.

FP32 dot behavior remains strict (`allow_tf32=False`) in this PR.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

The tests cover FP32, FP16, and BF16 across all four APIs. In addition to the
upstream cases, they cover five vector-bias shapes, row- and column-major
`mat2`, padded strides, scalar and broadcast bias, zero-K matrices, and
non-contiguous output tensors.

| Platform | `addmm` | `addmm_out` | `dtype` | `dtype_out` | Total |
|---|---:|---:|---:|---:|---:|
| NVIDIA H100 | 123 | 108 | 3 | 3 | 237 passed |
| Ascend 910C | 123 | 108 | 3 | 3 | 237 passed |
| Hygon BW1000 | 123 | 108 | 3 | 3 | 237 passed |
| PTG 810E | 123 | 108 | 3 | 3 | 237 passed |
| MetaX C550 | 123 | 108 | 3 | 3 | 237 passed |
| Moore Threads S5000 | 123 | 108 | 3 | 3 | 237 passed |

The S5000 Official baseline passes 235/237; the two failures are existing
large-shape FP32 accumulation cases. This PR passes both cases.

### GitHub CI Status

Current rebased head `00c210491`:

- `code-style`, `python-op`, and `ascend-cann850` passed.
- `mthreads-musa520` failed in `Set up job`: downloading
  `actions/checkout` timed out after three attempts. The repository was not
  checked out, so no AddMM test ran.
- `metax-maca3810` failed in `setup-flaggems`: downloading the SciPy wheel
  from the configured PyPI mirror timed out. No AddMM test ran.
- `ascend-cann900` is still running the backend tests.

The pre-rebase run also had environment-stage failures on MThreads
(`libmusart.so.5` unavailable) and CANN 9.0
(`LLVM ERROR: pthread_join failed`). These runner/runtime failures are
reported separately from the local correctness results above.

### Performance

Measurements follow the public FlagGems benchmark path with kernel mode, core
level, a 100 ms warmup window, and a 200 ms repetition window. Each entry below
is the geometric mean of five cases and reports `Official Gems / This PR`;
values above 1 mean this PR is faster. The original group is the upstream
`BlasBenchmark` set. The added group uses medium-size vector bias and
column-major `mat2` views.

| Platform | API | Original FP32 | Original FP16 | Original BF16 | Added FP32 | Added FP16 | Added BF16 |
|---|---|---:|---:|---:|---:|---:|---:|
| NVIDIA H100 | `addmm` | 0.999x | 0.921x | 0.909x | 3.099x | 10.270x | 10.273x |
| NVIDIA H100 | `addmm_out` | 0.990x | 1.000x | 0.998x | 2.883x | 10.378x | 10.452x |
| Ascend 910C | `addmm` | 1.563x | 2.040x | 2.043x | 136.123x | 183.434x | 183.619x |
| Ascend 910C | `addmm_out` | 1.766x | 2.522x | 2.523x | 245.511x | 346.580x | 344.160x |
| Hygon BW1000 | `addmm` | 0.992x | 0.952x | 0.940x | 4.165x | 4.268x | 4.294x |
| Hygon BW1000 | `addmm_out` | 0.910x | 0.880x | 0.960x | 12.590x | 15.631x | 16.143x |
| PTG 810E | `addmm` | 1.243x | 0.912x | 0.894x | 3.074x | 14.100x | 14.004x |
| PTG 810E | `addmm_out` | 1.077x | 1.033x | 1.005x | 2.693x | 14.971x | 13.109x |
| MetaX C550 | `addmm` | 1.016x | 1.004x | 0.999x | 3.027x | 3.834x | 3.771x |
| MetaX C550 | `addmm_out` | 1.008x | 1.011x | 1.005x | 3.103x | 3.168x | 3.136x |
| Moore Threads S5000 | `addmm` | 1.026x | 0.963x | 0.959x | 2.942x | 8.398x | 8.459x |
| Moore Threads S5000 | `addmm_out` | 1.035x | 2.238x | 2.337x | 2.872x | 10.647x | 10.556x |

Selected raw rows show the three measured implementations:

| Platform | API / dtype / shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---|---:|---:|---:|---:|
| H100 | `addmm` FP16, `[128,512]@[512,512]` | 0.007872 | 0.152800 | 0.012128 | 12.599x |
| Ascend 910C | `addmm` FP32, upstream `4096^3` | 0.884449 | 1.409076 | 0.771947 | 1.825x |
| Ascend 910C | `addmm` FP32, `[128,512]@[512,512]` | 0.006207 | 0.698051 | 0.005508 | 126.734x |
| Hygon BW1000 | `addmm` FP32, `[64,184]@[184,256]` | 0.020320 | 0.734879 | 0.169920 | 4.325x |
| PTG 810E | `addmm` FP16, `[128,512]@[512,512]` | 0.008560 | 0.213720 | 0.008440 | 25.322x |
| MetaX C550 | `addmm` FP32, `[128,512]@[512,512]` | 0.024832 | 0.289792 | 0.074752 | 3.877x |
| MThreads S5000 | `addmm_out` FP16, `[512,1024]@[1024,1024]` | 0.014320 | 2.574400 | 0.158300 | 16.263x |

The large speedups in the added group primarily come from reducing
two-dimensional bias overhead: vendor paths that materialized broadcast bias no
longer do so, while other paths avoid reloading vector bias for every M row.
They are not claimed as equivalent GEMM-core speedups. Original large cases are
generally neutral or faster. Small H100/PTG `addmm` cases and small Hygon
`addmm_out` cases retain measurable fixed-dispatch regressions; the complete
per-case results are available in the validation artifacts.

### Files Changed

- `benchmark/core_shapes.yaml`
- `benchmark/test_addmm.py`
- `src/flag_gems/ops/addmm.py`
- `src/flag_gems/runtime/backend/_ascend/ops/__init__.py`
- `src/flag_gems/runtime/backend/_ascend/ops/addmm.py`
- `src/flag_gems/runtime/backend/_metax/ops/__init__.py`
- `src/flag_gems/runtime/backend/_metax/ops/addmm.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/addmm.py`
- `src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml`
- `src/flag_gems/runtime/backend/_thead/tune_configs.yaml`
- `tests/test_addmm.py`