### PR TITLE
fix(utils): add pure-triton j0 and log2 fallbacks for non-CUDA backends

### DIFF
--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -183,12 +183,173 @@ def _fallback_sinpi(x):
     return tl.sin(3.141592653589793 * x)
 
 
+@triton.jit
+def _fallback_log2(x):
+    # log2(x) == ln(x) / ln(2); used when a backend's libdevice lacks a native
+    # log2 (e.g. the sunrise tang fork, which does provide the core tl.log).
+    # tl.log is a core Triton builtin (not vendor libdevice), so it lowers on
+    # every backend.  Paired with exp2 in ops/pairwise_distance.py to compute
+    # x**p, so it must be a true base-2 logarithm.
+    return tl.log(x) * 1.4426950408889634  # 1 / ln(2)
+
+
+@triton.jit
+def _fallback_j0(x):
+    # Bessel J0(x) for float32/float64, used when a backend's libdevice lacks a
+    # native j0 (e.g. the cambricon mlu fork).  Body adapted verbatim from the
+    # verified metax kernel (runtime/backend/_metax/ops/special_bessel_j0.py):
+    #   |x| <= 8  -> 20-term Taylor series  J0 = sum (-1)^k (x^2/4)^k / (k!)^2
+    #   |x| >  8  -> fdlibm pzero/qzero asymptotic form (public-domain SunPro
+    #                e_j0.c band-8 coefficients; same as glibc/CUDA libdevice).
+    # Uses only core Triton primitives (sin/cos/sqrt/abs/where), so it lowers on
+    # every backend.  Edge cases match PyTorch/fdlibm: J0(NaN)=NaN, J0(inf)=0,
+    # J0(0)=1.
+    ax = tl.abs(x)
+    is_nan = ax != ax
+    is_inf = ax == float("inf")
+    # Safe finite value for inf/nan lanes; overwritten by the edge-case results.
+    ax_safe = tl.where(is_nan | is_inf, 1.0, ax)
+
+    # ----- small region: |x| <= 8, 20-term Taylor series -----
+    # c_k = (-1)^k / (k!)^2 via the recurrence c_k = -c_{k-1} / k^2 (folded at
+    # compile time), Horner-evaluated in y = x^2/4.
+    x2 = ax_safe * ax_safe
+    y = x2 * 0.25
+    c1 = -1.0
+    c2 = -c1 / 4.0
+    c3 = -c2 / 9.0
+    c4 = -c3 / 16.0
+    c5 = -c4 / 25.0
+    c6 = -c5 / 36.0
+    c7 = -c6 / 49.0
+    c8 = -c7 / 64.0
+    c9 = -c8 / 81.0
+    c10 = -c9 / 100.0
+    c11 = -c10 / 121.0
+    c12 = -c11 / 144.0
+    c13 = -c12 / 169.0
+    c14 = -c13 / 196.0
+    c15 = -c14 / 225.0
+    c16 = -c15 / 256.0
+    c17 = -c16 / 289.0
+    c18 = -c17 / 324.0
+    c19 = -c18 / 361.0
+    t = c19
+    t = c18 + t * y
+    t = c17 + t * y
+    t = c16 + t * y
+    t = c15 + t * y
+    t = c14 + t * y
+    t = c13 + t * y
+    t = c12 + t * y
+    t = c11 + t * y
+    t = c10 + t * y
+    t = c9 + t * y
+    t = c8 + t * y
+    t = c7 + t * y
+    t = c6 + t * y
+    t = c5 + t * y
+    t = c4 + t * y
+    t = c3 + t * y
+    t = c2 + t * y
+    t = c1 + t * y
+    ans_small = 1.0 + t * y
+
+    # ----- large region: |x| > 8, fdlibm pzero/qzero asymptotic -----
+    ax_large = tl.where(ax > 8.0, ax_safe, 8.0)
+    s = tl.sin(ax_large)
+    c = tl.cos(ax_large)
+    ss = s - c
+    cc = s + c
+    sc = s * c
+    z2 = -tl.cos(2.0 * ax_large)
+    cc_new = z2 / ss
+    ss_new = z2 / cc
+    is_sc_neg = sc < 0.0
+    cc = tl.where(is_sc_neg, cc_new, cc)
+    ss = tl.where(is_sc_neg, ss, ss_new)
+
+    z = 1.0 / (ax_large * ax_large)
+    pR = (
+        -7.03124999999900357484e-02
+        + (
+            -8.08167041275349795626e00
+            + (
+                -2.57063105679704847262e02
+                + (-2.48521641009428822144e03 + (-5.25304380490729545272e03) * z) * z
+            )
+            * z
+        )
+        * z
+    ) * z
+    pS = (
+        1.0
+        + (
+            1.16534364619668181717e02
+            + (
+                3.83374475364121826715e03
+                + (
+                    4.05978572648472545552e04
+                    + (1.16752972564375915681e05 + 4.76277284146730962675e04 * z) * z
+                )
+                * z
+            )
+            * z
+        )
+        * z
+    )
+    u = 1.0 + pR / pS
+    qR = (
+        7.32421874999935051953e-02
+        + (
+            1.17682064682252693899e01
+            + (
+                5.57673380256401856059e02
+                + (8.85919720756468632317e03 + 3.70146267776887834771e04 * z) * z
+            )
+            * z
+        )
+        * z
+    ) * z
+    qS = (
+        1.0
+        + (
+            1.63776026895689824414e02
+            + (
+                8.09834494656449805916e03
+                + (
+                    1.42538291419120476348e05
+                    + (
+                        8.03309257119514397345e05
+                        + (8.40501579819060512818e05 - 3.43899293537866615225e05 * z)
+                        * z
+                    )
+                    * z
+                )
+                * z
+            )
+            * z
+        )
+        * z
+    )
+    v = (qR / qS - 0.125) / ax_large
+    ans_large = 5.64189583547756279280e-01 * (u * cc - v * ss) / tl.sqrt(ax_large)
+
+    # ----- combine + edge cases -----
+    ans = tl.where(ax > 8.0, ans_large, ans_small)
+    ans = tl.where(is_inf, 0.0, ans)
+    ans = tl.where(is_nan, float("nan"), ans)
+    return ans
+
+
 _FALLBACK_SYMBOLS = {
     "pow": _fallback_pow,
     "tanh": _fallback_tanh,
     "erfinv": _fallback_erfinv,
     "floor": _fallback_floor,
+    "j0": _fallback_j0,
     "j1": _fallback_j1,
+    "log2": _fallback_log2,
     "nextafter": _fallback_nextafter,
     "sinpi": _fallback_sinpi,
 }
