### PR TITLE
Split multi-version vendors into versioned backend keys

### DIFF
--- a/.github/backends.json
+++ b/.github/backends.json
@@ -14,7 +14,14 @@
     "enabled": true
   },
   {
-    "backend": "enflame",
+    "backend": "cambricon-neuware472",
+    "runner_label": "cambricon",
+    "label": "vendor/Cambricon",
+    "gpu_check": "tools/gpu_check_cambricon.sh",
+    "enabled": true
+  },
+  {
+    "backend": "enflame-tops1106",
     "runner_label": "enflame",
     "label": "vendor/Enflame",
     "gpu_check": "",
@@ -42,7 +49,7 @@
     "enabled": true
   },
   {
-    "backend": "metax",
+    "backend": "metax-maca3810",
     "runner_label": "metax",
     "label": "vendor/MetaX",
     "gpu_check": "tools/gpu_check_metax.sh",
@@ -86,7 +93,7 @@
   {
     "backend": "thead",
     "runner_label": "thead",
-    "label": "vendor/Thead",
+    "label": "vendor/THead",
     "gpu_check": "tools/gpu_check_thead.sh",
     "enabled": true
   },

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -108,6 +108,18 @@ jobs:
               VENDOR="mthreads"
               BACKEND="mthreads-musa520"
               ;;
+            metax)
+              VENDOR="metax"
+              BACKEND="metax-maca3810"
+              ;;
+            enflame)
+              VENDOR="enflame"
+              BACKEND="enflame-tops1106"
+              ;;
+            cambricon)
+              VENDOR="cambricon"
+              BACKEND="cambricon-neuware472"
+              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               BACKEND="${RUNNER_LABEL}"

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -85,6 +85,18 @@ jobs:
               VENDOR="ascend"
               BACKEND="ascend-cann900"
               ;;
+            metax)
+              VENDOR="metax"
+              BACKEND="metax-maca3810"
+              ;;
+            enflame)
+              VENDOR="enflame"
+              BACKEND="enflame-tops1106"
+              ;;
+            cambricon)
+              VENDOR="cambricon"
+              BACKEND="cambricon-neuware472"
+              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               BACKEND="${RUNNER_LABEL}"

--- a/docs/content/en/getting-started/install.md
+++ b/docs/content/en/getting-started/install.md
@@ -93,8 +93,8 @@ flaggems-setup nvidia-cuda128
 # Huawei Ascend CANN 9.0.0
 flaggems-setup ascend-cann900
 
-# MetaX MACA
-flaggems-setup metax
+# MetaX MACA 3.8.1
+flaggems-setup metax-maca3810
 ```
 
 Preview the exact commands without running them:
@@ -159,8 +159,8 @@ For example:
 # Huawei Ascend CANN 9.0.0
 ./setup.sh ascend-cann900
 
-# MetaX MACA
-./setup.sh metax
+# MetaX MACA 3.8.1
+./setup.sh metax-maca3810
 ```
 
 To see available backends:

--- a/docs/content/zh-cn/getting-started/install.md
+++ b/docs/content/zh-cn/getting-started/install.md
@@ -157,8 +157,8 @@ flaggems-setup nvidia-cuda128
 # Huawei Ascend CANN 9.0.0
 flaggems-setup ascend-cann900
 
-# MetaX MACA
-flaggems-setup metax
+# MetaX MACA 3.8.1
+flaggems-setup metax-maca3810
 ```
 
 <!--
@@ -266,8 +266,8 @@ For example:
 # Huawei Ascend CANN 9.0.0
 ./setup.sh ascend-cann900
 
-# MetaX MACA
-./setup.sh metax
+# MetaX MACA 3.8.1
+./setup.sh metax-maca3810
 ```
 
 <!--

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,20 +84,43 @@ ascend-cann900 = [
     "torch-npu==2.10.0",
 ]
 
