### PR TITLE
fix svd orthonormal precision

### DIFF
--- a/src/flag_gems/ops/svd.py
+++ b/src/flag_gems/ops/svd.py
@@ -1574,6 +1574,57 @@ def _small_jacobi_svd(input):
             SWEEPS=sweeps,
             num_warps=1 if block_r <= 64 else 4,
         )
+    if k <= 17 and rows <= 64:
+        with torch_device_fn.device(input.device):
+            if m >= n:
+                _thin_reorthogonalize_kernel[(batch,)](
+                    v,
+                    ROWS=n,
+                    K=k,
+                    BLOCK_R=triton.next_power_of_2(n),
+                    num_warps=1,
+                )
+            else:
+                _thin_reorthogonalize_kernel[(batch,)](
+                    u,
+                    ROWS=m,
+                    K=k,
+                    BLOCK_R=triton.next_power_of_2(m),
+                    num_warps=1,
+                )
+        if m >= n:
+            u = _triton_bmm(a, v, (batch, m, k))
+            projected = u
+            projected_rows = m
+        else:
+            a_t = a.transpose(1, 2).contiguous()
+            v = _triton_bmm(a_t, u, (batch, n, k))
+            projected = v
+            projected_rows = n
+        with torch_device_fn.device(input.device):
+            _normalize_projection_kernel[(batch, k)](
+                projected,
+                s,
+                ROWS=projected_rows,
+                K=k,
+                BLOCK_R=triton.next_power_of_2(projected_rows),
+                num_warps=1,
+            )
+            _complete_zero_projection_kernel[(batch, k)](
+                projected,
+                s,
+                ROWS=projected_rows,
+                K=k,
+                BLOCK_R=triton.next_power_of_2(projected_rows),
+                num_warps=1,
+            )
+            _thin_reorthogonalize_kernel[(batch,)](
+                projected,
+                ROWS=projected_rows,
+                K=k,
+                BLOCK_R=triton.next_power_of_2(projected_rows),
+                num_warps=1,
+            )
     return (
         u.reshape(*input.shape[:-2], m, k),
         s.reshape(*input.shape[:-2], k),
@@ -2385,14 +2436,13 @@ def _cyclic_jacobi_svd(input):
                 BLOCK_R=triton.next_power_of_2(projected_rows),
                 num_warps=1,
             )
-            if batch > 1 and k <= 16:
-                _thin_reorthogonalize_kernel[(batch,)](
-                    projected,
-                    ROWS=projected_rows,
-                    K=k,
-                    BLOCK_R=triton.next_power_of_2(projected_rows),
-                    num_warps=1,
-                )
+            _thin_reorthogonalize_kernel[(batch,)](
+                projected,
+                ROWS=projected_rows,
+                K=k,
+                BLOCK_R=triton.next_power_of_2(projected_rows),
+                num_warps=1,
+            )
     return (
         u.reshape(*input.shape[:-2], m, k),
         s.reshape(*input.shape[:-2], k),


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Add post-processing steps to `_small_jacobi_svd` and `_cyclic_jacobi_svd` to improve U/V orthonormality.

Changes:
1. `_small_jacobi_svd`: add a post-processing pipeline after Jacobi iteration — `_thin_reorthogonalize_kernel` on the orthonormal side, bmm projection to obtain the opposite-side matrix, then `_normalize_projection_kernel`, `_complete_zero_projection_kernel`, and a final `_thin_reorthogonalize_kernel` on the projected matrix. The logic is identical to the post-processing in `_cyclic_jacobi_svd`.
2. `_cyclic_jacobi_svd`: remove the `if batch > 1 and k <= 16` guard on the final `_thin_reorthogonalize_kernel` call, so it also runs for batch=1 with ill-conditioned matrices (e.g. k=17).

### Issue
- #5069

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
No performance regression. 
All 47 tests in `tests/test_svd.py` pass.
