### PR TITLE
fix(cambricon): tolerate triton forks lacking TRITON_MAX_TENSOR_NUMEL

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/softmax.py
@@ -19,7 +19,14 @@ import math
 import torch
 import triton
 import triton.language as tl
-from triton._utils import TRITON_MAX_TENSOR_NUMEL
+
+try:
+    from triton._utils import TRITON_MAX_TENSOR_NUMEL
+except ImportError:
+    # Older vendor triton forks (e.g. cambricon mlu 3.2.0) don't export this
+    # constant from triton._utils. Fall back to the upstream literal value
+    # (2**20), matching how _tsingmicro/ops/rms_norm.py defines it locally.
+    TRITON_MAX_TENSOR_NUMEL = 1048576
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn


### PR DESCRIPTION
## Summary

`import flag_gems` fails on **cambricon neuware-4.4.3** (mlu triton 3.2.0 fork):

```
_cambricon/ops/softmax.py:22:
    from triton._utils import TRITON_MAX_TENSOR_NUMEL
ImportError: cannot import name 'TRITON_MAX_TENSOR_NUMEL' from 'triton._utils'
```

`TRITON_MAX_TENSOR_NUMEL` is a newer triton-core symbol that the older mlu 3.2.0 fork doesn't export. The import is at module top-level in the cambricon backend ops package, so the whole `flag_gems` package fails to import.

This sat **behind** the `j0` libdevice failure — import aborts at the first missing symbol, so it only became visible once the `j0` fallback landed. Verified on hardware: with the `j0` fix alone, `import flag_gems` still aborts here; with this change it succeeds.

## Fix

Fall back to the upstream literal value (`2**20 = 1048576`) when the import fails, matching how `_tsingmicro/ops/rms_norm.py` already defines the same constant locally. The value is only used in a `numel <= TRITON_MAX_TENSOR_NUMEL` comparison, so the literal is equivalent on forks that lack the export.

```python
try:
    from triton._utils import TRITON_MAX_TENSOR_NUMEL
except ImportError:
    TRITON_MAX_TENSOR_NUMEL = 1048576
```

## Testing

On a cambricon neuware-4.4.3 node, inside the runtime image, with this patch + the merged `j0`/`log2` fallbacks applied:

```
torch OK 2.7.1+cpu
triton OK 3.2.0
flag_gems OK 5.3.4
use_gems+add OK shape=[2, 3]
```

All 4 checks pass. `pre-commit` (flake8 / isort / black) passes.
