### PR TITLE
[KMCompiler] perf-opt grouped_topk for DeepSeek-v3.2

### DIFF
--- a/benchmark/test_grouped_topk.py
+++ b/benchmark/test_grouped_topk.py
@@ -19,14 +19,18 @@ import flag_gems
 
 from . import base, utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
-    from vllm._custom_ops import grouped_topk as vllm_grouped_topk
+    if vendor_name == "metax":
+        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
+    else:
+        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
 
     HAS_VLLM = True
 except (ImportError, AttributeError):
     HAS_VLLM = False
-
-vendor_name = flag_gems.vendor_name
+    vllm_grouped_topk = None
 
 
 class GroupedTopKBenchmark(base.Benchmark):
@@ -46,20 +50,13 @@ class GroupedTopKBenchmark(base.Benchmark):
 
     def set_shapes(self, shape_file_path=None):
         grouped_topk_configs = [
-            (1, 64, 8, 2, 8),
-            (8, 64, 8, 2, 8),
-            (32, 64, 8, 2, 8),
-            (64, 64, 8, 2, 8),
-            (128, 64, 8, 2, 8),
-            (256, 64, 8, 2, 8),
-            (32, 128, 8, 2, 8),
-            (64, 128, 8, 2, 8),
-            (128, 128, 8, 2, 8),
-            (64, 64, 4, 2, 4),
-            (64, 128, 16, 2, 8),
-            (512, 64, 8, 2, 8),
-            (1024, 64, 8, 2, 8),
-            (2048, 64, 8, 2, 8),
+            # Deepseek-3.2
+            (num_tokens, num_experts, n_group, topk_group, topk)
+            for num_tokens in [1, 8, 32, 64, 128, 256, 496, 512, 16384]
+            for num_experts in [256]
+            for n_group in [8]
+            for topk_group in [4]
+            for topk in [8]
         ]
         self.shapes = grouped_topk_configs
 
@@ -71,7 +68,7 @@ class GroupedTopKBenchmark(base.Benchmark):
         num_tokens, num_experts, n_group, topk_group, topk = config
 
         scores = torch.randn(num_tokens, num_experts, device=device, dtype=dtype)
-        bias = torch.randn(num_experts, device=device, dtype=dtype)
+        bias = torch.randn(num_experts, device=device, dtype=torch.float32)
 
         yield (
             scores,
@@ -95,7 +92,6 @@ class GroupedTopKBenchmark(base.Benchmark):
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -105,7 +101,7 @@ def test_grouped_topk_no_renorm():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=False,
         scoring_func=0,
     )
@@ -124,7 +120,6 @@ def test_grouped_topk_no_renorm():
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working ")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -134,7 +129,7 @@ def test_grouped_topk_score_0():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=0,
     )
@@ -153,7 +148,6 @@ def test_grouped_topk_score_0():
     utils.SkipVersion("torch", "<2.7"),
     reason="The version prior to 2.7 is not compatible with VLLM.",
 )
-@pytest.mark.skipif(vendor_name == "metax", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="#2891: Not working")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="#2891: Not working")
@@ -163,7 +157,7 @@ def test_grouped_topk_score_1():
     bench = GroupedTopKBenchmark(
         op_name="grouped_topk",
         torch_op=vllm_grouped_topk,
-        dtypes=[torch.float32, torch.bfloat16],
+        dtypes=[torch.bfloat16],
         renormalize=True,
         scoring_func=1,
     )

--- a/src/flag_gems/fused/grouped_topk.py
+++ b/src/flag_gems/fused/grouped_topk.py
@@ -18,6 +18,22 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.utils import tl_extra_shim
+from flag_gems.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -54,7 +70,7 @@ def topk_with_k2_triton(
         bias_ptr + bias_offset + lane,
         mask=mask,
         other=0.0,
-    )
+    ).to(INPUT_DTYPE)
 
     x = x + b
 
@@ -181,7 +197,7 @@ def group_idx_and_topk_triton(
         bias_ptr + expert_offsets,
         mask=valid_expert,
         other=0.0,
-    )
+    ).to(INPUT_DTYPE)
 
     selection_scores_native = scored + expert_bias
 
@@ -242,6 +258,246 @@ def group_idx_and_topk_triton(
     )
 
 