-cambricon = [
+cambricon-neuware443 = [
     "cambricon_dali==0.13.0",
     "torch==2.7.1+cpu",
     "torch-mlu==1.29.2+torch2.7.1",
     "torch-mlu-ops==1.8.0+torch2.7.1",
+    "numpy==2.2.6",
 ]
 
-enflame = [
+cambricon-neuware472 = [
+    "numpy==2.2.6",
+    "pandas==3.0.5",
+    "torch==2.11.0+cpu",
+    "torch-mlu==1.33.1+torch2.11.0",
+    "torch-mlu-ops==1.12.1+torch2.11.0",
+]
+
+enflame-tops1910 = [
     "pyefml==1.9.10",
     "torch==2.10.0+cpu",
     "torchaudio==2.10.0+cpu",
     "torchvision==0.25.0+cpu",
     "torch-gcu==2.10.0+3.7.20260408",
-    "flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323",
+    "flash-attn==2.7.2+torch.2.10.0.gcu.3.4.20260506",
+]
+
+enflame-tops1106 = [
+    "enflame-modelopt==3.6.20260615+torch.2.11.0",
+    "numpy==2.3.5",
+    "pyefml==1.10.6",
+    "torch==2.11.0+cpu",
+    "torchaudio==2.11.0+cpu",
+    "torchvision==0.26.0+cpu",
+    "torch-gcu==2.11.0+3.8.20260713",
+    "torchcodec==3.8.20260624+torch.2.11.0",
+    "flash-attn==2.7.2+torch.2.11.0.gcu.3.8.20260706",
+    "tops-extension==3.6.20260529+torch.2.11.0",
+    "topstx==1.10.6",
 ]
 
 hygon = [
@@ -129,11 +152,25 @@ kunlunxin = [
     "xmlir==1.0.0.1",
 ]
 
-metax = [
+metax-maca3720 = [
     "torch==2.8.0+metax3.7.2.0",
     "torchaudio==2.4.1+metax3.7.2.0",
     "torchvision==0.15.1+metax3.7.2.0",
     "flash_attn==2.6.3+metax3.7.2.0torch2.8",
+    "numpy==2.3.5",
+]
+
+metax-maca3810 = [
+    "apex==0.1+metax3.8.1.0",
+    "flash_attn==2.6.3+metax3.8.1.0torch2.10",
+    "flashinfer==0.2.6+metax3.8.1.0torch2.10",
+    "flash_linear_attention==0.5.0+metax3.8.1.0torch2.10",
+    "flash_mla==1.0.1+metax3.8.1.0torch2.10",
+    "numpy==2.3.5",
+    "torch==2.10.0+metax3.8.1.0",
+    "torchcodec==0.6.0+metax3.8.1.0",
+    "torchaudio==2.4.1+metax3.8.1.0",
+    "torchvision==0.25.0+metax3.8.1.0"
 ]
 
 mthreads-musa436 = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -88,19 +88,20 @@ backends:
     python: "3.11"
     cmake_backend: NPU
     triton: triton==3.5.0
+    triton_post_install:
+      - triton_ascend==3.2.1
     flagtree: flagtree==0.6.0+ascend3.5
     env_source:
       - /usr/local/Ascend/cann/set_env.sh
-    triton_post_install:
-      - triton_ascend==3.2.1
     deps:
       - torch==2.10.0+cpu
       - torch-npu==2.10.0
 
-  cambricon:
+  cambricon-neuware443:
     python: "3.10"
     triton: triton==3.2.0+mlu1.7.2
     env:
+      NEUWARE_HOME: /usr/local/neuware
       PATH: /usr/local/neuware/bin:$PATH
       LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
     deps:
@@ -108,21 +109,67 @@ backends:
       - torch==2.7.1+cpu
       - torch-mlu==1.29.2+torch2.7.1
       - torch-mlu-ops==1.8.0+torch2.7.1
+      - numpy==2.2.6
 
-  enflame:
+  cambricon-neuware472:
+    python: "3.12"
+    triton: triton==3.4.0+mlu2.1.1
+    env:
+      NEUWARE_HOME: /usr/local/neuware
+      PATH: /usr/local/neuware/bin:$PATH
+      LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
+    deps:
+      - "numpy==2.2.6"
+      - "pandas==3.0.5"
+      - "torch==2.11.0+cpu"
+      - "torch-mlu==1.33.1+torch2.11.0"
+      - "torch-mlu-ops==1.12.1+torch2.11.0"
+
+  enflame-tops1910:
     python: "3.12"
     cmake_backend: GCU
-    triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+    triton: triton==3.6.0
     flagtree: flagtree==0.6.0+enflame3.6
+    triton_post_install:
+      - triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
     env:
       LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
+      TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
+      ENABLE_I64_CHECK: "0"
     deps:
       - pyefml==1.9.10
       - torch==2.10.0+cpu
       - torchaudio==2.10.0+cpu
       - torchvision==0.25.0+cpu
       - torch-gcu==2.10.0+3.7.20260408
-      - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
+      - flash-attn==2.7.2+torch.2.10.0.gcu.3.4.20260506
+
+  enflame-tops1106:
+    python: "3.12"
+    cmake_backend: GCU
+    triton: triton==3.6.0
+    flagtree: flagtree==0.6.0+enflame3.6
+    triton_post_install:
+      - triton-gcu==3.6.0+1.0.20260722
+    # This version of flagtree doesn't work yet
+    # flagtree: flagtree==0.6.0+enflame.git657f543d
+    env:
+      LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
+      TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
+      ENABLE_I64_CHECK: "0"
+      TORCHGCU_INDUCTOR_ENABLE: "1"
+    deps:
+      - enflame-modelopt==3.6.20260615+torch.2.11.0
+      - numpy==2.3.5
+      - pyefml==1.10.6
+      - torch==2.11.0+cpu
+      - torchaudio==2.11.0+cpu
+      - torchvision==0.26.0+cpu
+      - torch-gcu==2.11.0+3.8.20260713
+      - torchcodec==3.8.20260624+torch.2.11.0
+      - flash-attn==2.7.2+torch.2.11.0.gcu.3.8.20260706
+      - tops-extension==3.6.20260529+torch.2.11.0
+      - topstx==1.10.6
 
   hygon:
     python: "3.10"
@@ -173,18 +220,40 @@ backends:
       - xformers==0.0.29+1e7a8ec.d20260114
       - xmlir==1.0.0.1
 
-  metax:
+  metax-maca3720:
     python: "3.12"
     triton: triton==3.0.0+metax3.7.2.0
     flagtree: flagtree==3.1.0+metax3.7.2.0
     env:
       MACA_PATH: /opt/maca
-      LD_LIBRARY_PATH: $MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+      PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}
+      LD_LIBRARY_PATH: /opt/maca/lib:/opt/maca/mxgpu_llvm/lib:$LD_LIBRARY_PATH
     deps:
       - torch==2.8.0+metax3.7.2.0
       - torchaudio==2.4.1+metax3.7.2.0
       - torchvision==0.15.1+metax3.7.2.0
       - flash_attn==2.6.3+metax3.7.2.0torch2.8
+      - numpy==2.3.5
+
+  metax-maca3810:
+    python: "3.12"
+    triton: triton==3.6.0+metax3.8.1.0
+    flagtree: flagtree==0.6.1a2+metax3.6
+    env:
+      MACA_PATH: /opt/maca
+      PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}
+      LD_LIBRARY_PATH: /opt/maca/lib:/opt/maca/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+    deps:
+      - apex==0.1+metax3.8.1.0
+      - flash_attn==2.6.3+metax3.8.1.0torch2.10
+      - flashinfer==0.2.6+metax3.8.1.0torch2.10
+      - flash_linear_attention==0.5.0+metax3.8.1.0torch2.10
+      - flash_mla==1.0.1+metax3.8.1.0torch2.10
+      - numpy==2.3.5
+      - torch==2.10.0+metax3.8.1.0
+      - torchcodec==0.6.0+metax3.8.1.0
+      - torchaudio==2.4.1+metax3.8.1.0
+      - torchvision==0.25.0+metax3.8.1.0
 
   mthreads-musa436:
     python: "3.10"


### PR DESCRIPTION
## Summary

`cambricon`, `enflame`, and `metax` each shipped **multiple hardware/SDK versions under a single backend key**, so their differing torch / triton / flagtree stacks could not be addressed independently. This splits each into version-specific keys and propagates the rename through **every consumer of a backend key**, so nothing silently breaks.

```
cambricon -> cambricon-neuware443, cambricon-neuware472
enflame   -> enflame-tops1910,     enflame-tops1106
metax     -> metax-maca3720,       metax-maca3810
```

(PEP 508 extra names can't contain dots, hence the undotted version suffixes.)

## Changes

**Registry (kept in lockstep):**
- `src/flag_gems/backends.yaml` + `pyproject.toml` — split the extras + backend entries. Also fixed a **stray duplicate `flagtree` key** on `enflame-tops1910` (it was an *ascend* package that YAML silently let win), aligned its `flash-attn` build to the deployed image, and added the missing `numpy` pins to `cambricon-neuware443` / `metax-maca3720`.

**CI consumers of a backend key (each calls `setup.sh <backend>`, which hard-fails on an unknown key):**
- `.github/backends.json` — `enflame` → `enflame-tops1106`, `metax` → `metax-maca3810`, **added a `cambricon-neuware472` entry** (`unittest.yaml` builds its PR-triggered matrix from this file). Also corrected the thead label `vendor/Thead` → `vendor/THead` so it matches `labeler.yml` (pre-existing mismatch — the `thead` entry was never selectable by the label filter).
- `.github/workflows/command.yaml`, `.github/workflows/random-test.yaml` — added explicit `metax` / `enflame` / `cambricon` runner-label cases so they resolve to versioned keys instead of falling through to the bare (now-nonexistent) label.

**Docs:**
- `docs/content/{en,zh-cn}/getting-started/install.md` — `metax` → `metax-maca3810`.

## Verification

- All modified JSON / YAML / TOML parse; `pre-commit` passes.
- Cross-checked: every `backend` in `backends.json` and every literal `BACKEND=` in the two workflows resolves to a real `backends.yaml` key.
- Confirmed the weekly path (`C550.yml` / `MLU590-M9DE.yml`) uses prebuilt container images and never calls `setup.sh`, so it needs no change.
- Remaining bare `metax`/`enflame`/`cambricon` tokens are legitimate vendor-family uses (runner labels, `VENDOR=`, GPU env-var maps, `FLAGTREE_BACKEND`), not backend keys.
