### PR TITLE
fused: int32 slot_mapping for enflame reshape_and_cache_flash (GCU300)

### DIFF
--- a/src/flag_gems/fused/reshape_and_cache_flash.py
+++ b/src/flag_gems/fused/reshape_and_cache_flash.py
@@ -19,10 +19,12 @@ import triton
 import triton.language as tl
 
 from flag_gems.config import use_c_extension
-from flag_gems.runtime import torch_device_fn
+from flag_gems.runtime import device, torch_device_fn
 from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
+
+vendor_name = device.vendor_name
 
 
 @libentry()
@@ -96,6 +98,12 @@ def reshape_and_cache_flash(
         )
     else:
         logger.debug("GEMS RESHAPE_AND_CACHE_FLASH")
+        # GCU300 rejects 64-bit IR; slot_mapping arrives as int64 and its
+        # index arithmetic would emit 64-bit ops. Downcast to int32 on enflame
+        # (mirrors the enflame concat_and_cache_mla override). Vendor+dtype
+        # guarded so no other backend is affected.
+        if vendor_name == "enflame" and slot_mapping.dtype == torch.int64:
+            slot_mapping = slot_mapping.to(torch.int32)
         num_tokens = slot_mapping.size(0)
         num_heads = key.size(1)
         head_size = key.size(2)


### PR DESCRIPTION
## What

On Enflame GCU300, `reshape_and_cache_flash` receives `slot_mapping` as int64.
The generic triton kernel derives all cache indices from it, so it emits 64-bit
IR — which the GCU300 `triton_gcu` compiler rejects (`64-bit data type not
supported on GCU300`, PassManager failure).

This downcasts `slot_mapping` to int32 before the kernel launch, guarded on
`vendor_name == "enflame"` **and** `dtype == torch.int64`. It mirrors the fix
the enflame `concat_and_cache_mla` gcu300 override already applies for the MLA
cache variant.

## Scope / safety

- Vendor- and dtype-guarded: only enflame + an int64 input takes the downcast;
  every other backend is untouched.
- The cache-slot index space (`num_blocks * block_size`, ~1e8 in realistic
  configs) is far below the int32 limit (~2.1e9), so the downcast is lossless.
- No change to the generic kernel body or any other vendor.

## Verification

Part of an end-to-end enflame GCU300 run (Qwen3-4B, vLLM 0.20.2 empty build +
vllm-plugin-FL): with this fix the KV-cache write path compiles and executes,
and inference returns coherent output. Independent of vLLM version.