+@triton.jit
+def _sigmoid(x):
+    log2e: tl.constexpr = 1.4426950408889634
+    return 1 / (1 + tl_extra_shim.exp2(-x * log2e))
+
+
+@triton.jit
+def _pack_val_idx_fp32(val, idx):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    bits = val.to(tl.uint32, bitcast=True)
+    key = tl.where((bits & 0x80000000) != 0, ~bits, bits | 0x80000000)
+    high = key.to(tl.uint64) << 32
+    low = (0xFFFF & (MAX_IDX - idx)).to(tl.uint64)
+    return high | low
+
+
+@triton.jit
+def _unpack_val_idx_fp32(pair):
+    MAX_IDX: tl.constexpr = 0xFFFF
+    key = (pair >> 32).to(tl.uint32)
+    idx = (MAX_IDX - (pair & 0xFFFF)).to(tl.uint32)
+    bits = tl.where((key & 0x80000000) != 0, key ^ 0x80000000, ~key)
+    val = bits.to(tl.float32, bitcast=True)
+    return val, idx
+
+
+# Adapted from vLLM:
+#   ./vllm/csrc/moe/grouped_topk_kernels.cu
+#   ./vllm/csrc/moe/moeTopKFuncs.cuh
+@triton.jit
+def triton_grouped_topk_fused_small_expert_count_kernel(
+    scores_ptr,
+    topk_values_ptr,
+    topk_indices_ptr,
+    routing_bias_ptr,
+    num_tokens,
+    num_groups,
+    topk_group,
+    topk: tl.constexpr,
+    num_experts,
+    num_experts_per_group,
+    renormalize,
+    routed_scaling_factor,
+    scores_stride0,
+    g_score_sigmoid_ptr,
+    g_score_bias_ptr,
+    SCORING_FUNC: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+):
+    WARP_SIZE: tl.constexpr = 32
+    NUM_WARPS: tl.constexpr = 8
+    neg_inf: tl.constexpr = float("-inf")
+    MAX_IDX: tl.constexpr = 65535
+
+    token_id = tl.program_id(0)
+    scores_ptr += token_id * scores_stride0
+    topk_values_ptr += token_id * topk
+    topk_indices_ptr += token_id * topk
+    warps = tl.arange(0, NUM_WARPS)
+    lane = tl.arange(0, WARP_SIZE)
+
+    if HAS_TLE:
+        s_score_sigmoid = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_bias = tle.gpu.alloc(
+            [NUM_WARPS, WARP_SIZE],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        s_score_sigmoid_ptr = tle.gpu.local_ptr(s_score_sigmoid, (0, 0))
+        s_score_bias_ptr = tle.gpu.local_ptr(s_score_bias, (0, 0))
+    else:
+        s_score_sigmoid_ptr = g_score_sigmoid_ptr + token_id * scores_stride0
+        s_score_bias_ptr = g_score_bias_ptr + token_id * scores_stride0
+
+    # step1: load score/bias, get score_sigmoid/score_bias
+    offs = warps[:, None] * num_experts_per_group + lane[None, :]
+    score = tl.load(
+        scores_ptr + offs,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+        other=neg_inf,
+    ).to(tl.float32)
+    if SCORING_FUNC == 1:
+        score_sigmoid = _sigmoid(score)
+    else:
+        score_sigmoid = score
+    tl.store(
+        s_score_sigmoid_ptr + offs,
+        score_sigmoid,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    )
+    bias_val = tl.load(
+        routing_bias_ptr + offs,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+        other=neg_inf,
+    ).to(tl.float32)
+    score_bias = score_sigmoid + bias_val
+    tl.store(
+        s_score_bias_ptr + offs,
+        score_bias,
+        mask=(warps[:, None] < num_groups) & (lane[None, :] < num_experts_per_group),
+    )
+
+    # step2: get top2 as group_score
+    min_val0 = tl.full((NUM_WARPS, WARP_SIZE), neg_inf, dtype=tl.float32)
+    comp_val_idx0 = _pack_val_idx_fp32(score_bias, offs)
+    packed_max00 = tl.max(comp_val_idx0, axis=-1)
+    val_max0, _0 = _unpack_val_idx_fp32(packed_max00)
+    comp_val_idx0 = tl.where(
+        comp_val_idx0 == packed_max00[:, None],
+        _pack_val_idx_fp32(min_val0, offs),
+        comp_val_idx0,
+    )
+    packed_max01 = tl.max(comp_val_idx0, axis=-1)
+    val_max1, _0 = _unpack_val_idx_fp32(packed_max01)
+    group_score = val_max0 + val_max1
+
+    # step3: get topk_group, topk_group <= MAX_NUM_TOP_GROUPS, where MAX_NUM_TOP_GROUPS = 4
+    min_val1 = tl.full((NUM_WARPS,), neg_inf, dtype=tl.float32)
+    comp_val_idx1 = _pack_val_idx_fp32(group_score, warps)
+    packed_max10 = tl.max(comp_val_idx1)
+    _2, group_idx0 = _unpack_val_idx_fp32(packed_max10)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max10,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max11 = tl.max(comp_val_idx1)
+    _2, group_idx1 = _unpack_val_idx_fp32(packed_max11)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max11,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max12 = tl.max(comp_val_idx1)
+    _2, group_idx2 = _unpack_val_idx_fp32(packed_max12)
+    comp_val_idx1 = tl.where(
+        comp_val_idx1 == packed_max12,
+        _pack_val_idx_fp32(min_val1, warps),
+        comp_val_idx1,
+    )
+    packed_max13 = tl.max(comp_val_idx1)
+    _2, group_idx3 = _unpack_val_idx_fp32(packed_max13)
+
+    # step4: get topk, topk <= MAX_NUM_TOP_EXPERTS, where MAX_NUM_TOP_EXPERTS = 8
+    expert_idx_group0 = group_idx0 * num_experts_per_group + lane
+    expert_idx_group1 = group_idx1 * num_experts_per_group + lane
+    expert_idx_group2 = group_idx2 * num_experts_per_group + lane
+    expert_idx_group3 = group_idx3 * num_experts_per_group + lane
+    expert_score_group0 = tl.load(
+        s_score_bias_ptr + expert_idx_group0,
+        mask=(0 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group1 = tl.load(
+        s_score_bias_ptr + expert_idx_group1,
+        mask=(1 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group2 = tl.load(
+        s_score_bias_ptr + expert_idx_group2,
+        mask=(2 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    expert_score_group3 = tl.load(
+        s_score_bias_ptr + expert_idx_group3,
+        mask=(3 < topk_group) & (lane < num_experts_per_group),
+        other=neg_inf,
+    )
+    comp_val_idx20 = _pack_val_idx_fp32(expert_score_group0, expert_idx_group0)
+    comp_val_idx21 = _pack_val_idx_fp32(expert_score_group1, expert_idx_group1)
+    comp_val_idx22 = _pack_val_idx_fp32(expert_score_group2, expert_idx_group2)
+    comp_val_idx23 = _pack_val_idx_fp32(expert_score_group3, expert_idx_group3)
+    # TOPK_SWAP(0, 2); TOPK_SWAP(1, 3); TOPK_SWAP(0, 1); TOPK_SWAP(2, 3); TOPK_SWAP(1, 2);
+    comp_val_idx20, comp_val_idx22 = max(comp_val_idx20, comp_val_idx22), min(
+        comp_val_idx20, comp_val_idx22
+    )
+    comp_val_idx21, comp_val_idx23 = max(comp_val_idx21, comp_val_idx23), min(
+        comp_val_idx21, comp_val_idx23
+    )
+    comp_val_idx20, comp_val_idx21 = max(comp_val_idx20, comp_val_idx21), min(
+        comp_val_idx20, comp_val_idx21
+    )
+    comp_val_idx22, comp_val_idx23 = max(comp_val_idx22, comp_val_idx23), min(
+        comp_val_idx22, comp_val_idx23
+    )
+    comp_val_idx21, comp_val_idx22 = max(comp_val_idx21, comp_val_idx22), min(
+        comp_val_idx21, comp_val_idx22
+    )
+
+    min_val2 = tl.full((WARP_SIZE,), neg_inf, dtype=tl.float32)
+    top_experts = tl.full((WARP_SIZE,), MAX_IDX, dtype=tl.uint32)
+    packed_max20 = tl.full((), 0, dtype=tl.uint64)
+    for kk in tl.static_range(0, topk):
+        update = (kk > 0) & (comp_val_idx20 == packed_max20)
+        comp_val_idx20 = tl.where(
+            update,
+            comp_val_idx21,
+            comp_val_idx20,
+        )
+        comp_val_idx21 = tl.where(
+            update,
+            comp_val_idx22,
+            comp_val_idx21,
+        )
+        comp_val_idx22 = tl.where(
+            update,
+            comp_val_idx23,
+            comp_val_idx22,
+        )
+        comp_val_idx23 = tl.where(
+            update,
+            _pack_val_idx_fp32(min_val2, expert_idx_group3),
+            comp_val_idx23,
+        )
+        packed_max20 = tl.max(comp_val_idx20)
+        _3, out_idx = _unpack_val_idx_fp32(packed_max20)
+        top_experts = tl.where(lane == kk, out_idx, top_experts)
+
+    # step5: renormalize and output
+    lane_unbiased = tl.load(
+        s_score_sigmoid_ptr + top_experts, mask=lane < topk, other=0.0
+    )
+    topk_sum = 1e-20
+    if renormalize:
+        topk_sum += tl.sum(lane_unbiased)
+    scale = routed_scaling_factor.to(tl.float32)
+    if renormalize:
+        scale /= topk_sum
+    tl.store(topk_values_ptr + lane, lane_unbiased * scale, mask=lane < topk)
+    tl.store(topk_indices_ptr + lane, top_experts, mask=lane < topk)
+
+
 def grouped_topk(
     scores: torch.Tensor,
     n_group: int,
@@ -265,8 +521,6 @@ def grouped_topk(
     if scoring_func not in (0, 1):
         raise ValueError("scoring_func must be 0 (none) or 1 (sigmoid)")
 
-    if bias.dtype != scores.dtype:
-        bias = bias.to(scores.dtype)
     if bias.ndim != 1:
         bias = bias.flatten()
     if len(bias) != num_experts:
@@ -284,6 +538,64 @@ def grouped_topk(
         INPUT_DTYPE = tl.bfloat16
     else:
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
+
+    if (
+        (n_group > 1)
+        & (n_group <= 32)
+        & (num_experts <= 256)
+        & (num_experts_per_group <= 32)
+        & (num_experts_per_group * topk_group <= 128)
+        & (topk <= 8)
+        & (topk_group <= 4)
+    ):
+        # DeepSeek-v3.2
+        topk_values = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.float32,
+        )
+        topk_indices = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.int32,
+        )
+        if not HAS_TLE:
+            g_scores_sigmoid = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+            g_scores_bias = torch.empty(
+                (num_tokens, num_experts),
+                device=scores.device,
+                dtype=torch.float32,
+            )
+        else:
+            g_scores_sigmoid = None
+            g_scores_bias = None
+
+        triton_grouped_topk_fused_small_expert_count_kernel[(num_tokens,)](
+            scores,
+            topk_values,
+            topk_indices,
+            bias,
+            num_tokens,
+            n_group,
+            topk_group,
+            topk,
+            num_experts,
+            num_experts_per_group,
+            renormalize,
+            routed_scaling_factor,
+            scores.stride(0),
+            g_scores_sigmoid,
+            g_scores_bias,
+            SCORING_FUNC=scoring_func,
+            HAS_TLE=HAS_TLE,
+            num_warps=1,
+        )
+
+        return topk_values, topk_indices
 
     if scoring_func == 1:
         scores_processed = torch.sigmoid(scores.float()).to(scores.dtype)

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -29,6 +29,7 @@ device = flag_gems.device
 
 if cfg.QUICK_MODE:
     N_TOKEN_LIST = [8]
+    N_TOKEN_LIST_DEEPSEEK_V3_2 = [16384]
     N_EXPERT_LIST = [16]
     N_GROUP_LIST = [4]
     TOPK_LIST = [2]
@@ -37,6 +38,7 @@ if cfg.QUICK_MODE:
     DTYPE_LIST = [torch.float32]
 else:
     N_TOKEN_LIST = [1, 3, 8]
+    N_TOKEN_LIST_DEEPSEEK_V3_2 = [1, 8, 32, 64, 128, 256, 496, 512, 16384]
     N_EXPERT_LIST = [16]
     N_EXPERT_LIST = [8, 16]
     N_GROUP_LIST = [2, 4]
@@ -45,13 +47,76 @@ else:
     SCORING_FUNC_LIST = [0, 1]
     DTYPE_LIST = [torch.bfloat16, torch.float32]
 
+
+vendor_name = flag_gems.vendor_name
+
 try:
-    from vllm._custom_ops import grouped_topk as vllm_grouped_topk
+    if vendor_name == "metax":
+        from vllm_metax._custom_ops import grouped_topk as vllm_grouped_topk
+    else:
+        from vllm._custom_ops import grouped_topk as vllm_grouped_topk
 
     HAS_VLLM = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_VLLM = False
     vllm_grouped_topk = None
+
+
+@torch.compile(
+    dynamic=True,
+    backend="inductor",
+    options={"graph_partition": False},
+)
+def torch_grouped_topk(
+    scores: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+):
+    """Adapted from vLLM: vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py"""
+    scores = scores.float()
+    if scoring_func == 1:
+        scores = scores.sigmoid()
+
+    num_token = scores.size(0)
+    original_scores = scores
+    scores = scores + bias.unsqueeze(0)
+    group_scores = (
+        scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+    )
+
+    use_sorted = True
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
+        1
+    ]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_token, num_expert_group, scores.size(-1) // num_expert_group)
+        .reshape(num_token, -1)
+    )  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
+
+    if bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(
+            tmp_scores, k=topk, dim=-1, sorted=use_sorted
+        )
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
 def get_tolerance(dtype, scoring_func, renormalize):
@@ -71,7 +136,66 @@ def get_tolerance(dtype, scoring_func, renormalize):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("n_token", N_TOKEN_LIST_DEEPSEEK_V3_2)
+@pytest.mark.parametrize("renormalize", RENORMALIZE_LIST)
+@pytest.mark.parametrize("scoring_func", SCORING_FUNC_LIST)
+def test_grouped_topk_deepseek_v3_2(
+    n_token,
+    renormalize,
+    scoring_func,
+):
+    """Test grouped_topk accuracy with configs from DeepSeek-v3.2"""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
+
+    n_expert = 256
+    n_group = 8
+    topk = 8
+    topk_group = 4
+    routed_scaling_factor = 1.0
+    scores_dtype = torch.bfloat16
+    bias_dtype = torch.float32
+
+    scores = torch.randn(
+        (n_token, n_expert), dtype=scores_dtype, device=flag_gems.device
+    )
+    bias = torch.randn((n_expert,), dtype=bias_dtype, device=flag_gems.device)
+
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
+        scores.clone(),
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func,
+    )
+    ref_topk_weights = utils.to_reference(ref_topk_weights)
+    ref_topk_ids = utils.to_reference(ref_topk_ids)
+
+    with flag_gems.use_gems():
+        res_topk_weights, res_topk_ids = flag_gems.grouped_topk(
+            scores.clone(),
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )
+
+    utils.gems_assert_equal(res_topk_ids, ref_topk_ids)
+
+    atol, rtol = get_tolerance(ref_topk_weights.dtype, scoring_func, renormalize)
+    res_topk_weights = utils.to_reference(res_topk_weights)
+    torch.testing.assert_close(res_topk_weights, ref_topk_weights, atol=atol, rtol=rtol)
+
+
+@pytest.mark.grouped_topk
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.parametrize("n_token", N_TOKEN_LIST)
 @pytest.mark.parametrize("n_expert", N_EXPERT_LIST)
 @pytest.mark.parametrize("n_group", N_GROUP_LIST)
@@ -95,6 +219,7 @@ def test_grouped_topk(
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     topk_group = topk
     routed_scaling_factor = 1.0
@@ -102,7 +227,7 @@ def test_grouped_topk(
     scores = torch.randn((n_token, n_expert), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((n_expert,), dtype=dtype, device=flag_gems.device)
 
-    ref_topk_weights, ref_topk_ids = vllm_grouped_topk(
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
         scores.clone(),
         n_group,
         topk_group,
@@ -136,7 +261,6 @@ def test_grouped_topk(
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("n_token", [32, 64])
 @pytest.mark.parametrize("n_expert", [64])
 @pytest.mark.parametrize("n_group", [8])
@@ -158,13 +282,14 @@ def test_grouped_topk_large_scale(
     """Test grouped_topk with larger scale configurations"""
     torch.manual_seed(0)
     torch.cuda.manual_seed(0)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     routed_scaling_factor = 1.0
 
     scores = torch.randn((n_token, n_expert), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((n_expert,), dtype=dtype, device=flag_gems.device)
 
-    ref_topk_weights, ref_topk_ids = vllm_grouped_topk(
+    ref_topk_weights, ref_topk_ids = ref_grouped_topk(
         scores.clone(),
         n_group,
         topk_group,
@@ -198,7 +323,6 @@ def test_grouped_topk_large_scale(
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
@@ -206,12 +330,13 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((16,), dtype=dtype, device=flag_gems.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, routed_scaling_factor, bias, 0
     )
     ref_weights = utils.to_reference(ref_weights)
@@ -231,7 +356,6 @@ def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("renormalize", [True, False])
 @pytest.mark.parametrize("scoring_func", [0, 1])
 def test_grouped_topk_single_token(renormalize, scoring_func):
@@ -239,12 +363,13 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((1, 16), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((16,), dtype=dtype, device=flag_gems.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, 1.0, bias, scoring_func
     )
     ref_weights = utils.to_reference(ref_weights)
@@ -264,18 +389,18 @@ def test_grouped_topk_single_token(renormalize, scoring_func):
 
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_sigmoid(renormalize):
     """Test grouped_topk with sigmoid scoring function"""
     torch.manual_seed(45)
     torch.cuda.manual_seed(45)
+    ref_grouped_topk = vllm_grouped_topk if HAS_VLLM else torch_grouped_topk
 
     dtype = torch.float32
     scores = torch.randn((8, 16), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((16,), dtype=dtype, device=flag_gems.device)
 
-    ref_weights, ref_ids = vllm_grouped_topk(
+    ref_weights, ref_ids = ref_grouped_topk(
         scores.clone(), 4, 2, 2, renormalize, 1.0, bias, 1
     )
     ref_weights = utils.to_reference(ref_weights)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. port kernel "grouped_topk_fused_small_expert_count_kernel" from vLLM
2. replace benchmark test shapes with top-hit shapes from DeepSeek-v3.2
3. add correctness test for top-hit shapes from DeepSeek-v3.2
4. port torch implementation from vLLM as vllm-uninstalled fallback in correctness test
5. enable tests for the metax backend

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
GPU: NVIDIA H800、MetaX C550

vLLM version: 
| NVIDIA H800 | MetaX C550 |
| --- | --- | 
| 0.23.0 |  0.21.0(same for vllm and vllm-metax) | 

test command: `pytest benchmark/test_grouped_topk.py -s --mode=cudagraph`

common config from DeepSeek-v3.2: 
| num_experts | n_group | topk_group | topk | scores_dtype | bias_dtype |
| --- | --- | --- | --- | --- | --- | 
| 256 | 8 | 4 | 8 | bfloat16 | float32 |

NVIDIA H800 speedup result(min: 1.002, max: 1.940, avg: 1.324):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 1.002 | 1.313 | 1.306 |
| 8 | 1.078 | 1.331 | 1.325 |
| 32 | 1.082 | 1.325 | 1.322 |
| 64 | 1.081 | 1.318 | 1.310 |
| 128 | 1.079 | 1.321 | 1.316 |
| 256 | 1.094 | 1.332 | 1.332 |
| 496 | 1.139 | 1.368 | 1.387 |
| 512 | 1.145 | 1.367 | 1.384 |
| 16384 | 1.865 | 1.940 | 1.889 |

MetaX C550 speedup result(min: 1.440, max: 5.076, avg: 2.078):
| num_tokens | renormalize=False, scoring_func=0 |  renormalize=True, scoring_func=0 | renormalize=True, scoring_func=1 |
| --- | --- | --- | --- |
| 1 | 1.502 | 1.510 | 1.440 |
| 8 | 1.496 | 1.495 | 1.456 |
| 32 | 1.505 | 1.615 | 1.444 |
| 64 | 1.506 | 1.497 | 1.450 |
| 128 | 1.595 | 1.607 | 1.606 |
| 256 | 1.807 | 1.869 | 1.829 |
| 496 | 2.160 | 2.254 | 2.217 |
| 512 | 2.166 | 2.275 | 2.206 |
| 16384 | 4.564 | 4.956 | 5.076 |