@@ -221,6 +382,7 @@ tl_extra_shim = _patch_missing_symbols(
     (
         "acos",
         "atan",
+        "j0",
         "j1",
         "atan2",
         "div_rn",
@@ -243,6 +405,7 @@ tl_extra_shim = _patch_missing_symbols(
         "isnan",
         "lgamma",
         "log",
+        "log2",
         "nextafter",
         "pow",
         "rint",


### PR DESCRIPTION
## Summary

FlagGems 5.3.4 fails to import on the oldest vendor triton forks:

```
cambricon mlu 3.2.0:  module 'triton.language.extra.mlu.libdevice'  has no attribute 'j0'
sunrise   tang 3.6.0: module 'triton.language.extra.tang.libdevice' has no attribute 'log2'
```

Two new/existing ops reach for libdevice intrinsics through `tl_extra_shim`, but the symbols were never registered for the fallback machinery:

- `ops/special_bessel_j0.py:31` -> `tl_extra_shim.j0(...)` (added in 5.3.4)
- `ops/pairwise_distance.py:13`  -> `log2 = tl_extra_shim.log2`

`j0`/`log2` were absent from both the patched-names tuple and `_FALLBACK_SYMBOLS`, so on any fork whose libdevice lacks them the attribute lookup throws at `flag_gems` import time.

This is the same class as #5088 (`nextafter`/`sinpi`). Newer forks are unaffected — cambricon mlu 2.1.1 exports `j0`, which is exactly why `neuware-4.7.2` passes and `neuware-4.4.3` fails on the **same** wheel (clean natural experiment).

## Fix

Mirrors the #5088 pattern — pure-triton fallbacks preferred over borrowing a foreign libdevice symbol that may not lower:

- **`_fallback_log2`** = `ln(x) / ln(2)`. It's paired with `exp2` in `pairwise_distance` to compute `x**p`, so it must be a true base-2 log. `tl.log` is a core Triton builtin and lowers on every backend.
- **`_fallback_j0`** = fdlibm J0, with the body adapted **verbatim** from the already-verified metax kernel (`runtime/backend/_metax/ops/special_bessel_j0.py`): 20-term Taylor series for `|x| <= 8`, pzero/qzero asymptotic form (public-domain SunPro `e_j0.c` band-8 coefficients) for `|x| > 8`. Uses only core primitives (`sin`/`cos`/`sqrt`/`abs`/`where`). Edge cases match fdlibm/PyTorch: `J0(nan)=nan`, `J0(inf)=0`, `J0(0)=1`.
- Registered both in `_FALLBACK_SYMBOLS`; added `j0` and `log2` to the patched-names tuple.

## Testing

- **Math (local):** ported both bodies to pure Python and checked against textbook values and an independent high-term Taylor series. `log2` exact to ~1e-15; `j0` reproduces the metax kernel to float32 tolerance across the small/large branch boundary and edge cases.
- **Lowering (hardware):** to be validated on cambricon (neuware-4.4.3) and sunrise nodes via the FlagOS runtime v2 verify — will report back.
- `pre-commit` (flake8 / isort / black) passes.
