### PR TITLE
device TMA mm on Hopper

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -688,15 +688,16 @@ class BlasBenchmark(Benchmark):
                 yield from self.input_fn(b, m, n, k, dtype, self.device, True)
 
     def set_more_shapes(self):
-        large_k_shapes = [
-            (8, 1848, 1536, 151936),
-            (8, 1848, 1536, 128256),
-            (8, 1848, 1536, 152064),
-            (8, 4096, 1, 152064),
-        ]
+        return None
+        # large_k_shapes = [
+        #     (8, 1848, 1536, 151936),
+        #     (8, 1848, 1536, 128256),
+        #     (8, 1848, 1536, 152064),
+        #     (8, 4096, 1, 152064),
+        # ]
 
-        model_shaps = model_shapes()
-        return large_k_shapes + model_shaps
+        # model_shaps = model_shapes()
+        # return large_k_shapes + model_shaps
 
     def get_tflops(self, op, *args, **kwargs):
         total_flops = 0

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -688,16 +688,15 @@ class BlasBenchmark(Benchmark):
                 yield from self.input_fn(b, m, n, k, dtype, self.device, True)
 
     def set_more_shapes(self):
-        return None
-        # large_k_shapes = [
-        #     (8, 1848, 1536, 151936),
-        #     (8, 1848, 1536, 128256),
-        #     (8, 1848, 1536, 152064),
-        #     (8, 4096, 1, 152064),
-        # ]
+        large_k_shapes = [
+            (8, 1848, 1536, 151936),
+            (8, 1848, 1536, 128256),
+            (8, 1848, 1536, 152064),
+            (8, 4096, 1, 152064),
+        ]
 
-        # model_shaps = model_shapes()
-        # return large_k_shapes + model_shaps
+        model_shaps = model_shapes()
+        return large_k_shapes + model_shaps
 
     def get_tflops(self, op, *args, **kwargs):
         total_flops = 0

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -30,10 +30,17 @@ from flag_gems.utils.triton_version_utils import HAS_TLE, HAS_TLE_DEVICE_MESH
 
 logger = logging.getLogger(__name__)
 CACHE_USAGE_THRESHOLD = 0.8
+_MM_DEVICE_TMA_ENV = "FLAGGEMS_NVIDIA_MM_DEVICE_TMA"
+_TRUE_ENV_VALUES = frozenset(("1", "true", "yes", "on"))
 EXPAND_CONFIG_FILENAME = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "mm_hopper_expand.yaml")
 )
 _SHARED_MEM_SAFETY_MARGIN_BYTES = 1024
+
+
+def _use_mm_device_tma():
+    """Return whether the experimental device-side TMA path is enabled."""
+    return os.environ.get(_MM_DEVICE_TMA_ENV, "0").strip().lower() in _TRUE_ENV_VALUES
 
 
 def _get_shared_memory_limit_bytes():
@@ -105,6 +112,36 @@ def is_tma_compatible(a, b, N, K):
         and N % 4 == 0
         and K % 4 == 0
     )
+
+
+def _is_device_tma_layout_compatible(a, b, c):
+    """Check the stride constraints used by the device-created descriptors."""
+
+    def has_aligned_contiguous_dimension(tensor, allow_transpose):
+        tensor_type = type(tensor).__name__
+        if tensor_type not in ("FakeTensor", "FunctionalTensor"):
+            if tensor.data_ptr() % 16 != 0:
+                return False
+        if tensor.stride(1) == 1:
+            leading_stride = tensor.stride(0)
+        elif allow_transpose and tensor.stride(0) == 1:
+            leading_stride = tensor.stride(1)
+        else:
+            return False
+        return leading_stride > 0 and (leading_stride * tensor.element_size()) % 16 == 0
+
+    return (
+        has_aligned_contiguous_dimension(a, allow_transpose=True)
+        and has_aligned_contiguous_dimension(b, allow_transpose=True)
+        and has_aligned_contiguous_dimension(c, allow_transpose=False)
+    )
+
+
+def _set_tma_allocator(device):
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
 
 
 @triton.jit
@@ -391,6 +428,115 @@ def mm_kernel_general_host_tma(
     c_desc.store([offset_am, offset_bn], c)
 
 
+@libentry()
+@libtuner(
+    configs=matmul_get_configs(pre_hook=None),
+    key=["M", "N", "K", "stride_am", "stride_bk", "dtype"],
+    strategy=["align32", "align32", "align32", "align32", "align32", "default"],
+    warmup=5,
+    rep=5,
+    flagtune_op_name="mm",
+    flagtune_expand_op_name="mm_general_tma",
+    flagtune_yaml_path=EXPAND_CONFIG_FILENAME,
+    flagtune_pre_hook=None,
+)
+@triton.jit
+def mm_kernel_general_device_tma(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    A_ROW_MAJOR: tl.constexpr,
+    B_ROW_MAJOR: tl.constexpr,
+    dtype: tl.constexpr,
+):
+    if A_ROW_MAJOR:
+        a_desc = tl.make_tensor_descriptor(
+            base=A,
+            shape=[M, K],
+            strides=[stride_am, 1],
+            block_shape=[BLOCK_M, BLOCK_K],
+        )
+    else:
+        a_desc = tl.make_tensor_descriptor(
+            base=A,
+            shape=[K, M],
+            strides=[stride_ak, 1],
+            block_shape=[BLOCK_K, BLOCK_M],
+        )
+
+    if B_ROW_MAJOR:
+        b_desc = tl.make_tensor_descriptor(
+            base=B,
+            shape=[K, N],
+            strides=[stride_bk, 1],
+            block_shape=[BLOCK_K, BLOCK_N],
+        )
+    else:
+        b_desc = tl.make_tensor_descriptor(
+            base=B,
+            shape=[N, K],
+            strides=[stride_bn, 1],
+            block_shape=[BLOCK_N, BLOCK_K],
+        )
+
+    c_desc = tl.make_tensor_descriptor(
+        base=C,
+        shape=[M, N],
+        strides=[stride_cm, 1],
+        block_shape=[BLOCK_M, BLOCK_N],
+    )
+
+    pid = tl.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    offset_am = (pid_m * BLOCK_M).to(tl.int32)
+    offset_bn = (pid_n * BLOCK_N).to(tl.int32)
+    iters = tl.cdiv(K, BLOCK_K)
+    for k in range(iters):
+        offset_ak = (k * BLOCK_K).to(tl.int32)
+
+        if A_ROW_MAJOR:
+            a = a_desc.load([offset_am, offset_ak])
+        else:
+            a_t = a_desc.load([offset_ak, offset_am])
+            a = tl.trans(a_t)
+
+        if B_ROW_MAJOR:
+            b = b_desc.load([offset_ak, offset_bn])
+        else:
+            b_t = b_desc.load([offset_bn, offset_ak])
+            b = tl.trans(b_t)
+
+        if A.dtype.element_ty == tl.float16 or A.dtype.element_ty == tl.bfloat16:
+            accumulator = tl.dot(a, b, acc=accumulator, allow_tf32=False)
+        else:
+            accumulator = tl.dot(a, b, acc=accumulator, input_precision="tf32x3")
+
+    c = accumulator.to(C.dtype.element_ty)
+    c_desc.store([offset_am, offset_bn], c)
+
+
 def _sync_mm_host_tma_descriptor_block_shapes(args, kwargs):
     if len(args) < 3:
         return
@@ -465,11 +611,52 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
     )
