### PR TITLE
[KernelGen][Nvidia] Add addbmm_ operator with Triton kernel

### DIFF
--- a/benchmark/test_addbmm_.py
+++ b/benchmark/test_addbmm_.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+def _input_fn(b, m, n, k, dtype, device, b_column_major):
+    inp1 = torch.randn([b, m, k], dtype=dtype, device=device, requires_grad=True)
+
+    if b_column_major:
+        inp2 = torch.randn([b, n, k], dtype=dtype, device=device, requires_grad=True)
+        inp2 = inp2.transpose(1, 2).contiguous()
+    else:
+        inp2 = torch.randn([b, k, n], dtype=dtype, device=device, requires_grad=True)
+
+    # addbmm_ is inplace, bias must not require grad (leaf tensor constraint)
+    bias = torch.randn([m, n], dtype=dtype, device=device, requires_grad=False)
+
+    yield bias, inp1, inp2
+
+
+@pytest.mark.addbmm_
+def test_addbmm_():
+    bench = base.BlasBenchmark(
+        op_name="addbmm_",
+        input_fn=_input_fn,
+        torch_op=lambda bias, inp1, inp2: bias.addbmm_(inp1, inp2),
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -211,6 +211,20 @@ ops:
       - LinearAlg
     stages:
       - alpha: '5.4'
+  - id: addbmm_
+    description: |
+      Inplace variant of addbmm. Performs a batch matrix-matrix product of matrices in
+      `batch1` and `batch2`, with a reduced add step, and stores the result in `self`.
+      Formula: self = beta * self + alpha * (sum_i batch1_i @ batch2_i).
+    for:
+      - addbmm_
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - LinearAlg
+    stages:
+      - alpha: '5.4'
   - id: addcdiv
     description: |
       Performs the element-wise division of `tensor1` by `tensor2`, multiplies the result

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -197,6 +197,7 @@ _FULL_CONFIG = (
     ("add_.Tensor", add_),
     ("add_rms_norm", add_rms_norm),
     ("addbmm", addbmm),
+    ("addbmm_", addbmm_),
     ("addcdiv", addcdiv),
     ("addcdiv.out", addcdiv_out),
     ("addcdiv_", addcdiv_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -98,7 +98,7 @@ from flag_gems.ops.acosh import acosh, acosh_
 from flag_gems.ops.adaptive_avg_pool2d import adaptive_avg_pool2d
 from flag_gems.ops.adaptive_max_pool3d_backward import adaptive_max_pool3d_backward
 from flag_gems.ops.add import add, add_
-from flag_gems.ops.addbmm import addbmm
+from flag_gems.ops.addbmm import addbmm, addbmm_
 from flag_gems.ops.addcdiv import addcdiv, addcdiv_, addcdiv_out
 from flag_gems.ops.addcmul import addcmul, addcmul_, addcmul_out
 from flag_gems.ops.addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
@@ -821,6 +821,7 @@ __all__ = [
     "add",
     "add_",
     "addbmm",
+    "addbmm_",
     "addcdiv",
     "addcdiv_",
     "addcdiv_out",

--- a/src/flag_gems/ops/addbmm.py
+++ b/src/flag_gems/ops/addbmm.py
@@ -153,3 +153,53 @@ def addbmm(bias, batch1, batch2, beta=1.0, alpha=1.0):
         )
 
     return out
+
+
+def addbmm_(bias, batch1, batch2, beta=1.0, alpha=1.0):
+    logger.debug("GEMS ADDBMM_")
+
+    assert batch1.ndim == 3 and batch2.ndim == 3, "batch1 and batch2 must be 3D"
+    assert bias.ndim == 2, "bias must be 2D"
+
+    B, M, K = batch1.shape
+    _, K2, N = batch2.shape
+    assert K == K2, "Inner dimensions must match"
+    assert (
+        bias.shape[0] == M and bias.shape[1] == N
+    ), f"bias shape mismatch: expected ({M}, {N}), got {bias.shape}"
+
+    batch1 = batch1.contiguous()
+    batch2 = batch2.contiguous()
+    bias_contig = bias.contiguous()
+
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]),
+        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
+
+    with torch_device_fn.device(bias.device):
+        addbmm_kernel[grid](
+            bias_contig,
+            batch1,
+            batch2,
+            bias,
+            alpha,
+            beta,
+            B,
+            M,
+            N,
+            K,
+            bias_contig.stride(0),
+            bias_contig.stride(1),
+            batch1.stride(0),
+            batch1.stride(1),
+            batch1.stride(2),
+            batch2.stride(0),
+            batch2.stride(1),
+            batch2.stride(2),
+            bias.stride(0),
+            bias.stride(1),
+            IS_FP64=bias.dtype == torch.float64,
+        )
+
+    return bias

--- a/tests/test_addbmm_.py
+++ b/tests/test_addbmm_.py
@@ -1,0 +1,49 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from .conftest import QUICK_MODE
+
+if QUICK_MODE:
+    # Reduced shapes for CI quick mode
+    MNK_SHAPES = [
+        (1, 1, 32),
+        (16, 16, 64),
+    ]
+else:
+    # Standard test shapes covering small, medium, large and non-aligned dimensions
+    MNK_SHAPES = [
+        (1, 1, 32),
+        (16, 16, 64),
+        (15, 160, 1024),
+        (128, 256, 512),
+        (256, 256, 256),
+        (495, 5333, 71),
+        (1024, 1024, 128),
+    ]
+
+
+@pytest.mark.addbmm_
+@pytest.mark.parametrize("M, N, K", MNK_SHAPES)
+@pytest.mark.parametrize("scalar", utils.SCALARS)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_accuracy_addbmm_(M, N, K, scalar, dtype):
+    batch = 4
+    mat1 = torch.randn((batch, M, K), dtype=dtype, device=flag_gems.device)
+    mat2 = torch.randn((batch, K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((M, N), dtype=dtype, device=flag_gems.device)
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_bias = utils.to_reference(bias, True)
+
+    alpha = beta = scalar
+
+    ref_out = torch.addbmm(ref_bias, ref_mat1, ref_mat2, alpha=alpha, beta=beta)
+    with flag_gems.use_gems():
+        res_out = bias.addbmm_(mat1, mat2, beta=beta, alpha=alpha)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=K)
+    # Verify inplace: result is the same object as input
+    assert res_out is bias


### PR DESCRIPTION
## Summary
Adds the inplace variant `addbmm_` which performs `self = beta * self + alpha * (sum_i batch1_i @ batch2_i)` using the same Triton kernel as `addbmm`.

## Testing
- Parametrized tests over `M, N, K` shapes, scalars, and `FLOAT_DTYPES`
- Validated against PyTorch reference (`torch.addbmm`) on device side
- Verifies inplace semantics (result is same object as input)

## Performance
Test command: `pytest benchmark/test_addbmm_.py --level core --mode cudagraph` (NVIDIA H20)

**torch.float16:**

| Shape | Torch (ms) | Gems (ms) | Speedup |
|---|---|---|---|
| [384, 384] B=2 | 0.006 | 0.006 | 1.011 |
| [4096, 4096] B=2 | 2.078 | 2.040 | 1.019 |
| [1024, 1024] B=16 | 0.353 | 0.299 | 1.180 |
| [2048, 2048] B=16 | 2.314 | 2.060 | 1.123 |
| [4096, 4096] B=16 | 16.472 | 16.698 | 0.986 |
| **Arithmetic Mean** | — | — | **1.064x** |

**torch.float32:**

| Shape | Torch (ms) | Gems (ms) | Speedup |
|---|---|---|---|
| [384, 384] B=2 | 0.021 | 0.025 | 0.835 |
| [4096, 4096] B=2 | 9.175 | 11.212 | 0.818 |
| [1024, 1024] B=16 | 1.495 | 1.639 | 0.912 |
| [2048, 2048] B=16 | 11.219 | 12.629 | 0.888 |
| [4096, 4096] B=16 | 73.325 | 89.180 | 0.822 |
| **Arithmetic Mean** | — | — | **0.855x** |

**torch.bfloat16:**

| Shape | Torch (ms) | Gems (ms) | Speedup |
|---|---|---|---|
| [384, 384] B=2 | 0.006 | 0.006 | 1.061 |
| [4096, 4096] B=2 | 2.062 | 2.004 | 1.029 |
| [1024, 1024] B=16 | 0.345 | 0.298 | 1.158 |
| [2048, 2048] B=16 | 2.296 | 2.059 | 1.115 |
| [4096, 4096] B=16 | 16.493 | 16.188 | 1.019 |
| **Arithmetic Mean** | — | — | **1.076x** |

**Overall: 15 cases, Arithmetic Mean Speedup = 0.998x**

## Multi-backend Testing

| Backend | Accuracy Test | Benchmark | Speedup (mean) | Notes |
|---|---|---|---|---|
| Nvidia (H20) | PASS | PASS (15 cases, --level core) | 0.998x | — |
| — | — | — | — | Not tested |

Tested-on: NVIDIA H20

## Files Changed
- `src/flag_gems/ops/addbmm.py`: Add inplace `addbmm_` wrapper (shares kernel with `addbmm`)
- `tests/test_addbmm_.py`: Accuracy test for inplace variant
- `benchmark/test_addbmm_.py`: Performance benchmark
- `src/flag_gems/ops/__init__.py`: Register import and `__all__`
- `src/flag_gems/__init__.py`: Register to `_FULL_CONFIG`
- `conf/operators.yaml`: Add operator entry (kind: LinearAlg, stage: alpha 5.4)