-    if hasattr(
-        triton.tools.tensor_descriptor, "TensorDescriptor"
-    ) and is_tma_compatible(a, b, N, K):
-        a_row_major = a.stride(1) == 1
-        b_row_major = b.stride(1) == 1
+    tma_compatible = is_tma_compatible(a, b, N, K)
+    a_row_major = a.stride(1) == 1
+    b_row_major = b.stride(1) == 1
+    dtype_str = str(a.dtype).split(".")[-1]
+    device_tma_requested = _use_mm_device_tma()
+    use_device_tma = (
+        device_tma_requested
+        and hasattr(tl, "make_tensor_descriptor")
+        and tma_compatible
+        and M > 0
+        and N > 0
+        and K > 0
+        and a.dtype == b.dtype
+        and _is_device_tma_layout_compatible(a, b, c)
+    )
+    has_host_tma = (
+        hasattr(triton.tools.tensor_descriptor, "TensorDescriptor") and tma_compatible
+    )
+
+    if use_device_tma:
+        logger.debug("GEMS_NVIDIA MM_HOPPER using device-created TMA descriptors")
+        _set_tma_allocator(a.device)
+        with torch_device_fn.device(a.device):
+            mm_kernel_general_device_tma[grid](
+                a,
+                b,
+                c,
+                M,
+                N,
+                K,
+                a.stride(0),
+                a.stride(1),
+                b.stride(0),
+                b.stride(1),
+                c.stride(0),
+                c.stride(1),
+                A_ROW_MAJOR=a_row_major,
+                B_ROW_MAJOR=b_row_major,
+                dtype=dtype_str,
+            )
+    elif has_host_tma:
+        if device_tma_requested:
+            logger.debug(
+                "GEMS_NVIDIA MM_HOPPER device TMA request is incompatible; "
+                "falling back to host-created descriptors"
+            )
         dummy_block = [1, 1]
         # triton 3.5.0
         from triton.tools.tensor_descriptor import TensorDescriptor
@@ -483,9 +670,6 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
         else:
             b_desc = TensorDescriptor(b, b.T.shape, b.T.stride(), dummy_block)
         c_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
-
-        input_dtype = a.dtype
-        dtype_str = str(input_dtype).split(".")[-1]
 
         with torch_device_fn.device(a.device):
             mm_kernel_general_host_tma[grid](
@@ -506,12 +690,12 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
                 dtype=dtype_str,
             )
     else:
-
-        def alloc_fn(size: int, align: int, stream: Optional[int]):
-            return torch.empty(size, dtype=torch.int8, device=a.device)
-
-        triton.set_allocator(alloc_fn)
-
+        if device_tma_requested:
+            logger.debug(
+                "GEMS_NVIDIA MM_HOPPER device TMA request is incompatible; "
+                "falling back to the general kernel"
+            )
+        _set_tma_allocator(a.device)
         with torch_device_fn.device(a.device):
             mm_kernel_general[grid](
                 a,

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -30,17 +30,11 @@ from flag_gems.utils.triton_version_utils import HAS_TLE, HAS_TLE_DEVICE_MESH
 
 logger = logging.getLogger(__name__)
 CACHE_USAGE_THRESHOLD = 0.8
-_MM_DEVICE_TMA_ENV = "FLAGGEMS_NVIDIA_MM_DEVICE_TMA"
 _TRUE_ENV_VALUES = frozenset(("1", "true", "yes", "on"))
 EXPAND_CONFIG_FILENAME = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "mm_hopper_expand.yaml")
 )
 _SHARED_MEM_SAFETY_MARGIN_BYTES = 1024
-
-
-def _use_mm_device_tma():
-    """Return whether the experimental device-side TMA path is enabled."""
-    return os.environ.get(_MM_DEVICE_TMA_ENV, "0").strip().lower() in _TRUE_ENV_VALUES
 
 
 def _get_shared_memory_limit_bytes():
@@ -615,10 +609,8 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
     a_row_major = a.stride(1) == 1
     b_row_major = b.stride(1) == 1
     dtype_str = str(a.dtype).split(".")[-1]
-    device_tma_requested = _use_mm_device_tma()
     use_device_tma = (
-        device_tma_requested
-        and hasattr(tl, "make_tensor_descriptor")
+        hasattr(tl, "make_tensor_descriptor")
         and tma_compatible
         and M > 0
         and N > 0
@@ -652,11 +644,6 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
                 dtype=dtype_str,
             )
     elif has_host_tma:
-        if device_tma_requested:
-            logger.debug(
-                "GEMS_NVIDIA MM_HOPPER device TMA request is incompatible; "
-                "falling back to host-created descriptors"
-            )
         dummy_block = [1, 1]
         # triton 3.5.0
         from triton.tools.tensor_descriptor import TensorDescriptor
@@ -690,11 +677,6 @@ def general_mm(a, b, c, M, N, K, op_name="mm"):
                 dtype=dtype_str,
             )
     else:
-        if device_tma_requested:
-            logger.debug(
-                "GEMS_NVIDIA MM_HOPPER device TMA request is incompatible; "
-                "falling back to the general kernel"
-            )
         _set_tma_allocator(a.device)
         with torch_device_fn.device(a.device):
             mm_kernel_general[grid](

--- a/tests/test_mm.py
+++ b/tests/test_mm.py
@@ -193,6 +193,76 @@ def test_mm_kernel_general_host_tma_vllm_column_major_weight_compile_error():
 
 
 @pytest.mark.mm
+@pytest.mark.parametrize("a_column_major", [False, True])
+@pytest.mark.parametrize("b_column_major", [False, True])
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.skipif(
+    not hasattr(triton.language, "make_tensor_descriptor")
+    or flag_gems.vendor_name != "nvidia"
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability()[0] < 9,
+    reason="Device-side TMA tensor descriptors and a Hopper GPU are required.",
+)
+def test_mm_kernel_general_device_tma_layouts(
+    a_column_major, b_column_major, output_dtype
+):
+    from flag_gems.runtime.backend._nvidia.hopper.ops.mm import (
+        mm_kernel_general_device_tma,
+    )
+
+    torch.manual_seed(0)
+    M, K, N = 72, 72, 136
+    dtype = torch.bfloat16
+
+    if a_column_major:
+        mat1 = torch.randn((K, M), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((M, N), dtype=output_dtype, device=flag_gems.device)
+
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_out = torch.mm(ref_mat1, ref_mat2)
+
+    def alloc_fn(size, alignment, stream):
+        return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
+
+    triton.set_allocator(alloc_fn)
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+    )
+    mm_kernel_general_device_tma.fn.fn[grid](
+        mat1,
+        mat2,
+        out,
+        M,
+        N,
+        K,
+        mat1.stride(0),
+        mat1.stride(1),
+        mat2.stride(0),
+        mat2.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_M=64,
+        BLOCK_N=128,
+        BLOCK_K=64,
+        GROUP_M=8,
+        A_ROW_MAJOR=not a_column_major,
+        B_ROW_MAJOR=not b_column_major,
+        dtype="bfloat16",
+        num_warps=4,
+        num_stages=2,
+    )
+
+    utils.gems_assert_close(out, ref_out, output_dtype, reduce_dim=K)
+
+
+@pytest.mark.mm
 @pytest.mark.parametrize("M, K", MK_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_mm_self_transpose(M, K, dtype):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
on H20 HBM3
before
```
FlagGems/benchmark# pytest -vs test_mm.py::test_mm --mode operator
====================================== test session starts ======================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspace/FlagGems/benchmark/.hypothesis/examples'))
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.5.1, anyio-4.13.0, hypothesis-6.130.8
collected 1 item                                                                                

test_mm.py::test_mm 
Operator: mm  Performance Test (dtype=torch.float16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               0.014861            0.129700               0.115               0.873          [torch.Size([384, 384]), torch.Size([384, 384])]
SUCCESS               1.041485            1.005356               1.036             136.707          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.022274            0.111246               0.200              19.304          [torch.Size([1024, 1024]), torch.Size([1024, 1024])]
SUCCESS               0.144022            0.133230               1.081             128.949          [torch.Size([2048, 2048]), torch.Size([2048, 2048])]
SUCCESS               1.039161            0.998725               1.040             137.614          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               6.172674           10.380793               0.595              83.091          [torch.Size([1848, 151936]), torch.Size([151936, 1536])]
SUCCESS               5.192465            9.057307               0.573              80.390          [torch.Size([1848, 128256]), torch.Size([128256, 1536])]
SUCCESS               6.165457           10.636806               0.580              81.159          [torch.Size([1848, 152064]), torch.Size([152064, 1536])]
SUCCESS               0.360064            0.558487               0.645               2.231          [torch.Size([4096, 152064]), torch.Size([152064, 1])]
SUCCESS               0.013324            0.104246               0.128               0.080          [torch.Size([1, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.281050            0.395162               0.711               2.659          [torch.Size([1, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035638            0.112651               0.316               1.043          [torch.Size([1, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040291            0.111483               0.361               1.053          [torch.Size([1, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010888            0.110346               0.099               0.304          [torch.Size([1, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016683            0.111035               0.150               0.453          [torch.Size([1, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.067857            0.111092               0.611               2.114          [torch.Size([1, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010959            0.110677               0.099               0.232          [torch.Size([1, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041307            0.111150               0.372               1.222          [torch.Size([1, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044044            0.110798               0.398               1.226          [torch.Size([1, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.293401            0.532888               0.551               2.045          [torch.Size([1, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076636            0.113013               0.678               2.403          [torch.Size([1, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013035            0.110798               0.118               0.033          [torch.Size([1, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010826            0.110941               0.098               0.298          [torch.Size([1, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013165            0.105082               0.125               0.160          [torch.Size([2, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.281408            0.413024               0.681               5.088          [torch.Size([2, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035794            0.111051               0.322               2.115          [torch.Size([2, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041323            0.111951               0.369               2.098          [torch.Size([2, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010669            0.111931               0.095               0.600          [torch.Size([2, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016684            0.110879               0.150               0.908          [torch.Size([2, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.067857            0.111993               0.606               4.195          [torch.Size([2, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010894            0.110887               0.098               0.463          [torch.Size([2, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041304            0.112058               0.369               2.424          [torch.Size([2, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044644            0.111829               0.399               2.429          [torch.Size([2, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.293699            0.412962               0.711               5.279          [torch.Size([2, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076710            0.112826               0.680               4.814          [torch.Size([2, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013035            0.111800               0.117               0.066          [torch.Size([2, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010943            0.111532               0.098               0.592          [torch.Size([2, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013107            0.105258               0.125               0.239          [torch.Size([3, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.282029            0.406797               0.693               7.748          [torch.Size([3, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035894            0.111215               0.323               3.168          [torch.Size([3, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040617            0.110820               0.367               3.179          [torch.Size([3, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010846            0.110853               0.098               0.908          [torch.Size([3, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016384            0.111166               0.147               1.358          [torch.Size([3, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.067816            0.111969               0.606               6.293          [torch.Size([3, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010856            0.111277               0.098               0.693          [torch.Size([3, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041712            0.111283               0.375               3.661          [torch.Size([3, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044595            0.111646               0.399               3.649          [torch.Size([3, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.294113            0.414033               0.710               7.898          [torch.Size([3, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076786            0.112503               0.683               7.242          [torch.Size([3, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013038            0.110879               0.118               0.099          [torch.Size([3, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010851            0.111143               0.098               0.892          [torch.Size([3, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013153            0.103957               0.127               0.323          [torch.Size([4, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.283031            0.402887               0.703              10.431          [torch.Size([4, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035791            0.111167               0.322               4.226          [torch.Size([4, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041784            0.111471               0.375               4.214          [torch.Size([4, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010865            0.111280               0.098               1.206          [torch.Size([4, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017020            0.111402               0.153               1.807          [torch.Size([4, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068024            0.111647               0.609               8.415          [torch.Size([4, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010799            0.110888               0.097               0.927          [torch.Size([4, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041452            0.111938               0.370               4.852          [torch.Size([4, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044862            0.111416               0.403               4.875          [torch.Size([4, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.294380            0.417357               0.705              10.447          [torch.Size([4, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076843            0.112635               0.682               9.645          [torch.Size([4, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013217            0.110529               0.120               0.133          [torch.Size([4, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010778            0.110774               0.097               1.193          [torch.Size([4, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013050            0.103990               0.125               0.645          [torch.Size([8, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.284584            0.412340               0.690              20.385          [torch.Size([8, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036033            0.111277               0.324               8.443          [torch.Size([8, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040518            0.110990               0.365               8.465          [torch.Size([8, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010773            0.110703               0.097               2.425          [torch.Size([8, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017375            0.110203               0.158               3.654          [torch.Size([8, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068202            0.111567               0.611              16.842          [torch.Size([8, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010897            0.110994               0.098               1.852          [torch.Size([8, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041387            0.110875               0.373               9.798          [torch.Size([8, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044778            0.110716               0.404               9.812          [torch.Size([8, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.295854            0.419063               0.706              20.808          [torch.Size([8, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076959            0.111224               0.692              19.534          [torch.Size([8, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013233            0.110662               0.120               0.265          [torch.Size([8, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010918            0.110961               0.098               2.381          [torch.Size([8, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.014392            0.104639               0.138               7.856          [torch.Size([98, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.783563            0.972106               0.806             105.920          [torch.Size([98, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.095964            0.118708               0.808              96.954          [torch.Size([98, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.105491            0.136408               0.773              84.373          [torch.Size([98, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.033557            0.111468               0.301              29.500          [torch.Size([98, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.054860            0.111732               0.491              44.146          [torch.Size([98, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.186667            0.240319               0.777              95.782          [torch.Size([98, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.027640            0.112050               0.247              22.469          [torch.Size([98, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.112189            0.138288               0.811              96.230          [torch.Size([98, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.116218            0.137646               0.844              96.679          [torch.Size([98, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.844399            1.293782               0.653              82.564          [torch.Size([98, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.216408            0.278325               0.778              95.625          [torch.Size([98, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013326            0.110784               0.120               3.247          [torch.Size([98, 3584]), torch.Size([3584, 512])]
SUCCESS               0.029829            0.111443               0.268              29.046          [torch.Size([98, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.021677            0.104554               0.207              20.539          [torch.Size([256, 4096]), torch.Size([4096, 1024])]
SUCCESS               1.918749            1.935598               0.991             138.961          [torch.Size([256, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.227453            0.229232               0.992             131.154          [torch.Size([256, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.232680            0.235207               0.989             127.823          [torch.Size([256, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.077570            0.111463               0.696              77.066          [torch.Size([256, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.115946            0.112247               1.033             114.791          [torch.Size([256, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.448588            0.437359               1.026             137.483          [torch.Size([256, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.052250            0.111544               0.468              58.960          [torch.Size([256, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.263900            0.271736               0.971             127.927          [torch.Size([256, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.270941            0.264063               1.026             131.644          [torch.Size([256, 18944]), torch.Size([18944, 3584])]
SUCCESS               2.061987            2.014067               1.024             138.545          [torch.Size([256, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.522392            0.535362               0.976             129.865          [torch.Size([256, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.014682            0.111070               0.132               8.459          [torch.Size([256, 3584]), torch.Size([3584, 512])]
SUCCESS               0.068118            0.111392               0.612              75.910          [torch.Size([256, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.519722            0.503594               1.032             136.458          [torch.Size([8192, 4096]), torch.Size([4096, 1024])]
SUCCESS              61.272621           61.120510               1.002             140.822          [torch.Size([8192, 4096]), torch.Size([4096, 128256])]
SUCCESS               6.831921            6.850334               0.997             140.442          [torch.Size([8192, 4096]), torch.Size([4096, 14336])]
SUCCESS               7.104984            6.876667               1.033             139.904          [torch.Size([8192, 14336]), torch.Size([14336, 4096])]
SUCCESS               2.032900            1.979188               1.027             138.884          [torch.Size([8192, 4096]), torch.Size([4096, 4096])]
SUCCESS               2.986062            2.969207               1.006             138.864          [torch.Size([8192, 4096]), torch.Size([4096, 6144])]
SUCCESS              13.644968           13.678176               0.998             140.673          [torch.Size([8192, 4096]), torch.Size([4096, 28672])]
SUCCESS               1.549515            1.508937               1.027             139.471          [torch.Size([8192, 3584]), torch.Size([3584, 3584])]
SUCCESS               7.980628            7.923563               1.007             140.391          [torch.Size([8192, 3584]), torch.Size([3584, 18944])]
SUCCESS               8.159300            7.861159               1.038             141.505          [torch.Size([8192, 18944]), torch.Size([18944, 3584])]
SUCCESS              63.258410           63.477516               0.997             140.668          [torch.Size([8192, 3584]), torch.Size([3584, 152064])]
SUCCESS              15.803417           15.848358               0.997             140.380          [torch.Size([8192, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.247162            0.228213               1.083             131.740          [torch.Size([8192, 3584]), torch.Size([3584, 512])]
SUCCESS               1.936575            1.966511               0.985             137.595          [torch.Size([8192, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.010917            0.114074               0.096               0.993          [torch.Size([384, 384]), torch.Size([384, 384])]
SUCCESS               1.035900            1.010999               1.025             135.944          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.022176            0.113779               0.195              18.874          [torch.Size([1024, 1024]), torch.Size([1024, 1024])]
SUCCESS               0.133856            0.133158               1.005             129.019          [torch.Size([2048, 2048]), torch.Size([2048, 2048])]
SUCCESS               1.035741            1.080005               0.959             127.258          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               6.148577           10.664543               0.577              80.880          [torch.Size([1848, 151936]), torch.Size([151936, 1536])]
SUCCESS               5.188743            8.908228               0.582              81.735          [torch.Size([1848, 128256]), torch.Size([128256, 1536])]
SUCCESS               6.154617           10.393884               0.592              83.056          [torch.Size([1848, 152064]), torch.Size([152064, 1536])]
SUCCESS               0.401025            0.553257               0.725               2.252          [torch.Size([4096, 152064]), torch.Size([152064, 1])]
SUCCESS               0.013234            0.103525               0.128               0.081          [torch.Size([1, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.282545            0.394344               0.716               2.664          [torch.Size([1, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035899            0.114136               0.315               1.029          [torch.Size([1, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040752            0.114019               0.357               1.030          [torch.Size([1, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.011069            0.113908               0.097               0.295          [torch.Size([1, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017777            0.114054               0.156               0.441          [torch.Size([1, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069555            0.115105               0.604               2.041          [torch.Size([1, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.011141            0.113786               0.098               0.226          [torch.Size([1, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.042119            0.114202               0.369               1.189          [torch.Size([1, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.045598            0.113716               0.401               1.194          [torch.Size([1, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.312046            0.547682               0.570               1.990          [torch.Size([1, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.082883            0.114551               0.724               2.371          [torch.Size([1, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013181            0.113340               0.116               0.032          [torch.Size([1, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010928            0.113414               0.096               0.291          [torch.Size([1, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013300            0.105201               0.126               0.159          [torch.Size([2, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.282069            0.396425               0.712               5.301          [torch.Size([2, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036093            0.114607               0.315               2.049          [torch.Size([2, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041915            0.114134               0.367               2.058          [torch.Size([2, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.011100            0.113614               0.098               0.591          [torch.Size([2, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017694            0.113499               0.156               0.887          [torch.Size([2, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069260            0.114670               0.604               4.097          [torch.Size([2, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010963            0.113202               0.097               0.454          [torch.Size([2, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.042311            0.114341               0.370               2.375          [torch.Size([2, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046217            0.114623               0.403               2.369          [torch.Size([2, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.313194            0.415671               0.753               5.245          [torch.Size([2, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.083360            0.114353               0.729               4.750          [torch.Size([2, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013310            0.113617               0.117               0.065          [torch.Size([2, 3584]), torch.Size([3584, 512])]
SUCCESS               0.011085            0.114002               0.097               0.579          [torch.Size([2, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013342            0.103788               0.129               0.242          [torch.Size([3, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.283371            0.402979               0.703               7.822          [torch.Size([3, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036163            0.114041               0.317               3.089          [torch.Size([3, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041100            0.113788               0.361               3.096          [torch.Size([3, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010939            0.113745               0.096               0.885          [torch.Size([3, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017807            0.113646               0.157               1.329          [torch.Size([3, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069234            0.114330               0.606               6.163          [torch.Size([3, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010928            0.114125               0.096               0.675          [torch.Size([3, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.042452            0.114069               0.372               3.571          [torch.Size([3, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046160            0.114517               0.403               3.557          [torch.Size([3, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.319137            0.408517               0.781               8.005          [torch.Size([3, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.083338            0.114008               0.731               7.146          [torch.Size([3, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013341            0.112982               0.118               0.097          [torch.Size([3, 3584]), torch.Size([3584, 512])]
SUCCESS               0.011046            0.113060               0.098               0.876          [torch.Size([3, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013335            0.104305               0.128               0.322          [torch.Size([4, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.283927            0.399789               0.710              10.512          [torch.Size([4, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036370            0.113114               0.322               4.153          [torch.Size([4, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.042368            0.113376               0.374               4.143          [torch.Size([4, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010981            0.113264               0.097               1.185          [torch.Size([4, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017990            0.113135               0.159               1.780          [torch.Size([4, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069030            0.113635               0.607               8.268          [torch.Size([4, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.011136            0.112628               0.099               0.912          [torch.Size([4, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.042397            0.113763               0.373               4.774          [torch.Size([4, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046052            0.113455               0.406               4.787          [torch.Size([4, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.314422            0.416392               0.755              10.471          [torch.Size([4, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.083322            0.114264               0.729               9.507          [torch.Size([4, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013310            0.113494               0.117               0.129          [torch.Size([4, 3584]), torch.Size([3584, 512])]
SUCCESS               0.011058            0.113381               0.098               1.165          [torch.Size([4, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013296            0.103845               0.128               0.646          [torch.Size([8, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.284758            0.406461               0.701              20.679          [torch.Size([8, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036641            0.113832               0.322               8.254          [torch.Size([8, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040931            0.113751               0.360               8.260          [torch.Size([8, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.011040            0.113427               0.097               2.367          [torch.Size([8, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.018285            0.113637               0.161               3.543          [torch.Size([8, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069671            0.113850               0.612              16.505          [torch.Size([8, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010964            0.113769               0.096               1.806          [torch.Size([8, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.042634            0.114194               0.373               9.513          [torch.Size([8, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046844            0.113806               0.412               9.545          [torch.Size([8, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.316009            0.414041               0.763              21.061          [torch.Size([8, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.083502            0.114685               0.728              18.945          [torch.Size([8, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013213            0.113551               0.116               0.259          [torch.Size([8, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010835            0.113375               0.096               2.331          [torch.Size([8, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.014398            0.104725               0.137               7.850          [torch.Size([98, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.782497            1.130231               0.692              91.102          [torch.Size([98, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.096219            0.119028               0.808              96.693          [torch.Size([98, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.104942            0.136823               0.767              84.117          [torch.Size([98, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.033416            0.114146               0.293              28.808          [torch.Size([98, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.051149            0.114587               0.446              43.046          [torch.Size([98, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.186665            0.235375               0.793              97.794          [torch.Size([98, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.027773            0.114072               0.243              22.070          [torch.Size([98, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.111127            0.137811               0.806              96.564          [torch.Size([98, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.116672            0.136898               0.852              97.207          [torch.Size([98, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.844686            1.001593               0.843             106.650          [torch.Size([98, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.216280            0.276189               0.783              96.365          [torch.Size([98, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013664            0.113771               0.120               3.161          [torch.Size([98, 3584]), torch.Size([3584, 512])]
SUCCESS               0.029759            0.114265               0.260              28.328          [torch.Size([98, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.023952            0.105617               0.227              20.333          [torch.Size([256, 4096]), torch.Size([4096, 1024])]
SUCCESS               1.918805            1.930411               0.994             139.334          [torch.Size([256, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.227521            0.226319               1.005             132.842          [torch.Size([256, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.232780            0.235381               0.989             127.728          [torch.Size([256, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.068661            0.114981               0.597              74.707          [torch.Size([256, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.102601            0.115105               0.891             111.940          [torch.Size([256, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.448253            0.438725               1.022             137.055          [torch.Size([256, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.052199            0.114049               0.458              57.665          [torch.Size([256, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.263855            0.264481               0.998             131.436          [torch.Size([256, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.270059            0.263816               1.024             131.768          [torch.Size([256, 18944]), torch.Size([18944, 3584])]
SUCCESS               2.061722            2.001776               1.030             139.396          [torch.Size([256, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.521658            0.521153               1.001             133.406          [torch.Size([256, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.014703            0.113837               0.129               8.253          [torch.Size([256, 3584]), torch.Size([3584, 512])]
SUCCESS               0.068082            0.114488               0.595              73.857          [torch.Size([256, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.511190            0.502622               1.017             136.722          [torch.Size([8192, 4096]), torch.Size([4096, 1024])]
SUCCESS              61.017752           61.090469               0.999             140.891          [torch.Size([8192, 4096]), torch.Size([4096, 128256])]
SUCCESS               6.847693            6.854912               0.999             140.348          [torch.Size([8192, 4096]), torch.Size([4096, 14336])]
SUCCESS               7.098033            6.855708               1.035             140.332          [torch.Size([8192, 14336]), torch.Size([14336, 4096])]
SUCCESS               2.033451            1.981107               1.026             138.750          [torch.Size([8192, 4096]), torch.Size([4096, 4096])]
SUCCESS               2.984643            2.951655               1.011             139.690          [torch.Size([8192, 4096]), torch.Size([4096, 6144])]
SUCCESS              13.643776           13.679845               0.997             140.655          [torch.Size([8192, 4096]), torch.Size([4096, 28672])]
SUCCESS               1.550485            1.512294               1.025             139.162          [torch.Size([8192, 3584]), torch.Size([3584, 3584])]
SUCCESS               7.967645            7.931948               1.005             140.243          [torch.Size([8192, 3584]), torch.Size([3584, 18944])]
SUCCESS               8.159161            7.880926               1.035             141.150          [torch.Size([8192, 18944]), torch.Size([18944, 3584])]
SUCCESS              63.261032           63.471794               0.997             140.680          [torch.Size([8192, 3584]), torch.Size([3584, 152064])]
SUCCESS              15.800834           15.830636               0.998             140.537          [torch.Size([8192, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.247379            0.228249               1.084             131.719          [torch.Size([8192, 3584]), torch.Size([3584, 512])]
SUCCESS               1.936252            1.949265               0.993             138.813          [torch.Size([8192, 3584]), torch.Size([3584, 4608])]
```

after
```
FlagGems/benchmark# pytest -vs test_mm.py::test_mm --mode operator
====================================== test session starts ======================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspace/FlagGems/benchmark/.hypothesis/examples'))
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.5.1, anyio-4.13.0, hypothesis-6.130.8
collected 1 item                                                                                

test_mm.py::test_mm 
Operator: mm  Performance Test (dtype=torch.float16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               0.014702            0.145197               0.101               0.780          [torch.Size([384, 384]), torch.Size([384, 384])]
SUCCESS               1.040541            1.001298               1.039             137.261          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.022059            0.126154               0.175              17.023          [torch.Size([1024, 1024]), torch.Size([1024, 1024])]
SUCCESS               0.142759            0.140623               1.015             122.169          [torch.Size([2048, 2048]), torch.Size([2048, 2048])]
SUCCESS               1.029841            1.000210               1.030             137.410          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               6.129043           10.462105               0.586              82.445          [torch.Size([1848, 151936]), torch.Size([151936, 1536])]
SUCCESS               5.168875            8.972732               0.576              81.148          [torch.Size([1848, 128256]), torch.Size([128256, 1536])]
SUCCESS               6.195100           10.619111               0.583              81.295          [torch.Size([1848, 152064]), torch.Size([152064, 1536])]
SUCCESS               0.360890            0.556758               0.648               2.237          [torch.Size([4096, 152064]), torch.Size([152064, 1])]
SUCCESS               0.013303            0.105284               0.126               0.080          [torch.Size([1, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.281013            0.384073               0.732               2.736          [torch.Size([1, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.037959            0.126519               0.300               0.928          [torch.Size([1, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041312            0.127369               0.324               0.922          [torch.Size([1, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.011004            0.125582               0.088               0.267          [torch.Size([1, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.015716            0.125716               0.125               0.400          [torch.Size([1, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.067841            0.125734               0.540               1.868          [torch.Size([1, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.011016            0.124918               0.088               0.206          [torch.Size([1, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041223            0.126227               0.327               1.076          [torch.Size([1, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044415            0.125861               0.353               1.079          [torch.Size([1, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.293739            0.508315               0.578               2.144          [torch.Size([1, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076720            0.125867               0.610               2.158          [torch.Size([1, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013061            0.124459               0.105               0.029          [torch.Size([1, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010956            0.124957               0.088               0.264          [torch.Size([1, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013164            0.104839               0.126               0.160          [torch.Size([2, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.281428            0.406539               0.692               5.169          [torch.Size([2, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036163            0.125859               0.287               1.866          [torch.Size([2, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040319            0.125988               0.320               1.864          [torch.Size([2, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010902            0.124447               0.088               0.539          [torch.Size([2, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.015943            0.125241               0.127               0.804          [torch.Size([2, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.067944            0.126457               0.537               3.715          [torch.Size([2, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010888            0.125693               0.087               0.409          [torch.Size([2, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041282            0.125133               0.330               2.170          [torch.Size([2, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044559            0.125663               0.355               2.161          [torch.Size([2, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.294273            0.447863               0.657               4.868          [torch.Size([2, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076752            0.127285               0.603               4.267          [torch.Size([2, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013155            0.126509               0.104               0.058          [torch.Size([2, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010920            0.125377               0.087               0.527          [torch.Size([2, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013037            0.105231               0.124               0.239          [torch.Size([3, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.281954            0.387869               0.727               8.127          [torch.Size([3, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036061            0.126640               0.285               2.782          [torch.Size([3, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041624            0.125635               0.331               2.804          [torch.Size([3, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010728            0.124829               0.086               0.806          [torch.Size([3, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016012            0.125025               0.128               1.208          [torch.Size([3, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068102            0.125408               0.543               5.619          [torch.Size([3, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010917            0.124829               0.087               0.617          [torch.Size([3, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041360            0.125501               0.330               3.246          [torch.Size([3, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044761            0.125131               0.358               3.256          [torch.Size([3, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.294832            0.420972               0.700               7.768          [torch.Size([3, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076748            0.125800               0.610               6.476          [torch.Size([3, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013164            0.124951               0.105               0.088          [torch.Size([3, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010754            0.124802               0.086               0.794          [torch.Size([3, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013186            0.103616               0.127               0.324          [torch.Size([4, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.282594            0.400154               0.706              10.503          [torch.Size([4, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.035905            0.125148               0.287               3.754          [torch.Size([4, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041782            0.125394               0.333               3.746          [torch.Size([4, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010930            0.124572               0.088               1.077          [torch.Size([4, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016212            0.126177               0.128               1.596          [torch.Size([4, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068139            0.125623               0.542               7.479          [torch.Size([4, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010841            0.124936               0.087               0.823          [torch.Size([4, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041242            0.125283               0.329               4.335          [torch.Size([4, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044382            0.125446               0.354               4.330          [torch.Size([4, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.295950            0.422008               0.701              10.332          [torch.Size([4, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.076855            0.125604               0.612               8.649          [torch.Size([4, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013209            0.124865               0.106               0.118          [torch.Size([4, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010788            0.125584               0.086               1.052          [torch.Size([4, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013164            0.103407               0.127               0.649          [torch.Size([8, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.283971            0.399902               0.710              21.019          [torch.Size([8, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036115            0.125958               0.287               7.459          [torch.Size([8, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040299            0.125776               0.320               7.470          [torch.Size([8, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010793            0.125290               0.086               2.143          [torch.Size([8, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016743            0.125011               0.134               3.221          [torch.Size([8, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068255            0.125456               0.544              14.978          [torch.Size([8, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010885            0.124563               0.087               1.650          [torch.Size([8, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041472            0.124973               0.332               8.692          [torch.Size([8, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.044949            0.124759               0.360               8.707          [torch.Size([8, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.296646            0.428421               0.692              20.354          [torch.Size([8, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.077092            0.125479               0.614              17.315          [torch.Size([8, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013042            0.124216               0.105               0.236          [torch.Size([8, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010769            0.124022               0.087               2.131          [torch.Size([8, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.014373            0.104668               0.137               7.854          [torch.Size([98, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.786778            1.101255               0.714              93.499          [torch.Size([98, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.097787            0.251532               0.389              45.756          [torch.Size([98, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.105390            0.277042               0.380              41.543          [torch.Size([98, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.033665            0.176907               0.190              18.588          [torch.Size([98, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.054509            0.194788               0.280              25.322          [torch.Size([98, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.187798            0.362158               0.519              63.559          [torch.Size([98, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.027627            0.179291               0.154              14.042          [torch.Size([98, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.111568            0.267029               0.418              49.835          [torch.Size([98, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.116849            0.282288               0.414              47.142          [torch.Size([98, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.848343            1.137972               0.745              93.868          [torch.Size([98, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.216547            0.398874               0.543              66.725          [torch.Size([98, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013318            0.152826               0.087               2.353          [torch.Size([98, 3584]), torch.Size([3584, 512])]
SUCCESS               0.029845            0.173807               0.172              18.624          [torch.Size([98, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.021809            0.145912               0.149              14.718          [torch.Size([256, 4096]), torch.Size([4096, 1024])]
SUCCESS               1.927432            2.059698               0.936             130.588          [torch.Size([256, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.227843            0.373363               0.610              80.524          [torch.Size([256, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.232437            0.372648               0.624              80.679          [torch.Size([256, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.077368            0.209093               0.370              41.082          [torch.Size([256, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.116117            0.236511               0.491              54.479          [torch.Size([256, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.450332            0.574112               0.784             104.735          [torch.Size([256, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.052371            0.194788               0.269              33.763          [torch.Size([256, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.265475            0.399351               0.665              87.047          [torch.Size([256, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.271329            0.421047               0.644              82.562          [torch.Size([256, 18944]), torch.Size([18944, 3584])]
SUCCESS               2.065769            2.112865               0.978             132.066          [torch.Size([256, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.523014            0.647783               0.807             107.327          [torch.Size([256, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.014621            0.157118               0.093               5.980          [torch.Size([256, 3584]), torch.Size([3584, 512])]
SUCCESS               0.067986            0.204802               0.332              41.287          [torch.Size([256, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.516924            0.641346               0.806             107.149          [torch.Size([8192, 4096]), torch.Size([4096, 1024])]
SUCCESS              60.732126           61.201572               0.992             140.636          [torch.Size([8192, 4096]), torch.Size([4096, 128256])]
SUCCESS               6.837111            6.926775               0.987             138.892          [torch.Size([8192, 4096]), torch.Size([4096, 14336])]
SUCCESS               7.099060            6.993055               1.015             137.575          [torch.Size([8192, 14336]), torch.Size([14336, 4096])]
SUCCESS               2.033052            2.103329               0.967             130.687          [torch.Size([8192, 4096]), torch.Size([4096, 4096])]
SUCCESS               2.970308            3.053188               0.973             135.045          [torch.Size([8192, 4096]), torch.Size([4096, 6144])]
SUCCESS              13.692822           13.744593               0.996             139.993          [torch.Size([8192, 4096]), torch.Size([4096, 28672])]
SUCCESS               1.542835            1.636505               0.943             128.599          [torch.Size([8192, 3584]), torch.Size([3584, 3584])]
SUCCESS               7.948095            7.983446               0.996             139.338          [torch.Size([8192, 3584]), torch.Size([3584, 18944])]
SUCCESS               8.119126            7.999897               1.015             139.051          [torch.Size([8192, 18944]), torch.Size([18944, 3584])]
SUCCESS              63.422918           63.585281               0.997             140.429          [torch.Size([8192, 3584]), torch.Size([3584, 152064])]
SUCCESS              15.844464           15.897512               0.997             139.946          [torch.Size([8192, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.247536            0.385284               0.642              78.033          [torch.Size([8192, 3584]), torch.Size([3584, 512])]
SUCCESS               1.924356            2.078295               0.926             130.195          [torch.Size([8192, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.010974            0.175238               0.063               0.646          [torch.Size([384, 384]), torch.Size([384, 384])]
SUCCESS               1.044563            1.127005               0.927             121.951          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.022058            0.155210               0.142              13.836          [torch.Size([1024, 1024]), torch.Size([1024, 1024])]
SUCCESS               0.134339            0.265121               0.507              64.800          [torch.Size([2048, 2048]), torch.Size([2048, 2048])]
SUCCESS               1.043859            0.997908               1.046             137.727          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               6.109272           10.224342               0.598              84.362          [torch.Size([1848, 151936]), torch.Size([151936, 1536])]
SUCCESS               5.157444            8.628130               0.598              84.389          [torch.Size([1848, 128256]), torch.Size([128256, 1536])]
SUCCESS               6.110112           10.203123               0.599              84.609          [torch.Size([1848, 152064]), torch.Size([152064, 1536])]
SUCCESS               0.389447            0.553427               0.704               2.251          [torch.Size([4096, 152064]), torch.Size([152064, 1])]
SUCCESS               0.013178            0.125408               0.105               0.067          [torch.Size([1, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.282076            0.517845               0.545               2.029          [torch.Size([1, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036314            0.185013               0.196               0.635          [torch.Size([1, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041457            0.197172               0.210               0.596          [torch.Size([1, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010996            0.156641               0.070               0.214          [torch.Size([1, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016750            0.165462               0.101               0.304          [torch.Size([1, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069084            0.226736               0.305               1.036          [torch.Size([1, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.011122            0.156879               0.071               0.164          [torch.Size([1, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041598            0.190735               0.218               0.712          [torch.Size([1, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.045911            0.214338               0.214               0.634          [torch.Size([1, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.311710            0.532150               0.586               2.048          [torch.Size([1, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.080905            0.241280               0.335               1.126          [torch.Size([1, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013184            0.144005               0.092               0.025          [torch.Size([1, 3584]), torch.Size([3584, 512])]
SUCCESS               0.011043            0.155687               0.071               0.212          [torch.Size([1, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013199            0.109005               0.121               0.154          [torch.Size([2, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.283461            0.517130               0.548               4.063          [torch.Size([2, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036035            0.186443               0.193               1.260          [torch.Size([2, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.040522            0.197172               0.206               1.191          [torch.Size([2, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010895            0.157356               0.069               0.426          [torch.Size([2, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016626            0.165462               0.100               0.608          [torch.Size([2, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.068977            0.228643               0.302               2.055          [torch.Size([2, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010772            0.147820               0.073               0.348          [torch.Size([2, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041923            0.189066               0.222               1.436          [torch.Size([2, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.045621            0.215054               0.212               1.263          [torch.Size([2, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.312353            0.527143               0.593               4.135          [torch.Size([2, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.080933            0.240803               0.336               2.256          [torch.Size([2, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013038            0.143290               0.091               0.051          [torch.Size([2, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010793            0.153542               0.070               0.430          [torch.Size([2, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013097            0.109529               0.120               0.230          [torch.Size([3, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.284033            0.514507               0.552               6.126          [torch.Size([3, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.038375            0.186205               0.206               1.892          [torch.Size([3, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041810            0.202894               0.206               1.736          [torch.Size([3, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010882            0.154972               0.070               0.650          [torch.Size([3, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.016825            0.168562               0.100               0.896          [torch.Size([3, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069385            0.225782               0.307               3.121          [torch.Size([3, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010812            0.156164               0.069               0.494          [torch.Size([3, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041886            0.190020               0.220               2.144          [torch.Size([3, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046148            0.215054               0.215               1.894          [torch.Size([3, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.312616            0.530005               0.590               6.170          [torch.Size([3, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.081433            0.248909               0.327               3.273          [torch.Size([3, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013080            0.144720               0.090               0.076          [torch.Size([3, 3584]), torch.Size([3584, 512])]
SUCCESS               0.011014            0.161409               0.068               0.614          [torch.Size([3, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013127            0.104464               0.126               0.321          [torch.Size([4, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.284775            0.394677               0.722              10.648          [torch.Size([4, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036209            0.125582               0.288               3.741          [torch.Size([4, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041938            0.130355               0.322               3.604          [torch.Size([4, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010845            0.124606               0.087               1.077          [torch.Size([4, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017028            0.125096               0.136               1.609          [torch.Size([4, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069558            0.124890               0.557               7.523          [torch.Size([4, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010716            0.124957               0.086               0.822          [torch.Size([4, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041939            0.125513               0.334               4.328          [torch.Size([4, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.045977            0.127671               0.360               4.254          [torch.Size([4, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.313253            0.420830               0.744              10.360          [torch.Size([4, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.081237            0.126436               0.643               8.592          [torch.Size([4, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013071            0.125257               0.104               0.117          [torch.Size([4, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010775            0.124819               0.086               1.058          [torch.Size([4, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.013022            0.107336               0.121               0.625          [torch.Size([8, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.285141            0.509501               0.560              16.497          [torch.Size([8, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.036362            0.182390               0.199               5.151          [torch.Size([8, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.041136            0.194311               0.212               4.835          [torch.Size([8, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.010777            0.150442               0.072               1.784          [torch.Size([8, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.017792            0.162840               0.109               2.473          [torch.Size([8, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.069912            0.226259               0.309               8.305          [torch.Size([8, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.010835            0.151634               0.071               1.355          [torch.Size([8, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.041985            0.195026               0.215               5.570          [torch.Size([8, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.046336            0.211239               0.219               5.143          [torch.Size([8, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.315142            0.526905               0.598              16.549          [torch.Size([8, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.081645            0.239134               0.341               9.085          [torch.Size([8, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013177            0.143051               0.092               0.205          [torch.Size([8, 3584]), torch.Size([3584, 512])]
SUCCESS               0.010801            0.148773               0.073               1.776          [torch.Size([8, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.014355            0.111246               0.129               7.390          [torch.Size([98, 4096]), torch.Size([4096, 1024])]
SUCCESS               0.780522            1.100063               0.710              93.600          [torch.Size([98, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.095631            0.253439               0.377              45.412          [torch.Size([98, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.105234            0.270367               0.389              42.569          [torch.Size([98, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.033345            0.175476               0.190              18.740          [torch.Size([98, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.050946            0.195026               0.261              25.291          [torch.Size([98, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.185898            0.371933               0.500              61.888          [torch.Size([98, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.027907            0.164986               0.169              15.260          [torch.Size([98, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.110365            0.268698               0.411              49.526          [torch.Size([98, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.116365            0.273466               0.426              48.662          [torch.Size([98, 18944]), torch.Size([18944, 3584])]
SUCCESS               0.840534            1.130819               0.743              94.462          [torch.Size([98, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.215291            0.396967               0.542              67.046          [torch.Size([98, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.013476            0.141621               0.095               2.540          [torch.Size([98, 3584]), torch.Size([3584, 512])]
SUCCESS               0.029853            0.180483               0.165              17.935          [torch.Size([98, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.024039            0.142813               0.168              15.037          [torch.Size([256, 4096]), torch.Size([4096, 1024])]
SUCCESS               1.926634            2.051592               0.939             131.104          [torch.Size([256, 4096]), torch.Size([4096, 128256])]
SUCCESS               0.227725            0.357151               0.638              84.179          [torch.Size([256, 4096]), torch.Size([4096, 14336])]
SUCCESS               0.232666            0.370979               0.627              81.042          [torch.Size([256, 14336]), torch.Size([14336, 4096])]
SUCCESS               0.068917            0.207663               0.332              41.365          [torch.Size([256, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.102674            0.232935               0.441              55.315          [torch.Size([256, 4096]), torch.Size([4096, 6144])]
SUCCESS               0.448709            0.576258               0.779             104.345          [torch.Size([256, 4096]), torch.Size([4096, 28672])]
SUCCESS               0.052305            0.187159               0.279              35.140          [torch.Size([256, 3584]), torch.Size([3584, 3584])]
SUCCESS               0.264001            0.397921               0.663              87.360          [torch.Size([256, 3584]), torch.Size([3584, 18944])]
SUCCESS               0.270154            0.394344               0.685              88.152          [torch.Size([256, 18944]), torch.Size([18944, 3584])]
SUCCESS               2.061300            2.112627               0.976             132.081          [torch.Size([256, 3584]), torch.Size([3584, 152064])]
SUCCESS               0.521819            0.645161               0.809             107.764          [torch.Size([256, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.014632            0.146151               0.100               6.428          [torch.Size([256, 3584]), torch.Size([3584, 512])]
SUCCESS               0.068217            0.201225               0.339              42.021          [torch.Size([256, 3584]), torch.Size([3584, 4608])]
SUCCESS               0.511382            0.640392               0.799             107.308          [torch.Size([8192, 4096]), torch.Size([4096, 1024])]
SUCCESS              61.027288           61.462641               0.993             140.038          [torch.Size([8192, 4096]), torch.Size([4096, 128256])]
SUCCESS               6.843050            7.048368               0.971             136.496          [torch.Size([8192, 4096]), torch.Size([4096, 14336])]
SUCCESS               7.057007            6.990910               1.009             137.618          [torch.Size([8192, 14336]), torch.Size([14336, 4096])]
SUCCESS               2.022965            2.104521               0.961             130.613          [torch.Size([8192, 4096]), torch.Size([4096, 4096])]
SUCCESS               2.975248            3.074408               0.968             134.113          [torch.Size([8192, 4096]), torch.Size([4096, 6144])]
SUCCESS              13.577121           13.791800               0.984             139.514          [torch.Size([8192, 4096]), torch.Size([4096, 28672])]
SUCCESS               1.552617            1.640797               0.946             128.263          [torch.Size([8192, 3584]), torch.Size([3584, 3584])]
SUCCESS               7.989970            8.026600               0.995             138.589          [torch.Size([8192, 3584]), torch.Size([3584, 18944])]
SUCCESS               8.176912            8.009434               1.021             138.886          [torch.Size([8192, 18944]), torch.Size([18944, 3584])]
SUCCESS              63.515902          139.758348               0.454              63.891          [torch.Size([8192, 3584]), torch.Size([3584, 152064])]
SUCCESS              35.419464           17.479181               2.026             127.282          [torch.Size([8192, 3584]), torch.Size([3584, 37888])]
SUCCESS               0.245892            0.361204               0.681              83.235          [torch.Size([8192, 3584]), torch.Size([3584, 512])]
SUCCESS               1.924806            2.060175               0.934             131.340          [torch.Size([8192, 3584]), torch.Size([3584, 4608])]
```
