### PR TITLE
perf(metax): add optimized varlen FlashAttention backend

### DIFF
--- a/benchmark/test_flash_attn_varlen_func_metax.py
+++ b/benchmark/test_flash_attn_varlen_func_metax.py
@@ -1,0 +1,380 @@
+from typing import Any, List, Optional
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, utils
+
+vendor_name = flag_gems.vendor_name
+
+
+class FlashAttnVarlenBenchmark(base.Benchmark):
+    """
+    benchmark for flash_attn_varlen_func
+    """
+
+    def set_shapes(self, shape_file_path: Optional[List[Any]] = None):
+        # Collecting from qwen/Qwen3-1.7B
+        # --random-input 512 --random-output 2048 --num-prompts 200 --request-rate inf
+        # Format: (cu_seq_lens_q, seqused_k, num_heads, head_size, block_size,
+        # num_blocks, alibi, soft_cap)
+
+        all_cu_seq_lens_q = [
+            (
+                0,
+                512,
+            ),
+            (
+                0,
+                1,
+                2,
+                72,
+            ),
+            tuple(range(0, 45))
+            + (
+                105,
+                121,
+                137,
+                153,
+                169,
+                185,
+                201,
+                217,
+                233,
+                249,
+                265,
+            ),
+            tuple(range(0, 196))
+            + (
+                211,
+                226,
+                240,
+                253,
+                265,
+            ),
+        ]
+        all_seqused_k = [
+            (512,),
+            (
+                1,
+                1,
+                70,
+            ),
+            (515,) + (514,) * 20 + (513,) * 20 + (512,) * 14,
+            (2333,)
+            + (2331,) * 20
+            + (2330,) * 20
+            + (2329,) * 14
+            + (2328,) * 18
+            + (2327,) * 15
+            + (2326,) * 17
+            + (2325,) * 18
+            + (2324,) * 21
+            + (2323,) * 22
+            + (2322,) * 24
+            + (2321,) * 5
+            + (
+                2320,
+                2319,
+                2318,
+                2317,
+                2316,
+            ),
+        ]
+
+        num_heads = 16
+        num_heads_k = 8
+        head_dim = 128
+        block_size = 16
+        num_blocks = 2000
+        alibi = False
+        soft_cap = None
+
+        all_configs = [
+            (
+                cu_seq_lens_q,
+                seqused_k,
+                num_heads,
+                num_heads_k,
+                head_dim,
+                block_size,
+                num_blocks,
+                alibi,
+                soft_cap,
+            )
+            for cu_seq_lens_q, seqused_k in zip(all_cu_seq_lens_q, all_seqused_k)
+        ]
+
+        self.shapes = all_configs
+
+    def get_input_iter(self, dtype):
+        for config in self.shapes:
+            yield self.flash_attn_varlen_input_fn(config, dtype, self.device)
+
+    def flash_attn_varlen_input_fn(self, config, dtype, device):
+        """Input function for flash attention varlen benchmark"""
+        (
+            cu_query_lens,
+            seqused_k,
+            num_query_heads,
+            num_kv_heads,
+            head_size,
+            block_size,
+            num_blocks,
+            alibi,
+            soft_cap,
+        ) = config
+
+        if alibi is True and soft_cap is not None:
+            return
+
+        num_seqs = len(cu_query_lens) - 1
+        max_query_len = max(
+            map(lambda x, y: x - y, cu_query_lens[1:], cu_query_lens[:-1])
+        )
+        max_kv_len = max(seqused_k)
+        window_size = (-1, -1)
+        scale = head_size**-0.5
+
+        assert num_seqs == len(seqused_k)
+
+        with torch.device(device):
+            query = torch.randn(
+                cu_query_lens[-1],
+                num_query_heads,
+                head_size,
+                dtype=dtype,
+                device=device,
+            )
+            out = torch.empty_like(query)
+            key_cache = torch.randn(
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+                dtype=dtype,
+                device=device,
+            )
+            value_cache = torch.randn_like(key_cache)
+            cu_query_lens = torch.tensor(
+                cu_query_lens, dtype=torch.int32, device=device
+            )
+            seqused_k = torch.tensor(seqused_k, dtype=torch.int32, device=device)
+
+            max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+            block_tables = torch.randint(
+                0,
+                num_blocks,
+                (num_seqs, max_num_blocks_per_seq),
+                dtype=torch.int32,
+                device=device,
+            )
+
+            causal = True
+
+            if alibi:
+                alibi_slopes = (
+                    torch.ones(
+                        num_seqs, num_query_heads, device=device, dtype=torch.float32
+                    )
+                    * 0.3
+                )
+            else:
+                alibi_slopes = None
+
+        return (
+            query,
+            key_cache,
+            value_cache,
+            max_query_len,
+            cu_query_lens,
+            max_kv_len,
+            None,
+            seqused_k,
+            None,
+            0.0,
+            scale,
+            causal,
+            window_size,
+            soft_cap if soft_cap is not None else 0,
+            alibi_slopes,
+            False,
+            False,
+            block_tables,
+            False,
+            out,
+            None,
+            None,
+            None,
+            None,
+            {
+                "s_aux": None,
+                "num_splits": 0,
+                "cp_world_size": 1,
+                "cp_rank": 0,
+                "cp_tot_seqused_k": None,
+                "fa_version": 2,
+            },
+        )
+
+
+def flash_attn_varlen_legacy(*args, **kwargs):
+    """
+    Compatibility wrapper for running old flash_attn_varlen_func (iluvatar).
+    """
+    (
+        query,
+        key_cache,
+        value_cache,
+        max_query_len,
+        cu_query_lens,
+        max_kv_len,
+        _,
+        seqused_k,
+        _,
+        dropout_p,
+        scale,
+        causal,
+        window_size,
+        soft_cap,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        block_tables,
+        _,
+        out,
+        *_,
+    ) = args
+
+    k_flat = key_cache.reshape(-1, key_cache.shape[2], key_cache.shape[3])
+    v_flat = value_cache.reshape(-1, value_cache.shape[2], value_cache.shape[3])
+    cu_seqlens_k = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=seqused_k.device),
+            torch.cumsum(seqused_k, dim=0),
+        ]
+    ).to(torch.int32)
+
+    from flash_attn import flash_attn_varlen_func
+
+    result = flash_attn_varlen_func(
+        query,  # q
+        k_flat,  # k (flattened from key_cache)
+        v_flat,  # v (flattened from value_cache)
+        cu_query_lens,  # cu_seqlens_q
+        cu_seqlens_k,  # cu_seqlens_k (constructed from seqused_k)
+        max_query_len,  # max_seqlen_q
+        max_kv_len,  # max_seqlen_k
+        dropout_p,  # dropout_p
+        scale,  # softmax_scale
+        causal,  # causal
+        tuple(window_size),  # window_size
+        float(soft_cap),  # softcap
+        alibi_slopes,  # alibi_slopes
+        deterministic,  # deterministic
+        return_attn_probs,  # return_attn_probs
+        block_tables,  # block_table
+        alibi_slopes is not None,  # use_alibi (derived from alibi_slopes)
+        0,  # alibi_mode
+        1,  # imp_mode
+        out=out,  # out
+        bias=None,  # bias
+    )
+    return result
+
+
+def flash_attn_varlen_metax(*args, **kwargs):
+    """
+    Compatibility wrapper for running flash_attn_varlen_func on metax backend.
+    Metax flash_attn does not support iluvatar-specific params (out, bias,
+    use_alibi, alibi_mode, imp_mode) and expects 4D paged k/v when block_table
+    is provided.
+    """
+    (
+        query,
+        key_cache,
+        value_cache,
+        max_query_len,
+        cu_query_lens,
+        max_kv_len,
+        _,
+        seqused_k,
+        _,
+        dropout_p,
+        scale,
+        causal,
+        window_size,
+        soft_cap,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        block_tables,
+        _,
+        out,
+        *_,
+    ) = args
+
+    cu_seqlens_k = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=seqused_k.device),
+            torch.cumsum(seqused_k, dim=0),
+        ]
+    ).to(torch.int32)
+
+    from flash_attn import flash_attn_varlen_func
+
+    # When block_table is provided, flash_attn expects k/v in 4D paged format
+    # (num_blocks, page_block_size, nheads_k, headdim), not flattened 3D.
+    result = flash_attn_varlen_func(
+        query,
+        key_cache,
+        value_cache,
+        cu_query_lens,
+        cu_seqlens_k,
+        max_query_len,
+        max_kv_len,
+        dropout_p=dropout_p,
+        softmax_scale=scale,
+        causal=causal,
+        window_size=tuple(window_size),
+        alibi_slopes=alibi_slopes,
+        deterministic=deterministic,
+        return_attn_probs=return_attn_probs,
+        softcap=float(soft_cap),
+        block_table=block_tables,
+    )
+    return result
+
+
+@pytest.mark.skipif(
+    utils.SkipVersion("vllm", "<0.9"),
+    reason="vLLM version prior to 0.9 does not include the flash_attn_varlen_func API.",
+)
+@pytest.mark.skipif(
+    utils.SkipVersion("torch", "<2.7"),
+    reason="Torch version prior to 2.7 is not compatible with VLLM.",
+)
+@pytest.mark.skipif(vendor_name == "hygon", reason="#2816: RuntimeError")
+@pytest.mark.skipif(vendor_name == "cambricon", reason="#2886: TypeError")
+@pytest.mark.flash_attn_varlen_func
+def test_flash_attn_varlen_func(monkeypatch):
+    monkeypatch.setenv("VLLM_CONFIGURE_LOGGING", "0")
+
+    if vendor_name == "iluvatar":
+        # iluvatar does not have updated vllm_flash_attn, use conversion wrapper
+        flash_attn_varlen_func = flash_attn_varlen_legacy
+    elif vendor_name == "metax":
+        # metax does not have vllm_fa2_C.varlen_fwd, use metax-specific wrapper
+        flash_attn_varlen_func = flash_attn_varlen_metax
+    else:
+        from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func
+
+    bench = FlashAttnVarlenBenchmark(
+        op_name="flash_attn_varlen_func",
+        torch_op=flash_attn_varlen_func,
+        gems_op=flag_gems.flash_attn_varlen_func,
+        dtypes=[torch.float16, torch.bfloat16],
+    )
+    bench.run()

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -501,7 +501,7 @@ HEURISTICS_CONFIGS = {
     },
     "mha_block_128": {
         "BLOCK_M": lambda args: 128,
-        "BLOCK_N": lambda args: 32,
+        "BLOCK_N": lambda args: 16,
         "num_warps": lambda args: 4,
         "num_stages": lambda args: 3,
     },

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -3,6 +3,7 @@ from ._nested_view_from_buffer_copy import _nested_view_from_buffer_copy
 from .addmm import addmm
 from .amax import amax
 from .arange import arange, arange_start
+from .attention import flash_attn_varlen_func
 from .bmm import bmm
 from .exponential_ import exponential_
 from .full import full
@@ -53,6 +54,7 @@ __all__ = [
     "arange_start",
     "bmm",
     "exponential_",
+    "flash_attn_varlen_func",
     "full",
     "full_like",
     "group_norm",

--- a/src/flag_gems/runtime/backend/_metax/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/attention.py
@@ -1,0 +1,1647 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.config import use_c_extension
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner
+
+from .flash_api import mha_fwd, mha_varlan_fwd, mha_varlan_fwd_opt
+from .flash_kernel import keep
+
+logger = logging.getLogger(__name__)
+
+
+# Modified from Triton tutorial: https://triton-lang.org/main/getting-started/tutorials/06-fused-attention.html
+@triton.jit
+def _attn_fwd_inner(
+    acc,
+    l_i,
+    m_i,
+    query,  #
+    K_block_ptr,
+    V_block_ptr,  #
+    mask_block_ptr,  #
+    stride_k_seqlen,
+    stride_v_seqlen,
+    stride_attn_mask_kv_seqlen,  #
+    start_m,
+    qk_scale,  #
+    q_load_mask,
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,
+    offs_m: tl.constexpr,
+    offs_n: tl.constexpr,  #
+    KV_CTX: tl.constexpr,
+    fp8_v: tl.constexpr,
+    HAS_ATTN_MASK: tl.constexpr,
+    PRE_LOAD_V: tl.constexpr,
+    HEAD_DIM_ACTUAL: tl.constexpr,
+):
+    # range of values handled by this stage
+    if STAGE == 1:
+        lo, hi = 0, start_m * BLOCK_M
+    elif STAGE == 2:
+        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
+    # causal = False
+    else:
+        lo, hi = 0, KV_CTX
+
+    K_block_ptr += lo * stride_k_seqlen
+    V_block_ptr += lo * stride_v_seqlen
+    if HAS_ATTN_MASK:
+        mask_block_ptr += lo * stride_attn_mask_kv_seqlen
+
+    LOG2E = 1.44269504  # log2(e) constant
+    # mask for non-power-of-2 head dims: shape [HEAD_DIM]
+    hd_mask = tl.arange(0, HEAD_DIM) < HEAD_DIM_ACTUAL
+
+    # loop over key, value and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        kv_load_mask = (start_n + offs_n) < KV_CTX
+        # start_n = tl.multiple_of(start_n, BLOCK_N)
+        # -- compute qk ----
+        # K shape: [HEAD_DIM, BLOCK_N] — mask both head and kv-seq axes
+        key = tl.load(
+            K_block_ptr, mask=hd_mask[:, None] & kv_load_mask[None, :], other=0.0
+        )
+        if PRE_LOAD_V:
+            # V shape: [BLOCK_N, HEAD_DIM] — mask both axes
+            value = tl.load(
+                V_block_ptr, mask=kv_load_mask[:, None] & hd_mask[None, :], other=0.0
+            )
+
+        qk = tl.dot(query, key, allow_tf32=False)
+        # incase not divisible.
+        qk = tl.where(kv_load_mask[None, :], qk, -float("inf"))
+        # qk = qk.to(tl.float32)
+
+        if HAS_ATTN_MASK:
+            attn_mask = tl.load(
+                mask_block_ptr,
+                mask=q_load_mask[:, None] & kv_load_mask[None, :],
+                other=0.0,
+            )
+
+        if STAGE == 2:
+            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+
+            if HAS_ATTN_MASK:
+                qk = qk * qk_scale + attn_mask
+                qk *= LOG2E
+                qk = qk + tl.where(mask, 0, -1.0e6)
+            else:
+                qk = qk * qk_scale * LOG2E + tl.where(mask, 0, -1.0e6)
+
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            qk -= m_ij[:, None]
+        else:
+            qk *= qk_scale * LOG2E
+            if HAS_ATTN_MASK:
+                qk = qk + attn_mask
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            qk = qk - m_ij[:, None]
+
+        p = tl.math.exp2(qk)
+        l_ij = tl.sum(p, 1)
+        # -- update m_i and l_i
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + l_ij
+        # -- update output accumulator --
+        acc = acc * alpha[:, None]
+        # update acc
+        if not PRE_LOAD_V:
+            value = tl.load(
+                V_block_ptr, mask=kv_load_mask[:, None] & hd_mask[None, :], other=0.0
+            )
+        if fp8_v:
+            p = p.to(tl.float8e5)
+        else:
+            p = p.to(query.dtype)
+        p = p.to(value.dtype)
+        acc = tl.dot(p, value, acc, allow_tf32=False)
+        # update m_i and l_i
+        m_i = m_ij
+
+        K_block_ptr += BLOCK_N * stride_k_seqlen
+        V_block_ptr += BLOCK_N * stride_v_seqlen
+
+        if HAS_ATTN_MASK:
+            mask_block_ptr += BLOCK_N * stride_attn_mask_kv_seqlen
+
+    return acc, l_i, m_i
+
+
+# NOTE: we assert BLOCK_N <= HEAD_DIM in _attn_fwd, so for small head_dim,
+# we need to generate more configs.
+configs = runtime.get_tuned_config("attention")
+SMALL_HEAD_DIM_CONFIGS = [
+    triton.Config(
+        {"BLOCK_M": BM, "BLOCK_N": BN, "PRE_LOAD_V": 0}, num_stages=s, num_warps=w
+    )
+    for BM in [64, 128]
+    for BN in [16, 32]
+    for s in [2, 3, 4]
+    for w in [4, 8]
+]
+configs += SMALL_HEAD_DIM_CONFIGS
+
+
+@libentry()
+@libtuner(
+    configs=list(filter(partial(keep, must_keep=SMALL_HEAD_DIM_CONFIGS), configs)),
+    key=["KV_CTX", "HEAD_DIM"],
+)
+@triton.jit
+def _attn_fwd(
+    Q,
+    K,
+    V,
+    attn_mask,
+    sm_scale,
+    M,
+    Out,  #
+    stride_q_batch,
+    stride_q_head,
+    stride_q_seqlen,
+    stride_q_headsize,
+    stride_k_batch,
+    stride_k_head,
+    stride_k_seqlen,
+    stride_k_headsize,
+    stride_v_batch,
+    stride_v_head,
+    stride_v_seqlen,
+    stride_v_headsize,
+    stride_attn_mask_batch,
+    stride_attn_mask_head,
+    stride_attn_mask_q_seqlen,
+    stride_attn_mask_kv_seqlen,
+    stride_o_batch,
+    stride_o_head,
+    stride_o_seqlen,
+    stride_o_headsize,
+    Z,
+    q_head_num,
+    kv_head_num,
+    GROUP_HEAD: tl.constexpr,
+    Q_CTX,
+    KV_CTX,
+    HEAD_DIM: tl.constexpr,
+    HEAD_DIM_ACTUAL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    STAGE: tl.constexpr,
+    HAS_ATTN_MASK: tl.constexpr,
+    PRE_LOAD_V: tl.constexpr,
+):
+    tl.static_assert(BLOCK_N <= HEAD_DIM)
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    batch_id = off_hz // q_head_num
+    head_id = off_hz % q_head_num
+    kv_head_id = head_id // GROUP_HEAD
+
+    q_offset = (
+        batch_id.to(tl.int64) * stride_q_batch + head_id.to(tl.int64) * stride_q_head
+    )
+    o_offset = (
+        batch_id.to(tl.int64) * stride_o_batch + head_id.to(tl.int64) * stride_o_head
+    )
+    kv_offset = (
+        batch_id.to(tl.int64) * stride_k_batch + kv_head_id.to(tl.int64) * stride_k_head
+    )
+
+    offs_headsize = tl.arange(0, HEAD_DIM)
+
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    q_load_mask = offs_m < Q_CTX
+    offs_n = tl.arange(0, BLOCK_N)
+
+    Q_block_ptr = (
+        Q
+        + q_offset
+        + offs_m[:, None] * stride_q_seqlen
+        + offs_headsize[None, :] * stride_q_headsize
+    )
+    K_block_ptr = (
+        K
+        + kv_offset
+        + offs_n[None, :] * stride_k_seqlen
+        + offs_headsize[:, None] * stride_k_headsize
+    )
+    V_block_ptr = (
+        V
+        + kv_offset
+        + offs_n[:, None] * stride_v_seqlen
+        + offs_headsize[None, :] * stride_v_headsize
+    )
+
+    if HAS_ATTN_MASK:
+        attn_mask_offset = (
+            batch_id.to(tl.int64) * stride_attn_mask_batch
+            + head_id.to(tl.int64) * stride_attn_mask_head
+        )
+        mask_block_ptr = (
+            attn_mask
+            + attn_mask_offset
+            + offs_m[:, None] * stride_attn_mask_q_seqlen
+            + offs_n[None, :] * stride_attn_mask_kv_seqlen
+        )
+    else:
+        mask_block_ptr = None
+
+    O_block_ptr = (
+        Out
+        + o_offset
+        + offs_m[:, None] * stride_o_seqlen
+        + offs_headsize[None, :] * stride_o_headsize
+    )
+
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    # load scales
+    qk_scale = sm_scale
+    # qk_scale *= 1.44269504  # 1/log(2)
+    # mask for non-power-of-2 head dims
+    hd_mask = offs_headsize < HEAD_DIM_ACTUAL
+    # load query: it will stay in SRAM throughout
+    query = tl.load(
+        Q_block_ptr, mask=q_load_mask[:, None] & hd_mask[None, :], other=0.0
+    )
+    # stage 1: off-band
+    # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
+    # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
+    if STAGE & 1:
+        acc, l_i, m_i = _attn_fwd_inner(
+            acc,
+            l_i,
+            m_i,
+            query,
+            K_block_ptr,
+            V_block_ptr,
+            mask_block_ptr,
+            stride_k_seqlen,
+            stride_v_seqlen,
+            stride_attn_mask_kv_seqlen,
+            start_m,
+            qk_scale,
+            q_load_mask,
+            BLOCK_M,
+            HEAD_DIM,
+            BLOCK_N,
+            4 - STAGE,
+            offs_m,
+            offs_n,
+            KV_CTX,
+            V.dtype.element_ty == tl.float8e5,
+            HAS_ATTN_MASK,
+            PRE_LOAD_V,
+            HEAD_DIM_ACTUAL,
+        )
+    # stage 2: on-band
+    if STAGE & 2:
+        # barrier makes it easier for compielr to schedule the
+        # two loops independently
+        acc, l_i, m_i = _attn_fwd_inner(
+            acc,
+            l_i,
+            m_i,
+            query,
+            K_block_ptr,
+            V_block_ptr,
+            mask_block_ptr,
+            stride_k_seqlen,
+            stride_v_seqlen,
+            stride_attn_mask_kv_seqlen,
+            start_m,
+            qk_scale,
+            q_load_mask,
+            BLOCK_M,
+            HEAD_DIM,
+            BLOCK_N,
+            2,
+            offs_m,
+            offs_n,
+            KV_CTX,
+            V.dtype.element_ty == tl.float8e5,
+            HAS_ATTN_MASK,
+            PRE_LOAD_V,
+            HEAD_DIM_ACTUAL,
+        )
+    # epilogue
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    m_ptrs = M + off_hz * Q_CTX + offs_m
+    tl.store(m_ptrs, m_i, mask=q_load_mask)
+    tl.store(
+        O_block_ptr,
+        acc.to(Out.type.element_ty),
+        mask=q_load_mask[:, None] & hd_mask[None, :],
+    )
+
+
+@triton.jit
+def _attn_bwd_preprocess(
+    O,
+    DO,
+    Delta,
+    Z,
+    H,
+    Q_CTX,
+    BLOCK_M: tl.constexpr,
+    D_HEAD: tl.constexpr,
+    D_HEAD_ACTUAL: tl.constexpr,
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask = off_m < Q_CTX
+
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, D_HEAD)
+    # D_HEAD_ACTUAL is the real (unpadded) head size; use it for pointer
+    # arithmetic so we stride correctly through contiguous tensors.
+    # D_HEAD is the next power-of-2 block size used only for tl.arange.
+    hd_mask = off_n < D_HEAD_ACTUAL
+    # load
+    o = tl.load(
+        O
+        + off_hz * D_HEAD_ACTUAL * Q_CTX
+        + off_m[:, None] * D_HEAD_ACTUAL
+        + off_n[None, :],
+        mask=mask[:, None] & hd_mask[None, :],
+        other=0.0,
+    )
+    do = tl.load(
+        DO
+        + off_hz * D_HEAD_ACTUAL * Q_CTX
+        + off_m[:, None] * D_HEAD_ACTUAL
+        + off_n[None, :],
+        mask=mask[:, None] & hd_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * Q_CTX + off_m, delta, mask=mask)
+
+
+# The main inner-loop logic for computing dK and dV.
+@triton.jit
+def _attn_bwd_dkdv(
+    dk,
+    dv,  #
+    Q,
+    key,
+    value,
+    sm_scale,  #
+    DO,  #
+    M,
+    D,  #
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    H,
+    Q_CTX,
+    KV_CTX,
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,  #
+    # Filled in by the wrapper.
+    start_n,
+    start_m,
+    num_steps,  #
+    MASK: tl.constexpr,
+    BLOCK_DMODEL_ACTUAL: tl.constexpr,
+):
+    # BLOCK_M1: 32
+    # BLOCK_N1: 128
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    offs_n_mask = offs_n < KV_CTX  # (BLOCK_N1, )
+
+    offs_k = tl.arange(0, BLOCK_DMODEL)  # (BLOCK_DMODEL, )
+    hd_mask = offs_k < BLOCK_DMODEL_ACTUAL  # head dim mask
+
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    for blk_idx in range(num_steps):
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)  # (BLOCK_M1, )
+        offs_m_mask = offs_m < Q_CTX  # (BLOCK_M1, )
+
+        qT_ptrs = (
+            Q + offs_m[None, :] * stride_tok + offs_k[:, None] * stride_d
+        )  # (BLOCK_DMODEL, BLOCK_M1)
+        do_ptrs = (
+            DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+        )  # (BLOCK_M1, BLOCK_DMODEL)
+
+        qT = tl.load(
+            qT_ptrs, mask=hd_mask[:, None] & offs_m_mask[None, :], other=0.0
+        )  # (BLOCK_DMODEL, BLOCK_M1)
+
+        # Load m before computing qk to reduce pipeline stall.
+        m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))  # (BLOCK_M1, )
+
+        # key: (BLOCK_N1, BLOCK_DMODEL)
+        qkT = tl.dot(key, qT)  # (BLOCK_N1, BLOCK_M1)
+        m = tl.broadcast_to(m[None, :], (BLOCK_N1, BLOCK_M1))  # (BLOCK_N1, BLOCK_M1)
+        m = tl.where(offs_n_mask[:, None], m, float("inf"))  # (BLOCK_N1, BLOCK_M1)
+        pT = tl.math.exp2(qkT - m)
+        # pT = tl.math.exp2(qkT - m[None, :])
+
+        mask = (offs_m < Q_CTX)[None, :] & (offs_n < KV_CTX)[
+            :, None
+        ]  # (BLOCK_N1, BLOCK_M1)
+        # Autoregressive masking.
+        if MASK:
+            mask &= offs_m[None, :] >= offs_n[:, None]
+        pT = tl.where(mask, pT, 0.0)  # (BLOCK_N1, BLOCK_M1)
+
+        do = tl.load(
+            do_ptrs, mask=offs_m_mask[:, None] & hd_mask[None, :], other=0.0
+        )  # (BLOCK_M1, BLOCK_DMODEL)
+
+        # Compute dV.
+        dv += tl.dot(pT, do.to(tl.float32))  # (BLOCK_N1, BLOCK_DMODEL)
+        # D (= delta) is pre-divided by ds_scale.
+        Di = tl.load(D + offs_m, mask=offs_m_mask, other=0.0)  # (BLOCK_M1, )
+
+        # Compute dP and dS.
+        dpT = tl.dot(value, tl.trans(do)).to(
+            tl.float32
+        )  # (BLOCK_N1, BLOCK_DMODEL) @ (BLOCK_M1, BLOCK_DMODEL).T -> (BLOCK_N1, BLOCK_M1)
+        dsT = pT * (dpT - Di[None, :])  # (BLOCK_N1, BLOCK_M1)
+        dsT = dsT.to(qT.dtype)
+        qT = tl.where(offs_m_mask[None, :], qT, 0.0)  # (BLOCK_DMODEL, BLOCK_M1)
+        dsT = tl.where(
+            offs_m_mask[None, :] & offs_n_mask[:, None], dsT, 0.0
+        )  # (BLOCK_N1, BLOCK_M1)
+        dk += tl.dot(
+            dsT, tl.trans(qT)
+        )  # (BLOCK_N1, BLOCK_M1) @ (BLOCK_DMODEL, BLOCK_M1).T -> (BLOCK_N1, BLOCK_DMODEL)
+        # Increment pointers.
+        curr_m += step_m
+    return dk, dv
+
+
+# the main inner-loop logic for computing dQ
+@triton.jit
+def _attn_bwd_dq(
+    dq,
+    query,
+    K,
+    V,  #
+    do,
+    m,
+    D,
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    H,
+    Q_CTX,  #
+    KV_CTX,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,
+    # Filled in by the wrapper.
+    start_m,
+    start_n,
+    num_steps,  #
+    MASK: tl.constexpr,
+    BLOCK_DMODEL_ACTUAL: tl.constexpr,
+):
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    offs_m_mask = offs_m < Q_CTX
+
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    hd_mask = offs_k < BLOCK_DMODEL_ACTUAL  # head dim mask
+    # D (= delta) is pre-divided by ds_scale.
+    Di = tl.load(D + offs_m, mask=offs_m_mask, other=0.0)
+    # BLOCK_M2 must be a multiple of BLOCK_N2, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_M2 % BLOCK_N2 == 0)
+    curr_n = start_n
+    step_n = BLOCK_N2
+    for blk_idx in range(num_steps):
+        offs_n = curr_n + tl.arange(0, BLOCK_N2)
+        offs_n_mask = offs_n < KV_CTX
+
+        kT_ptrs = K + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+        vT_ptrs = V + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+
+        kT = tl.load(kT_ptrs, mask=hd_mask[:, None] & offs_n_mask[None, :], other=0.0)
+        vT = tl.load(vT_ptrs, mask=hd_mask[:, None] & offs_n_mask[None, :], other=0.0)
+        qk = tl.dot(query, kT)
+        p = tl.math.exp2(qk - m)
+        mask = (offs_m < Q_CTX)[:, None] & (offs_n < KV_CTX)[None, :]
+        # Autoregressive masking.
+        if MASK:
+            # mask = (offs_m[:, None] >= offs_n[None, :])
+            # mask = (offs_m[:, None] >= offs_n[None, :]) & (offs_m < N_CTX)[:, None] & (offs_n < N_CTX)[None, :]
+            mask &= offs_m[:, None] >= offs_n[None, :]
+        p = tl.where(mask, p, 0.0)
+        # Compute dP and dS.
+        dp = tl.dot(do, vT).to(tl.float32)
+        ds = p * (dp - Di[:, None])
+        ds = tl.where(mask, ds, 0.0).to(kT.dtype)
+        # Compute dQ.
+        # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
+        dq += tl.dot(ds, tl.trans(kT))
+        # Increment pointers.
+        curr_n += step_n
+    return dq
+
+
+config_backward = runtime.get_tuned_config("attention_bwd")
+
+
+@libentry()
+@libtuner(
+    configs=config_backward,
+    key=["KV_CTX", "BLOCK_DMODEL"],
+)
+@triton.jit
+def _attn_bwd(
+    Q,
+    K,
+    V,
+    sm_scale,  #
+    DO,  #
+    DQ,
+    DK,
+    DV,  #
+    M,
+    D,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    kv_stride_z,
+    kv_stride_h,  #
+    dk_stride_z,
+    dk_stride_h,
+    dk_stride_tok,  #
+    H,  # query head num
+    Q_CTX,  #
+    KV_CTX,  #
+    kv_head_num,  #
+    GROUP_HEAD: tl.constexpr,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DMODEL_ACTUAL: tl.constexpr,
+    IS_CAUSAL: tl.constexpr = True,
+):
+    LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
+
+    bhid = tl.program_id(2)
+    off_chz = (bhid * Q_CTX).to(tl.int64)
+    batch_id = bhid // H
+    q_head_id = bhid % H
+    kv_head_id = q_head_id // GROUP_HEAD
+    adj = (stride_h * q_head_id + stride_z * batch_id).to(tl.int64)
+    kv_adj = (kv_stride_h * kv_head_id + kv_stride_z * batch_id).to(tl.int64)
+    dk_adj = (dk_stride_h * q_head_id + dk_stride_z * batch_id).to(tl.int64)
+
+    pid = tl.program_id(0)
+
+    # offset pointers for batch/head
+    Q += adj
+    K += kv_adj
+    V += kv_adj
+    DO += adj
+    DQ += adj
+    DK += dk_adj
+    DV += dk_adj
+    M += off_chz
+    D += off_chz
+
+    # load scales
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    hd_mask = offs_k < BLOCK_DMODEL_ACTUAL  # head dim mask
+
+    # dK/dV: only execute when this pid covers a valid KV block
+    start_n = pid * BLOCK_N1
+    if start_n < KV_CTX:
+        dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+        dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+
+        # load K and V: they stay in SRAM throughout the inner loop.
+        offs_n = start_n + tl.arange(0, BLOCK_N1)
+        offs_n_mask = offs_n < KV_CTX
+        key = tl.load(
+            K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_n_mask[:, None] & hd_mask[None, :],
+            other=0.0,
+        )
+        value = tl.load(
+            V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_n_mask[:, None] & hd_mask[None, :],
+            other=0.0,
+        )
+
+        MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
+
+        # Causal: masked diagonal phase, then unmasked above-diagonal phase.
+        # Non-causal: skip masked phase, single unmasked pass over all Q rows.
+        if IS_CAUSAL:
+            # The causal mask is q_idx >= kv_idx, so for KV block starting at
+            # start_n, the first Q row that can attend is start_n itself.
+            start_m = start_n
+            # Clamp to valid Q range
+            if start_m < Q_CTX:
+                end_m = min(start_m + BLOCK_N1, Q_CTX)
+                num_steps = (end_m - start_m + MASK_BLOCK_M1 - 1) // MASK_BLOCK_M1
+                dk, dv = _attn_bwd_dkdv(
+                    dk,
+                    dv,  #
+                    Q,
+                    key,
+                    value,
+                    sm_scale,  #
+                    DO,  #
+                    M,
+                    D,  #
+                    stride_tok,
+                    stride_d,  #
+                    H,
+                    Q_CTX,  #
+                    KV_CTX,  #
+                    MASK_BLOCK_M1,
+                    BLOCK_N1,
+                    BLOCK_DMODEL,  #
+                    start_n,
+                    start_m,
+                    num_steps,  #
+                    MASK=True,  #
+                    BLOCK_DMODEL_ACTUAL=BLOCK_DMODEL_ACTUAL,
+                )
+                start_m += num_steps * MASK_BLOCK_M1
+            # else: start_n >= Q_CTX, no Q rows can attend to this KV block
+        else:
+            start_m = 0
+
+        # Unmasked phase (shared): traverse remaining Q rows.
+        remaining_m = Q_CTX - start_m
+        num_steps = (remaining_m + BLOCK_M1 - 1) // BLOCK_M1
+        if num_steps > 0:
+            dk, dv = _attn_bwd_dkdv(
+                dk,
+                dv,  #
+                Q,
+                key,
+                value,
+                sm_scale,  #
+                DO,  #
+                M,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                BLOCK_M1,
+                BLOCK_N1,
+                BLOCK_DMODEL,  #
+                start_n,
+                start_m,
+                num_steps,  #
+                MASK=False,  #
+                BLOCK_DMODEL_ACTUAL=BLOCK_DMODEL_ACTUAL,
+            )
+
+        dv_ptrs = DV + offs_n[:, None] * dk_stride_tok + offs_k[None, :] * stride_d
+        tl.store(dv_ptrs, dv, mask=offs_n_mask[:, None] & hd_mask[None, :])
+
+        # Write back dK.
+        dk *= sm_scale
+        dk_ptrs = DK + offs_n[:, None] * dk_stride_tok + offs_k[None, :] * stride_d
+        tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None] & hd_mask[None, :])
+
+    # dQ: only execute when this pid covers a valid Q block
+    start_m = pid * BLOCK_M2
+    if start_m < Q_CTX:
+        offs_m = start_m + tl.arange(0, BLOCK_M2)
+        offs_m_mask = offs_m < Q_CTX
+        query = tl.load(
+            Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_m_mask[:, None] & hd_mask[None, :],
+            other=0.0,
+        )
+        dq = tl.zeros([BLOCK_M2, BLOCK_DMODEL], dtype=tl.float32)
+        do = tl.load(
+            DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_m_mask[:, None] & hd_mask[None, :],
+            other=0.0,
+        )
+        m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
+        m = m[:, None]
+
+        MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+
+        if IS_CAUSAL:
+            # Masked diagonal phase: KV columns [diag_n, end_n)
+            # diag_n is the KV position where the causal boundary starts for
+            # this Q block. Only needed when diag_n < KV_CTX.
+            diag_n = min(start_m, KV_CTX)
+            end_n = min(start_m + BLOCK_M2, KV_CTX)
+            num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
+
+            if num_steps > 0:
+                dq = _attn_bwd_dq(
+                    dq,
+                    query,
+                    K,
+                    V,  #
+                    do,
+                    m,
+                    D,  #
+                    stride_tok,
+                    stride_d,  #
+                    H,
+                    Q_CTX,  #
+                    KV_CTX,  #
+                    BLOCK_M2,
+                    MASK_BLOCK_N2,
+                    BLOCK_DMODEL,  #
+                    start_m,
+                    diag_n,
+                    num_steps,  #
+                    MASK=True,  #
+                    BLOCK_DMODEL_ACTUAL=BLOCK_DMODEL_ACTUAL,
+                )
+
+            # Unmasked phase: KV columns [0, diag_n), all fully visible.
+            stage2_num_steps = (diag_n + BLOCK_N2 - 1) // BLOCK_N2
+        else:
+            # Non-causal: single unmasked pass over all KV columns.
+            stage2_num_steps = (KV_CTX + BLOCK_N2 - 1) // BLOCK_N2
+
+        if stage2_num_steps > 0:
+            dq = _attn_bwd_dq(
+                dq,
+                query,
+                K,
+                V,  #
+                do,
+                m,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                BLOCK_M2,
+                BLOCK_N2,
+                BLOCK_DMODEL,  #
+                start_m,
+                0,
+                stage2_num_steps,  #
+                MASK=False,  #
+                BLOCK_DMODEL_ACTUAL=BLOCK_DMODEL_ACTUAL,
+            )
+
+        # Write back dQ.
+        dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+        dq *= LN2
+        tl.store(dq_ptrs, dq, mask=offs_m_mask[:, None] & hd_mask[None, :])
+
+
+def scaled_dot_product_attention_forward(
+    query,
+    key,
+    value,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=False,
+    scale=None,
+    enable_gqa=False,
+):
+    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION FORWARD")
+    # shape constraints
+    HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
+    # when v is in float8_e5m2 it is transposed.
+    HEAD_DIM_V = value.shape[-1]
+    assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+    assert dropout_p == 0.0, "Currenty only support dropout_p=0.0"
+
+    o = torch.empty_like(query, dtype=value.dtype)
+
+    stage = 3 if is_causal else 1
+
+    if scale is None:
+        sm_scale = 1.0 / (HEAD_DIM_K**0.5)
+    else:
+        sm_scale = scale
+
+    # Triton kernels require HEAD_DIM (constexpr block size) to be a power of 2.
+    # We pass HEAD_DIM = next_power_of_2(HEAD_DIM_K) as the SRAM block size and
+    # HEAD_DIM_ACTUAL = HEAD_DIM_K as the real dimension, then mask inside the kernel.
+    # No tensor padding needed.
+    HEAD_DIM_ACTUAL = HEAD_DIM_K
+    HEAD_DIM_K = triton.next_power_of_2(HEAD_DIM_K)
+
+    q_head_num = query.shape[1]
+    kv_head_num = key.shape[1]
+    assert enable_gqa or q_head_num == kv_head_num, (
+        f"q_head_num {q_head_num} != kv_head_num {kv_head_num}, "
+        "enable_gqa must be True to support different head numbers."
+    )
+
+    grid = lambda args: (
+        triton.cdiv(query.shape[2], args["BLOCK_M"]),
+        query.shape[0] * query.shape[1],
+        1,
+    )
+
+    if attn_mask is not None:
+        HAS_ATTN_MASK = True
+        if attn_mask.dtype == torch.bool:
+            attn_mask = attn_mask.to(query.dtype) * -1.0e6
+        stride_attn_mask_batch = attn_mask.stride(0)
+        stride_attn_mask_head = attn_mask.stride(1)
+        stride_attn_mask_q_seqlen = attn_mask.stride(2)
+        stride_attn_mask_kv_seqlen = attn_mask.stride(3)
+    else:
+        HAS_ATTN_MASK = False
+        stride_attn_mask_batch = 1
+        stride_attn_mask_head = 1
+        stride_attn_mask_q_seqlen = 1
+        stride_attn_mask_kv_seqlen = 1
+
+    M = torch.empty(
+        (query.shape[0], query.shape[1], query.shape[2]),
+        device=query.device,
+        dtype=torch.float32,
+    )
+
+    with torch_device_fn.device(query.device):
+        _attn_fwd[grid](
+            query,
+            key,
+            value,
+            attn_mask,
+            sm_scale,
+            M,
+            o,  #
+            query.stride(0),
+            query.stride(1),
+            query.stride(2),
+            query.stride(3),  #
+            key.stride(0),
+            key.stride(1),
+            key.stride(2),
+            key.stride(3),  #
+            value.stride(0),
+            value.stride(1),
+            value.stride(2),
+            value.stride(3),  #
+            stride_attn_mask_batch,
+            stride_attn_mask_head,
+            stride_attn_mask_q_seqlen,
+            stride_attn_mask_kv_seqlen,  #
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            o.stride(3),  #
+            query.shape[0],
+            q_head_num,
+            kv_head_num,  #
+            q_head_num // kv_head_num,  # group_head
+            query.shape[2],  #
+            key.shape[2],  #
+            HEAD_DIM_K,  #
+            HEAD_DIM_ACTUAL=HEAD_DIM_ACTUAL,  #
+            STAGE=stage,  #
+            HAS_ATTN_MASK=HAS_ATTN_MASK,  #
+        )
+    return o, M
+
+
+def scaled_dot_product_attention_backward(
+    do,
+    query,
+    key,
+    value,
+    o,
+    M,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=False,
+    scale=None,
+    enable_gqa=False,
+):
+    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION BACKWARD")
+    # shape constraints
+    HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
+    # when v is in float8_e5m2 it is transposed.
+    HEAD_DIM_V = value.shape[-1]
+    assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+    assert dropout_p == 0.0, "Currenty only support dropout_p=0.0"
+
+    # sm_scale is based on the original head dim
+    if scale is None:
+        sm_scale = 1.0 / (HEAD_DIM_K**0.5)
+    else:
+        sm_scale = scale
+
+    assert do.is_contiguous()
+    assert (
+        query.is_contiguous()
+        and key.is_contiguous()
+        and value.is_contiguous()
+        and o.is_contiguous()
+    )
+    assert query.stride() == o.stride() == do.stride()
+    assert key.stride() == value.stride()
+
+    # Triton kernels require BLOCK_DMODEL to be a power of 2.
+    # Pass BLOCK_DMODEL = next_power_of_2(HEAD_DIM_K) as the SRAM block size and
+    # BLOCK_DMODEL_ACTUAL = HEAD_DIM_K as the real dimension, masking inside kernels.
+    BLOCK_DMODEL_ACTUAL = HEAD_DIM_K
+    BLOCK_DMODEL = triton.next_power_of_2(HEAD_DIM_K)
+    BATCH, Q_HEAD, Q_CTX = query.shape[:3]
+    _, KV_HEAD, KV_CTX = key.shape[:3]
+    group_head = Q_HEAD // KV_HEAD
+
+    # NUM_WARPS, NUM_STAGES = 4, 1
+    # BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
+    BLK_SLICE_FACTOR = 2
+    # RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+
+    RCP_LN2 = 1.0 / math.log(2)
+
+    arg_k = key * (sm_scale * RCP_LN2)
+    # PRE_BLOCK = 128
+    PRE_BLOCK = 256
+
+    # PRE_BLOCK = 32
+    # assert N_CTX % PRE_BLOCK == 0
+    # pre_grid = (N_CTX // PRE_BLOCK, BATCH * Q_HEAD)
+    pre_grid = (triton.cdiv(Q_CTX, PRE_BLOCK), BATCH * Q_HEAD)
+
+    delta = torch.empty_like(M)
+
+    # NOTE that dk & dv always have the same number of heads as q
+    dq = torch.empty_like(query).contiguous()
+    dk = torch.empty(
+        (BATCH, Q_HEAD, KV_CTX, BLOCK_DMODEL_ACTUAL),
+        device=key.device,
+        dtype=key.dtype,
+        memory_format=torch.contiguous_format,
+    )
+    dv = torch.empty(
+        (BATCH, Q_HEAD, KV_CTX, BLOCK_DMODEL_ACTUAL),
+        device=value.device,
+        dtype=value.dtype,
+        memory_format=torch.contiguous_format,
+    )
+
+    _attn_bwd_preprocess[pre_grid](
+        o,
+        do,  #
+        delta,  #
+        BATCH,
+        Q_HEAD,
+        Q_CTX,  #
+        BLOCK_M=PRE_BLOCK,
+        D_HEAD=BLOCK_DMODEL,  #
+        D_HEAD_ACTUAL=BLOCK_DMODEL_ACTUAL,  #
+    )
+
+    grid = lambda meta: (
+        max(
+            triton.cdiv(
+                KV_CTX, meta["BLOCK_N1"]
+            ),  # _attn_bwd_dq traverse the key-value sequence
+            triton.cdiv(
+                Q_CTX, meta["BLOCK_M2"]
+            ),  # _attn_bwd_dkdv traverse the query sequence
+        ),
+        1,
+        BATCH * Q_HEAD,
+    )
+    # logger.info(f"{triton.cdiv(Q_CTX, BLOCK_N1)=}")
+    # logger.info(f"{M.shape=}")
+
+    _attn_bwd[grid](
+        query,
+        arg_k,
+        value,
+        sm_scale,
+        do,
+        dq,
+        dk,
+        dv,  #
+        M,
+        delta,  #
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        query.stride(3),  #
+        key.stride(0),
+        key.stride(1),  #
+        dk.stride(0),
+        dk.stride(1),
+        dk.stride(2),  #
+        Q_HEAD,
+        Q_CTX,  #
+        KV_CTX,  #
+        KV_HEAD,  #
+        GROUP_HEAD=group_head,  #
+        # BLOCK_M1=BLOCK_M1,
+        # BLOCK_N1=BLOCK_N1,  #
+        # BLOCK_M2=BLOCK_M2,
+        # BLOCK_N2=BLOCK_N2,  #
+        BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+        BLOCK_DMODEL=BLOCK_DMODEL,  #
+        BLOCK_DMODEL_ACTUAL=BLOCK_DMODEL_ACTUAL,  #
+        IS_CAUSAL=is_causal,  #
+    )
+
+    if group_head > 1:
+        dk = dk.reshape(
+            BATCH, Q_HEAD // group_head, group_head, KV_CTX, BLOCK_DMODEL_ACTUAL
+        )
+        dv = dv.reshape(
+            BATCH, Q_HEAD // group_head, group_head, KV_CTX, BLOCK_DMODEL_ACTUAL
+        )
+        dk = dk.sum(dim=2)
+        dv = dv.sum(dim=2)
+
+    return dq, dk, dv
+
+
+class ScaleDotProductAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+        enable_gqa=False,
+    ):
+        sm_scale = scale if scale is not None else 1.0 / (key.shape[-1] ** 0.5)
+        o, M = scaled_dot_product_attention_forward(
+            query,
+            key,
+            value,
+            attn_mask,
+            dropout_p,
+            is_causal,
+            sm_scale,
+            enable_gqa,
+        )
+
+        ctx.save_for_backward(query, key, value, o, M)
+        ctx.sm_scale = sm_scale
+        ctx.causal = is_causal
+        ctx.enable_gqa = enable_gqa
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        query, key, value, o, M = ctx.saved_tensors
+        is_causal = ctx.causal
+        enable_gqa = ctx.enable_gqa
+        sm_scale = ctx.sm_scale
+        dq, dk, dv = scaled_dot_product_attention_backward(
+            do,
+            query,
+            key,
+            value,
+            o,
+            M,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=is_causal,
+            scale=sm_scale,
+            enable_gqa=enable_gqa,
+        )
+        return dq, dk, dv, None, None, None, None, None
+
+
+def scaled_dot_product_attention(
+    query,
+    key,
+    value,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=False,
+    scale=None,
+    enable_gqa=False,
+):
+    return ScaleDotProductAttention.apply(
+        query,
+        key,
+        value,
+        attn_mask,
+        dropout_p,
+        is_causal,
+        scale,
+        enable_gqa,
+    )
+
+
+def flash_attention_forward(
+    query,
+    key,
+    value,
+    cumulative_sequence_length_q,
+    cumulative_sequence_length_k,
+    max_q,
+    max_k,
+    dropout_p,
+    is_causal,
+    return_debug_mask,
+    *,
+    scale=None,
+    softcap=0.0,
+    window_size_left=None,
+    window_size_right=None,
+    seqused_k=None,
+    alibi_slopes=None,
+    disable_splitkv=False,
+):
+    logger.debug("GEMS FLASH_ATTENTION_FORWARD")
+    assert (
+        cumulative_sequence_length_q is None and cumulative_sequence_length_k is None
+    ), "varlen is not supported yet."
+
+    HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
+    HEAD_DIM_V = value.shape[-1]
+    assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+    original_head_dim = HEAD_DIM_K
+    supported_head_dims = (16, 32, 64, 96, 128, 192, 256)
+    if HEAD_DIM_K not in supported_head_dims:
+        padded_head_dim = None
+        for d in supported_head_dims:
+            if d >= HEAD_DIM_K:
+                padded_head_dim = d
+                break
+        assert (
+            padded_head_dim is not None
+        ), f"Unsupported head dim {HEAD_DIM_K}, max supported is {supported_head_dims[-1]}"
+        pad = padded_head_dim - HEAD_DIM_K
+        query = F.pad(query, (0, pad))
+        key = F.pad(key, (0, pad))
+        value = F.pad(value, (0, pad))
+        HEAD_DIM_K = padded_head_dim
+
+    softmax_scale = scale or 1.0 / (original_head_dim**0.5)
+    if window_size_left is not None:
+        non_null_window_left = window_size_left
+    else:
+        non_null_window_left = -1
+    if window_size_right is not None:
+        non_null_window_right = window_size_right
+    else:
+        non_null_window_right = -1
+
+    out = torch.empty_like(query)
+    if cumulative_sequence_length_q is not None:
+        out, q, k, v, lse, philox_seed, philox_offset, p = mha_varlan_fwd(
+            query,
+            key,
+            value,
+            out,
+            cumulative_sequence_length_q,
+            cumulative_sequence_length_k,
+            seqused_k,
+            None,
+            None,  # block_table
+            alibi_slopes,
+            max_q,
+            max_k,
+            dropout_p,
+            scale,
+            False,
+            is_causal,
+            non_null_window_left,
+            non_null_window_right,
+            softcap,
+            return_debug_mask and dropout_p > 0,
+            None,
+        )
+    else:
+        out, q, k, v, lse, philox_seed, philox_offset, p = mha_fwd(
+            query,
+            key,
+            value,
+            out,
+            alibi_slopes,
+            dropout_p,
+            softmax_scale,
+            is_causal,
+            non_null_window_left,
+            non_null_window_right,
+            softcap,
+            return_debug_mask,
+            disable_splitkv=disable_splitkv,
+        )
+
+    if HEAD_DIM_K != original_head_dim:
+        out = out[..., :original_head_dim]
+    return (out, lse, philox_seed, philox_offset, p)
+
+
+# Adapted from https://github.com/vllm-project/flash-attention/blob/main/vllm_flash_attn/flash_attn_interface.py
+def maybe_contiguous(x):
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+
+
+def flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    max_seqlen_q,
+    cu_seqlens_q,
+    max_seqlen_k,
+    cu_seqlens_k=None,  # only used for non-paged prefill
+    seqused_k=None,
+    q_v=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=None,
+    softcap=0.0,  # 0.0 means deactivated
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    block_table=None,
+    return_softmax_lse=False,
+    out=None,
+    # Dummy FA3 arguments
+    scheduler_metadata=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    s_aux=None,
+    num_splits: int = 0,
+    cp_world_size: int = 1,
+    cp_rank: int = 0,
+    cp_tot_seqused_k=None,
+    fa_version: int = 2,
+):
+    """dropout_p should be set to 0.0 during evaluation
+    Supports multi-query and grouped-query attention (MQA/GQA) by passing in K, V with fewer heads
+    than Q. Note that the number of heads in Q must be divisible by the number of heads in KV.
+    For example, if Q has 6 heads and K, V have 2 heads, head 0, 1, 2 of Q will attention to head
+    0 of K, V, and head 3, 4, 5 of Q will attention to head 1 of K, V.
+
+    If causal=True, the causal mask is aligned to the bottom right corner of the attention matrix.
+    For example, if seqlen_q = 2 and seqlen_k = 5, the causal mask (1 = keep, 0 = masked out) is:
+        1 1 1 1 0
+        1 1 1 1 1
+    If seqlen_q = 5 and seqlen_k = 2, the causal mask is:
+        0 0
+        0 0
+        0 0
+        1 0
+        1 1
+    If the row of the mask is all zero, the output will be zero.
+
+    If window_size != (-1, -1), implements sliding window local attention. Query at position i
+    will only attend to keys between
+    [i + seqlen_k - seqlen_q - window_size[0], i + seqlen_k - seqlen_q + window_size[1]] inclusive.
+
+    Arguments:
+        q: (total_q, nheads, headdim), where total_q = total number of query tokens in the batch.
+        k: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.
+        v: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.
+        cu_seqlens_q: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+           of the sequences in the batch, used to index into q.
+        cu_seqlens_k: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+           of the sequences in the batch, used to index into kv.
+        max_seqlen_q: int. Maximum query sequence length in the batch.
+        max_seqlen_k: int. Maximum key sequence length in the batch.
+        dropout_p: float. Dropout probability.
+        softmax_scale: float. The scaling of QK^T before applying softmax.
+            Default to 1 / sqrt(headdim).
+        causal: bool. Whether to apply causal attention mask (e.g., for auto-regressive modeling).
+        window_size: (left, right). If not (-1, -1), implements sliding window local attention.
+        softcap: float. Anything > 0 activates softcapping attention.
+        alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
+            (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
+            is added to the attention score of query i and key j.
+        deterministic: bool. Whether to use the deterministic implementation of the backward pass,
+            which is slightly slower and uses more memory. The forward pass is always deterministic.
+        return_attn_probs: bool. Whether to return the attention probabilities. This option is for
+           testing only. The returned probabilities are not guaranteed to be correct
+           (they might not have the right scaling).
+    Return:
+        out: (total, nheads, headdim).
+        softmax_lse [optional, if return_softmax_lse=True]: (nheads, total_q_seqlen). The
+            logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
+            normalization factor).
+    """
+    if fa_version != 2:
+        raise RuntimeError("Only FA2 is implemented.")
+    if num_splits > 0:
+        raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
+    if use_c_extension:
+        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        with torch_device_fn.device(q.device):
+            out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                max_seqlen_q,
+                cu_seqlens_q,
+                max_seqlen_k,
+                cu_seqlens_k,
+                seqused_k,
+                q_v,
+                dropout_p,
+                softmax_scale,
+                causal,
+                window_size,
+                softcap,
+                alibi_slopes,
+                deterministic,
+                return_attn_probs,
+                block_table,
+                return_softmax_lse,
+                out,
+                scheduler_metadata,
+                q_descale,
+                k_descale,
+                v_descale,
+                s_aux,
+                num_splits,
+                cp_world_size,
+                cp_rank,
+                cp_tot_seqused_k,
+                fa_version,
+            )
+        return (out_cpp, softmax_lse) if return_softmax_lse else out_cpp
+    else:
+        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC")
+        assert (
+            cu_seqlens_k is not None or seqused_k is not None
+        ), "cu_seqlens_k or seqused_k must be provided"
+        assert (
+            cu_seqlens_k is None or seqused_k is None
+        ), "cu_seqlens_k and seqused_k cannot be provided at the same time"
+        assert (
+            block_table is None or seqused_k is not None
+        ), "seqused_k must be provided if block_table is provided"
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
+        # custom op does not support non-tuple input
+        if window_size is None:
+            real_window_size = (-1, -1)
+        else:
+            assert len(window_size) == 2
+            real_window_size = (window_size[0], window_size[1])
+        q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
+        dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q)
+        max_seqlen_q = (
+            max_seqlen_q.item() if hasattr(max_seqlen_q, "item") else max_seqlen_q
+        )
+        max_seqlen_k = (
+            max_seqlen_k.item() if hasattr(max_seqlen_k, "item") else max_seqlen_k
+        )
+        out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(
+            q,
+            k,
+            v,
+            out,
+            cu_seqlens_q,
+            # cu_seqlens_k not used since we use seqused_k, but flash_api.cpp
+            # still wants it so we pass all zeros
+            dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
+            seqused_k,
+            None,
+            block_table,
+            alibi_slopes,
+            max_seqlen_q,
+            max_seqlen_k,
+            dropout_p,
+            softmax_scale,
+            False,
+            causal,
+            real_window_size[0],
+            real_window_size[1],
+            softcap,
+            return_softmax_lse and dropout_p > 0,
+            None,
+        )
+
+    return (out, softmax_lse) if return_softmax_lse else out
+
+
+def flash_attn_varlen_opt_func(
+    q,
+    k,
+    v,
+    max_seqlen_q,
+    cu_seqlens_q,
+    max_seqlen_k,
+    cu_seqlens_k=None,  # only used for non-paged prefill
+    seqused_k=None,
+    q_v=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=None,
+    softcap=0.0,  # 0.0 means deactivated
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    block_table=None,
+    return_softmax_lse=False,
+    out=None,
+    lse=None,
+    # Dummy FA3 arguments
+    scheduler_metadata=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    s_aux=None,
+    num_splits: int = 0,
+    cp_world_size: int = 1,
+    cp_rank: int = 0,
+    cp_tot_seqused_k=None,
+    fa_version: int = 2,
+):
+    """dropout_p should be set to 0.0 during evaluation
+    Supports multi-query and grouped-query attention (MQA/GQA) by passing in K, V with fewer heads
+    than Q. Note that the number of heads in Q must be divisible by the number of heads in KV.
+    For example, if Q has 6 heads and K, V have 2 heads, head 0, 1, 2 of Q will attention to head
+    0 of K, V, and head 3, 4, 5 of Q will attention to head 1 of K, V.
+
+    If causal=True, the causal mask is aligned to the bottom right corner of the attention matrix.
+    For example, if seqlen_q = 2 and seqlen_k = 5, the causal mask (1 = keep, 0 = masked out) is:
+        1 1 1 1 0
+        1 1 1 1 1
+    If seqlen_q = 5 and seqlen_k = 2, the causal mask is:
+        0 0
+        0 0
+        0 0
+        1 0
+        1 1
+    If the row of the mask is all zero, the output will be zero.
+
+    If window_size != (-1, -1), implements sliding window local attention. Query at position i
+    will only attend to keys between
+    [i + seqlen_k - seqlen_q - window_size[0], i + seqlen_k - seqlen_q + window_size[1]] inclusive.
+
+    Arguments:
+        q: (total_q, nheads, headdim), where total_q = total number of query tokens in the batch.
+        k: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.
+        v: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.
+        cu_seqlens_q: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+           of the sequences in the batch, used to index into q.
+        cu_seqlens_k: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+           of the sequences in the batch, used to index into kv.
+        max_seqlen_q: int. Maximum query sequence length in the batch.
+        max_seqlen_k: int. Maximum key sequence length in the batch.
+        dropout_p: float. Dropout probability.
+        softmax_scale: float. The scaling of QK^T before applying softmax.
+            Default to 1 / sqrt(headdim).
+        causal: bool. Whether to apply causal attention mask (e.g., for auto-regressive modeling).
+        window_size: (left, right). If not (-1, -1), implements sliding window local attention.
+        softcap: float. Anything > 0 activates softcapping attention.
+        alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
+            (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
+            is added to the attention score of query i and key j.
+        deterministic: bool. Whether to use the deterministic implementation of the backward pass,
+            which is slightly slower and uses more memory. The forward pass is always deterministic.
+        return_attn_probs: bool. Whether to return the attention probabilities. This option is for
+           testing only. The returned probabilities are not guaranteed to be correct
+           (they might not have the right scaling).
+    Return:
+        out: (total, nheads, headdim).
+        softmax_lse [optional, if return_softmax_lse=True]: (nheads, total_q_seqlen). The
+            logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
+            normalization factor).
+    """
+    if fa_version != 2:
+        raise RuntimeError("Only FA2 is implemented.")
+    if num_splits > 0:
+        raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
+    if use_c_extension:
+        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        with torch_device_fn.device(q.device):
+            out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                max_seqlen_q,
+                cu_seqlens_q,
+                max_seqlen_k,
+                cu_seqlens_k,
+                seqused_k,
+                q_v,
+                dropout_p,
+                softmax_scale,
+                causal,
+                window_size,
+                softcap,
+                alibi_slopes,
+                deterministic,
+                return_attn_probs,
+                block_table,
+                return_softmax_lse,
+                out,
+                scheduler_metadata,
+                q_descale,
+                k_descale,
+                v_descale,
+                s_aux,
+                num_splits,
+                cp_world_size,
+                cp_rank,
+                cp_tot_seqused_k,
+                fa_version,
+            )
+        return (out_cpp, softmax_lse) if return_softmax_lse else out_cpp
+    else:
+        logger.debug("GEMS FLASH_ATTN_VARLEN_OPT_FUNC")
+        assert (
+            cu_seqlens_k is not None or seqused_k is not None
+        ), "cu_seqlens_k or seqused_k must be provided"
+        assert (
+            cu_seqlens_k is None or seqused_k is None
+        ), "cu_seqlens_k and seqused_k cannot be provided at the same time"
+        assert (
+            block_table is None or seqused_k is not None
+        ), "seqused_k must be provided if block_table is provided"
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
+        # custom op does not support non-tuple input
+        if window_size is None:
+            real_window_size = (-1, -1)
+        else:
+            assert len(window_size) == 2
+            real_window_size = (window_size[0], window_size[1])
+        # q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
+        # dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q)
+        max_seqlen_q = (
+            max_seqlen_q.item() if hasattr(max_seqlen_q, "item") else max_seqlen_q
+        )
+        max_seqlen_k = (
+            max_seqlen_k.item() if hasattr(max_seqlen_k, "item") else max_seqlen_k
+        )
+        out, q, k, v, softmax_lse, *_ = mha_varlan_fwd_opt(
+            q,
+            k,
+            v,
+            out,
+            lse,
+            cu_seqlens_q,
+            # cu_seqlens_k not used since we use seqused_k, but flash_api.cpp
+            # still wants it so we pass all zeros
+            # dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
+            cu_seqlens_q if cu_seqlens_k is None else cu_seqlens_k,
+            seqused_k,
+            None,
+            block_table,
+            alibi_slopes,
+            max_seqlen_q,
+            max_seqlen_k,
+            dropout_p,
+            softmax_scale,
+            False,
+            causal,
+            real_window_size[0],
+            real_window_size[1],
+            softcap,
+            return_softmax_lse and dropout_p > 0,
+            None,
+        )
+
+    return (out, softmax_lse) if return_softmax_lse else out

--- a/src/flag_gems/runtime/backend/_metax/ops/flash_api.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/flash_api.py
@@ -1,0 +1,1321 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+
+import flag_gems
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.random_utils import philox_backend_seed_offset
+
+from .flash_kernel import (
+    block_m_splitkv_heuristic,
+    block_n_splitkv_heuristic,
+    flash_fwd_kernel,
+    flash_fwd_splitkv_combine_kernel,
+    flash_fwd_splitkv_kernel,
+    flash_varlen_fwd_kernel,
+)
+
+logger = logging.getLogger(__name__)
+_debug = False
+
+
+def CHECK_DEVICE(x):
+    assert x.device.type == flag_gems.device
+
+
+class fwd_params:
+    __slots__ = (
+        # pointers and strides
+        "q_ptr",
+        "k_ptr",
+        "v_ptr",
+        "o_ptr",
+        "p_ptr",
+        "softmax_lse_ptr",
+        "q_row_stride",
+        "k_row_stride",
+        "v_row_stride",
+        "q_head_stride",
+        "k_head_stride",
+        "v_head_stride",
+        "o_row_stride",
+        "o_head_stride",
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "is_cu_seqlens_q",
+        "cu_seqlens_q_ptr",
+        "is_cu_seqlens_k",
+        "cu_seqlens_k_ptr",
+        "is_seqused_k",
+        "seqused_k_ptr",
+        # sizes
+        "b",
+        "bk",
+        "h",
+        "hk",
+        "h_hk_ratio",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "d",
+        "d_rounded",
+        # scaling factors
+        "is_softcap",
+        "softcap",
+        "scale_softmax",
+        "scale_softmax_log2",
+        # dropout
+        "is_dropout",
+        "p_dropout",
+        "rp_dropout",
+        "p_dropout_in_uint8_t",
+        "philox_args",
+        "return_softmax",
+        # masking
+        "is_causal",
+        "is_local",
+        "window_size_left",
+        "window_size_right",
+        "seqlenq_ngroups_swapped",
+        "is_paged",
+        # alibi
+        "is_alibi",
+        "alibi_slopes_ptr",
+        "alibi_slopes_batch_stride",
+        # block table
+        "total_q",
+        "page_table_ptr",
+        "page_table_batch_stride",
+        "block_size",
+        "k_page_stride",
+    )
+
+    def __init__(
+        self,
+        q_ptr,
+        k_ptr,
+        v_ptr,
+        o_ptr,
+        p_ptr,
+        softmax_lse_ptr,
+        q_row_stride,
+        k_row_stride,
+        v_row_stride,
+        q_head_stride,
+        k_head_stride,
+        v_head_stride,
+        o_row_stride,
+        o_head_stride,
+        q_batch_stride,
+        k_batch_stride,
+        v_batch_stride,
+        o_batch_stride,
+        is_cu_seqlens_q,
+        cu_seqlens_q_ptr,
+        is_cu_seqlens_k,
+        cu_seqlens_k_ptr,
+        is_seqused_k,
+        seqused_k_ptr,
+        # sizes
+        b,
+        bk,
+        h,
+        hk,
+        h_hk_ratio,
+        seqlen_q,
+        seqlen_k,
+        seqlen_q_rounded,
+        seqlen_k_rounded,
+        d,
+        d_rounded,
+        # scaling factors
+        is_softcap,
+        softcap,
+        scale_softmax,
+        scale_softmax_log2,
+        # dropout
+        is_dropout,
+        p_dropout,
+        rp_dropout,
+        p_dropout_in_uint8_t,
+        philox_args,
+        return_softmax,
+        # masking
+        is_causal,
+        is_local,
+        window_size_left,
+        window_size_right,
+        seqlenq_ngroups_swapped,
+        is_paged,
+        # alibi
+        is_alibi,
+        alibi_slopes_ptr,
+        alibi_slopes_batch_stride,
+        # block table
+        total_q,
+        page_table_ptr,
+        page_table_batch_stride,
+        block_size,
+        k_page_stride,
+    ):
+        self.q_ptr = q_ptr
+        self.k_ptr = k_ptr
+        self.v_ptr = v_ptr
+        self.o_ptr = o_ptr
+        self.p_ptr = p_ptr
+        self.softmax_lse_ptr = softmax_lse_ptr
+        self.q_row_stride = q_row_stride
+        self.k_row_stride = k_row_stride
+        self.v_row_stride = v_row_stride
+        self.q_head_stride = q_head_stride
+        self.k_head_stride = k_head_stride
+        self.v_head_stride = v_head_stride
+        self.o_row_stride = o_row_stride
+        self.o_head_stride = o_head_stride
+        self.q_batch_stride = q_batch_stride
+        self.k_batch_stride = k_batch_stride
+        self.v_batch_stride = v_batch_stride
+        self.o_batch_stride = o_batch_stride
+        self.is_cu_seqlens_q = is_cu_seqlens_q
+        self.cu_seqlens_q_ptr = cu_seqlens_q_ptr
+        self.is_cu_seqlens_k = is_cu_seqlens_k
+        self.cu_seqlens_k_ptr = cu_seqlens_k_ptr
+        self.is_seqused_k = is_seqused_k
+        self.seqused_k_ptr = seqused_k_ptr
+        # sizes
+        self.b = b
+        self.bk = bk
+        self.h = h
+        self.hk = hk
+        self.h_hk_ratio = h_hk_ratio
+        self.seqlen_q = seqlen_q
+        self.seqlen_k = seqlen_k
+        self.seqlen_q_rounded = seqlen_q_rounded
+        self.seqlen_k_rounded = seqlen_k_rounded
+        self.d = d
+        self.d_rounded = d_rounded
+        # scaling factors
+        self.is_softcap = is_softcap
+        self.softcap = softcap
+        self.scale_softmax = scale_softmax
+        self.scale_softmax_log2 = scale_softmax_log2
+        # dropout
+        self.is_dropout = is_dropout
+        self.p_dropout = p_dropout
+        self.rp_dropout = rp_dropout
+        self.p_dropout_in_uint8_t = p_dropout_in_uint8_t
+        self.philox_args = philox_args
+        self.return_softmax = return_softmax
+        # masking
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.window_size_left = window_size_left
+        self.window_size_right = window_size_right
+        self.seqlenq_ngroups_swapped = seqlenq_ngroups_swapped
+        self.is_paged = is_paged
+        # alibi
+        self.is_alibi = is_alibi
+        self.alibi_slopes_ptr = alibi_slopes_ptr
+        self.alibi_slopes_batch_stride = alibi_slopes_batch_stride
+        # block table
+        self.total_q = total_q
+        self.page_table_ptr = page_table_ptr
+        self.page_table_batch_stride = page_table_batch_stride
+        self.block_size = block_size
+        self.k_page_stride = k_page_stride
+
+    def args(self):
+        return tuple(getattr(self, k) for k in self.__slots__)
+
+
+def mha_varlan_fwd(
+    q,
+    k,
+    v,
+    out,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_k,
+    leftpad_k,
+    page_table,
+    alibi_slopes,
+    max_seqlen_q,
+    max_seqlen_k,
+    p_dropout,
+    softmax_scale,
+    zero_tensors,
+    is_causal,
+    window_size_left,
+    window_size_right,
+    softcap,
+    return_softmax,
+    gen,
+):
+    CHECK_DEVICE(q), CHECK_DEVICE(k), CHECK_DEVICE(v)
+    q_device = q.device
+    q_dtype = q.dtype
+    assert q_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), "FlashAttention only support fp16 and bf16 data type"
+    assert q_dtype == k.dtype
+    assert q_dtype == v.dtype
+    assert q.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert k.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert v.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+
+    assert cu_seqlens_q.dtype == torch.int32
+    assert cu_seqlens_q.is_contiguous()
+
+    assert cu_seqlens_k.dtype == torch.int32
+    assert cu_seqlens_k.is_contiguous()
+
+    is_paged = page_table is not None
+    if not is_paged:
+        page_table = torch.empty((0, 0), device=q_device, dtype=torch.int32)
+
+    # q shape: [total_q_tokens, num_heads, head_size]
+    # k shape:
+    #   paged_kv: [num_pages, block_size, num_heads_k, head_size]
+    # batch_size, number of sentences
+    total_q, num_heads, head_size = q.size()
+    num_heads_k = k.size(2) if is_paged else k.size(1)
+    batch_size = cu_seqlens_q.numel() - 1
+    block_size = k.size(1) if is_paged else 1
+    num_pages = k.size(0) if is_paged else 0
+    k_batch_size = num_pages
+    # max_num_pages_per_seq = page_table.size(1)
+    page_table_batch_stride = page_table.stride(0)
+    k_batch_stride = k.stride(0)
+    v_batch_stride = v.stride(0)
+
+    assert k.size() == v.size()
+    assert cu_seqlens_q.size() == (batch_size + 1,)
+    assert cu_seqlens_k.size() == (batch_size + 1,)
+
+    # Check output shape
+    if out is not None:
+        assert out.stride(-1) == 1
+        assert out.dtype == q.dtype
+        assert out.size() == (total_q, num_heads, head_size)
+
+    if seqused_k is not None:
+        assert seqused_k.is_contiguous()
+        assert seqused_k.size() == (batch_size,)
+
+    if max_seqlen_q == 1 and alibi_slopes is None:
+        is_causal = False
+
+    if is_causal:
+        window_size_right = 0
+
+    # check disable swa
+    if window_size_left >= max_seqlen_k:
+        window_size_left = -1
+    if window_size_right >= max_seqlen_k:
+        window_size_right = -1
+
+    is_local = window_size_left >= 0
+
+    # Optimize all single-query sequences by swapping the query-group and sequence dimensions
+    seqlenq_ngroups_swapped = (
+        max_seqlen_q == 1
+        and alibi_slopes is None
+        and num_heads > num_heads_k
+        and window_size_left < 0
+        and window_size_right < 0
+        and p_dropout == 0
+    )
+    q_groups = num_heads // num_heads_k
+    if seqlenq_ngroups_swapped:
+        logger.debug("Swapping query groups and sequence dimensions")
+        q = (
+            q.reshape((batch_size, num_heads_k, q_groups, head_size))
+            .transpose(1, 2)
+            .reshape(batch_size * q_groups, num_heads_k, head_size)
+        )
+        max_seqlen_q = q_groups
+        num_heads = num_heads_k
+        cu_seqlens_q = None
+        q_batch_stride = q.stride(0) * max_seqlen_q
+        k_batch_stride = k.stride(0)
+        v_batch_stride = v.stride(0)
+        # o_batch_stride = out.stride(0) * max_seqlen_q
+    else:
+        q_batch_stride = 0
+        k_batch_stride = 0
+        v_batch_stride = 0
+        o_batch_stride = 0
+
+    total_q = q.size(0)
+
+    assert leftpad_k is None, "leftpad_k is not supported."
+    assert (
+        head_size <= 256
+    ), "FlashAttention forward only supports head dimension at most 256"
+    assert (
+        head_size % 8 == 0
+    ), "head_size must be a multiple of 8, this is ensured by padding!"
+    assert (
+        num_heads % num_heads_k == 0
+    ), "Number of heads in key/value must divide number of heads in query"
+
+    assert q.shape == (total_q, num_heads, head_size)
+    if is_paged:
+        assert k.shape == (num_pages, block_size, num_heads_k, head_size)
+        assert v.shape == (num_pages, block_size, num_heads_k, head_size)
+    assert k.stride() == v.stride()
+
+    if softcap > 0.0:
+        assert p_dropout == 0, "dropout is not supported if softcap is used."
+
+    round_multiple = lambda x, m: (x + m - 1) // m * m
+    head_size_rounded = round_multiple(head_size, 32) if head_size <= 192 else 256
+    seqlen_q_rounded = round_multiple(max_seqlen_q, 128)
+    seqlen_k_rounded = round_multiple(max_seqlen_k, 32)
+
+    M_LOG2E = 1.4426950408889634074
+    if softcap > 0.0:
+        is_softcap = True
+        adjusted_scale_softmax = softcap
+        adjusted_softcap = softmax_scale / softcap
+        adjusted_scale_softmax_log2e = softcap * M_LOG2E
+    else:
+        is_softcap = False
+        adjusted_softcap = 0.0
+        adjusted_scale_softmax = softmax_scale
+        adjusted_scale_softmax_log2e = softmax_scale * M_LOG2E
+
+    # Set alibi params
+    if alibi_slopes is not None:
+        assert alibi_slopes.device == q_device
+        assert alibi_slopes.dtype in (torch.float,)
+        assert alibi_slopes.stride(-1) == 1
+        assert alibi_slopes.shape == (num_heads,) or alibi_slopes.shape == (
+            batch_size,
+            num_heads,
+        )
+        alibi_slopes_batch_stride = (
+            alibi_slopes.stride(0) if alibi_slopes.ndim == 2 else 0
+        )
+        is_alibi = True
+    else:
+        alibi_slopes_batch_stride = 0
+        is_alibi = False
+
+    # Prepare params to kernel
+    with torch_device_fn.device(q_device):
+        if out is not None:
+            out_ = out
+            if seqlenq_ngroups_swapped:
+                out = torch.empty_like(q, dtype=v.dtype)
+        else:
+            out_ = None
+            out = torch.empty_like(q, dtype=v.dtype)
+
+        if seqlenq_ngroups_swapped:
+            o_batch_stride = out.stride(0) * max_seqlen_q
+
+        lse = torch.empty((num_heads, total_q), dtype=torch.float, device=q_device)
+
+        if p_dropout > 0:
+            is_dropout = True
+            increment = batch_size * num_heads * 32
+            philox_seed, philox_offset = philox_backend_seed_offset(increment)
+            philox_args = torch.tensor(
+                [philox_seed, philox_offset], dtype=torch.int64, device=q_device
+            )
+        else:
+            is_dropout = False
+            philox_args = torch.empty((2,), dtype=torch.int64, device=q_device)
+
+        p_dropout = 1 - p_dropout
+        p_dropout_in_uint8_t = math.floor(p_dropout * 255.0)
+        rp_dropout = 1.0 / p_dropout
+
+        if return_softmax:
+            assert is_dropout, "Only supported with non-zero dropout."
+            p = torch.empty(
+                (batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded),
+                device=q_device,
+            )
+        else:
+            p = torch.empty((), device=q_device)
+
+        if zero_tensors:
+            out.zero_()
+            lse.fill_(float("-inf"))
+
+        params = fwd_params(
+            q,  # q_ptr,
+            k,  # k_ptr,
+            v,  # v_ptr,
+            out,  # o_ptr,
+            p,  # p_ptr,
+            lse,  # softmax_lse_ptr,
+            q.stride(-3),  # q_row_stride,
+            k.stride(-3),  # k_row_stride,
+            v.stride(-3),  # v_row_stride,
+            q.stride(-2),  # q_head_stride,
+            k.stride(-2),  # k_head_stride,
+            v.stride(-2),  # v_head_stride,
+            out.stride(-3),  # o_row_stride,
+            out.stride(-2),  # o_head_stride,
+            q_batch_stride,  # q_batch_stride,
+            k_batch_stride,  # k_batch_stride,
+            v_batch_stride,  # v_batch_stride,
+            o_batch_stride,  # o_batch_stride,
+            cu_seqlens_q is not None,  # is_cu_seqlens_q,
+            cu_seqlens_q,  # cu_seqlens_q_ptr,
+            seqused_k is None,  # is_cu_seqlens_k,
+            cu_seqlens_k,  # cu_seqlens_k_ptr,
+            seqused_k is not None,  # is_seqused_k,
+            seqused_k,  # seqused_k_ptr,
+            # sizes
+            batch_size,  # b,
+            k_batch_size,  # bk,
+            num_heads,  # h,
+            num_heads_k,  # hk,
+            num_heads // num_heads_k,  # h_hk_ratio,
+            max_seqlen_q,  # seqlen_q,
+            max_seqlen_k,  # seqlen_k,
+            seqlen_q_rounded,  # seqlen_q_rounded,
+            seqlen_k_rounded,  # seqlen_k_rounded,
+            head_size,  # d,
+            head_size_rounded,  # d_rounded,
+            # scaling factors
+            is_softcap,
+            adjusted_softcap,  # softcap,
+            adjusted_scale_softmax,  # scale_softmax,
+            adjusted_scale_softmax_log2e,  # scale_softmax_log2,
+            # dropout
+            is_dropout,
+            p_dropout,
+            rp_dropout,
+            p_dropout_in_uint8_t,
+            philox_args,
+            return_softmax,
+            # causal and swa
+            is_causal,  # is_causal,
+            is_local,  # is_local,
+            window_size_left,  # window_size_left,
+            window_size_right,  # window_size_right,
+            seqlenq_ngroups_swapped,  # seqlenq_ngroups_swapped,
+            is_paged,
+            # alibi
+            is_alibi,  #
+            alibi_slopes,  # alibi_slopes_ptr,
+            alibi_slopes_batch_stride,  # alibi_slopes_batch_stride,
+            # block table params
+            total_q,  # total_q,
+            page_table,  # page_table_ptr,
+            page_table_batch_stride,  # page_table_batch_stride,
+            block_size,  # block_size,
+            k.stride(0) if is_paged else 0,  # k_page_stride,
+        )
+
+        if flag_gems.vendor_name == "iluvatar":
+            params.k_ptr = k.view(k.shape[0], k.shape[1], -1)
+            params.v_ptr = v.view(v.shape[0], v.shape[1], -1)
+        logger.debug("kernel: flash_varlen_fwd")
+        args = tuple(getattr(params, k) for k in params.__slots__)
+
+        # We assess which phase the requests are likely to be in and set the config accordingly.
+        total_rows = total_q * num_heads
+        num_sms = torch_device_fn.get_device_properties(
+            flag_gems.device
+        ).multi_processor_count
+        avg_rows_per_sm = total_rows / num_sms
+        avg_rows_per_batch = total_q / batch_size
+        avg_rows_per_cta = min(avg_rows_per_batch, avg_rows_per_sm)
+        # Heuristic: if avg_rows_per_sm >= 128, we are likely in prefill phase.
+        # This is a rough heuristic and may not be accurate for all scenarios.
+        if avg_rows_per_cta > 64:
+            varlen_fwd_config_str = "mha_block_128"
+        elif avg_rows_per_cta > 32:
+            varlen_fwd_config_str = "mha_block_64"
+        elif avg_rows_per_cta > 16:
+            varlen_fwd_config_str = "mha_block_32"
+        else:
+            varlen_fwd_config_str = "mha_block_16"
+        if flag_gems.vendor_name == "mthreads":
+            varlen_fwd_config_str = "mha_block_32"
+
+        cfg = runtime.get_heuristic_config(varlen_fwd_config_str)
+        cfg_params = {
+            "BLOCK_M": cfg["BLOCK_M"](args),
+            "BLOCK_N": cfg["BLOCK_N"](args),
+            "BLOCK_K": triton.next_power_of_2(head_size),
+            "num_warps": cfg["num_warps"](args),
+            "num_stages": 1 if not is_paged else cfg["num_stages"](args),
+        }
+        rectangular_mblocks = (
+            triton.cdiv(max_seqlen_q, cfg_params["BLOCK_M"])
+            * batch_size
+        )
+        compact_m_upper = (
+            triton.cdiv(total_q, cfg_params["BLOCK_M"])
+            + batch_size
+            - 1
+        )
+        cfg_params["COMPACT_RAGGED"] = (
+            flag_gems.vendor_name == "metax"
+            and is_paged
+            and cu_seqlens_q is not None
+            and not seqlenq_ngroups_swapped
+            and compact_m_upper < rectangular_mblocks
+        )
+        cfg_params["LPT_RAGGED"] = (
+            cfg_params["COMPACT_RAGGED"]
+            and is_causal
+            and not is_local
+            and max_seqlen_q > cfg_params["BLOCK_M"]
+        )
+
+        if cfg_params["COMPACT_RAGGED"]:
+            grid = (compact_m_upper * num_heads, 1, 1)
+        else:
+            grid = (
+                triton.cdiv(max_seqlen_q, cfg_params["BLOCK_M"]),
+                batch_size,
+                num_heads,
+            )
+        kernel = flash_varlen_fwd_kernel[grid]
+
+        logger.debug("Running flash_varlen_fwd_kernel with config: %s", cfg_params)
+        kernel(*args, **cfg_params)
+
+        if seqlenq_ngroups_swapped:
+            out = out.reshape(
+                batch_size, max_seqlen_q, num_heads_k, head_size
+            ).transpose(1, 2)
+            if out_ is not None:
+                out_.view(batch_size, num_heads_k, max_seqlen_q, head_size).copy_(out)
+                out = out_
+            else:
+                out = out.reshape(batch_size, num_heads_k * max_seqlen_q, head_size)
+            lse = lse.reshape(num_heads_k, batch_size, max_seqlen_q)
+            lse = lse.reshape(num_heads_k * max_seqlen_q, batch_size)
+
+        unused = torch.empty((), dtype=torch.int64, device=q_device)
+    return out, q, k, v, lse, philox_args, unused, p
+
+
+def mha_varlan_fwd_opt(
+    q,
+    k,
+    v,
+    out,
+    lse,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_k,
+    leftpad_k,
+    page_table,
+    alibi_slopes,
+    max_seqlen_q,
+    max_seqlen_k,
+    p_dropout,
+    softmax_scale,
+    zero_tensors,
+    is_causal,
+    window_size_left,
+    window_size_right,
+    softcap,
+    return_softmax,
+    gen,
+):
+    CHECK_DEVICE(q), CHECK_DEVICE(k), CHECK_DEVICE(v)
+    q_device = q.device
+    q_dtype = q.dtype
+    assert q_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), "FlashAttention only support fp16 and bf16 data type"
+    assert q_dtype == k.dtype
+    assert q_dtype == v.dtype
+    assert q.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert k.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert v.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+
+    assert cu_seqlens_q.dtype == torch.int32
+    assert cu_seqlens_q.is_contiguous()
+
+    assert cu_seqlens_k.dtype == torch.int32
+    assert cu_seqlens_k.is_contiguous()
+
+    is_paged = page_table is not None
+    if not is_paged:
+        page_table = torch.emtpty((0, 0), device=q_device, dtype=torch.int32)
+
+    # q shape: [total_q_tokens, num_heads, head_size]
+    # k shape:
+    #   paged_kv: [num_pages, block_size, num_heads_k, head_size]
+    # batch_size, number of sentences
+    total_q, num_heads, head_size = q.size()
+    num_heads_k = k.size(2) if is_paged else k.size(1)
+    batch_size = cu_seqlens_q.numel() - 1
+    block_size = k.size(1) if is_paged else 1
+    num_pages = k.size(0) if is_paged else 0
+    k_batch_size = num_pages
+    # max_num_pages_per_seq = page_table.size(1)
+    page_table_batch_stride = page_table.stride(0)
+    k_batch_stride = k.stride(0)
+    v_batch_stride = v.stride(0)
+
+    assert k.size() == v.size()
+    assert cu_seqlens_q.size() == (batch_size + 1,)
+    assert cu_seqlens_k.size() == (batch_size + 1,)
+
+    # Check output shape
+    if out is not None:
+        assert out.stride(-1) == 1
+        assert out.dtype == q.dtype
+        assert out.size() == (total_q, num_heads, head_size)
+
+    if seqused_k is not None:
+        assert seqused_k.is_contiguous()
+        assert seqused_k.size() == (batch_size,)
+
+    if max_seqlen_q == 1 and alibi_slopes is None:
+        is_causal = False
+
+    if is_causal:
+        window_size_right = 0
+
+    # check disable swa
+    if window_size_left >= max_seqlen_k:
+        window_size_left = -1
+    if window_size_right >= max_seqlen_k:
+        window_size_right = -1
+
+    is_local = window_size_left >= 0
+
+    # Optimize all single-query sequences by swapping the query-group and sequence dimensions
+    seqlenq_ngroups_swapped = (
+        max_seqlen_q == 1
+        and alibi_slopes is None
+        and num_heads > num_heads_k
+        and window_size_left < 0
+        and window_size_right < 0
+        and p_dropout == 0
+    )
+    q_groups = num_heads // num_heads_k
+    if seqlenq_ngroups_swapped:
+        logger.debug("Swapping query groups and sequence dimensions")
+        q = (
+            q.reshape((batch_size, num_heads_k, q_groups, head_size))
+            .transpose(1, 2)
+            .reshape(batch_size * q_groups, num_heads_k, head_size)
+        )
+        max_seqlen_q = q_groups
+        num_heads = num_heads_k
+        cu_seqlens_q = None
+        q_batch_stride = q.stride(0) * max_seqlen_q
+        k_batch_stride = k.stride(0)
+        v_batch_stride = v.stride(0)
+        # o_batch_stride = out.stride(0) * max_seqlen_q
+    else:
+        q_batch_stride = 0
+        k_batch_stride = 0
+        v_batch_stride = 0
+        o_batch_stride = 0
+
+    total_q = q.size(0)
+
+    assert leftpad_k is None, "leftpad_k is not supported."
+    assert (
+        head_size <= 256
+    ), "FlashAttention forward only supports head dimension at most 256"
+    assert (
+        head_size % 8 == 0
+    ), "head_size must be a multiple of 8, this is ensured by padding!"
+    assert (
+        num_heads % num_heads_k == 0
+    ), "Number of heads in key/value must divide number of heads in query"
+
+    assert q.shape == (total_q, num_heads, head_size)
+    if is_paged:
+        assert k.shape == (num_pages, block_size, num_heads_k, head_size)
+        assert v.shape == (num_pages, block_size, num_heads_k, head_size)
+    assert k.stride() == v.stride()
+
+    if softcap > 0.0:
+        assert p_dropout == 0, "dropout is not supported if softcap is used."
+
+    round_multiple = lambda x, m: (x + m - 1) // m * m
+    head_size_rounded = round_multiple(head_size, 32) if head_size <= 192 else 256
+    seqlen_q_rounded = round_multiple(max_seqlen_q, 128)
+    seqlen_k_rounded = round_multiple(max_seqlen_k, 32)
+
+    M_LOG2E = 1.4426950408889634074
+    if softcap > 0.0:
+        is_softcap = True
+        adjusted_scale_softmax = softcap
+        adjusted_softcap = softmax_scale / softcap
+        adjusted_scale_softmax_log2e = softcap * M_LOG2E
+    else:
+        is_softcap = False
+        adjusted_softcap = 0.0
+        adjusted_scale_softmax = softmax_scale
+        adjusted_scale_softmax_log2e = softmax_scale * M_LOG2E
+
+    # Set alibi params
+    if alibi_slopes is not None:
+        assert alibi_slopes.device == q_device
+        assert alibi_slopes.dtype in (torch.float,)
+        assert alibi_slopes.stride(-1) == 1
+        assert alibi_slopes.shape == (num_heads,) or alibi_slopes.shape == (
+            batch_size,
+            num_heads,
+        )
+        alibi_slopes_batch_stride = (
+            alibi_slopes.stride(0) if alibi_slopes.ndim == 2 else 0
+        )
+        is_alibi = True
+    else:
+        alibi_slopes_batch_stride = 0
+        is_alibi = False
+
+    # Prepare params to kernel
+    with torch_device_fn.device(q_device):
+        if out is not None:
+            out_ = out
+            if seqlenq_ngroups_swapped:
+                out = torch.empty_like(q, dtype=v.dtype)
+        else:
+            out_ = None
+            out = torch.empty_like(q, dtype=v.dtype)
+
+        if seqlenq_ngroups_swapped:
+            o_batch_stride = out.stride(0) * max_seqlen_q
+
+        if lse is None:
+            lse = torch.empty((num_heads, total_q), dtype=torch.float, device=q_device)
+
+        if p_dropout > 0:
+            is_dropout = True
+            increment = batch_size * num_heads * 32
+            philox_seed, philox_offset = philox_backend_seed_offset(increment)
+            philox_args = torch.tensor(
+                [philox_seed, philox_offset], dtype=torch.int64, device=q_device
+            )
+        else:
+            is_dropout = False
+            # philox_args = torch.empty((2,), dtype=torch.int64, device=q_device)
+            philox_args = None
+
+        p_dropout = 1 - p_dropout
+        p_dropout_in_uint8_t = math.floor(p_dropout * 255.0)
+        rp_dropout = 1.0 / p_dropout
+
+        if return_softmax:
+            assert is_dropout, "Only supported with non-zero dropout."
+            p = torch.empty(
+                (batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded),
+                device=q_device,
+            )
+        else:
+            # p = torch.empty((), device=q_device)
+            p = None
+        if zero_tensors:
+            out.zero_()
+            lse.fill_(float("-inf"))
+
+        params = fwd_params(
+            q,  # q_ptr,
+            k,  # k_ptr,
+            v,  # v_ptr,
+            out,  # o_ptr,
+            p,  # p_ptr,
+            lse,  # softmax_lse_ptr,
+            q.stride(-3),  # q_row_stride,
+            k.stride(-3),  # k_row_stride,
+            v.stride(-3),  # v_row_stride,
+            q.stride(-2),  # q_head_stride,
+            k.stride(-2),  # k_head_stride,
+            v.stride(-2),  # v_head_stride,
+            out.stride(-3),  # o_row_stride,
+            out.stride(-2),  # o_head_stride,
+            q_batch_stride,  # q_batch_stride,
+            k_batch_stride,  # k_batch_stride,
+            v_batch_stride,  # v_batch_stride,
+            o_batch_stride,  # o_batch_stride,
+            cu_seqlens_q is not None,  # is_cu_seqlens_q,
+            cu_seqlens_q,  # cu_seqlens_q_ptr,
+            cu_seqlens_k is not None,  # is_cu_seqlens_k,
+            cu_seqlens_k,  # cu_seqlens_k_ptr,
+            seqused_k is not None,  # is_seqused_k,
+            seqused_k,  # seqused_k_ptr,
+            # sizes
+            batch_size,  # b,
+            k_batch_size,  # bk,
+            num_heads,  # h,
+            num_heads_k,  # hk,
+            num_heads // num_heads_k,  # h_hk_ratio,
+            max_seqlen_q,  # seqlen_q,
+            max_seqlen_k,  # seqlen_k,
+            seqlen_q_rounded,  # seqlen_q_rounded,
+            seqlen_k_rounded,  # seqlen_k_rounded,
+            head_size,  # d,
+            head_size_rounded,  # d_rounded,
+            # scaling factors
+            is_softcap,
+            adjusted_softcap,  # softcap,
+            adjusted_scale_softmax,  # scale_softmax,
+            adjusted_scale_softmax_log2e,  # scale_softmax_log2,
+            # dropout
+            is_dropout,
+            p_dropout,
+            rp_dropout,
+            p_dropout_in_uint8_t,
+            philox_args,
+            return_softmax,
+            # causal and swa
+            is_causal,  # is_causal,
+            is_local,  # is_local,
+            window_size_left,  # window_size_left,
+            window_size_right,  # window_size_right,
+            seqlenq_ngroups_swapped,  # seqlenq_ngroups_swapped,
+            is_paged,
+            # alibi
+            is_alibi,  #
+            alibi_slopes,  # alibi_slopes_ptr,
+            alibi_slopes_batch_stride,  # alibi_slopes_batch_stride,
+            # block table params
+            total_q,  # total_q,
+            page_table,  # page_table_ptr,
+            page_table_batch_stride,  # page_table_batch_stride,
+            block_size,  # block_size,
+            k.stride(0) if is_paged else 0,  # k_page_stride,
+        )
+
+        if flag_gems.vendor_name == "iluvatar":
+            params.k_ptr = k.view(k.shape[0], k.shape[1], -1)
+            params.v_ptr = v.view(v.shape[0], v.shape[1], -1)
+        logger.debug("kernel: flash_varlen_fwd")
+        grid = lambda args: (
+            triton.cdiv(max_seqlen_q, args["BLOCK_M"]),
+            batch_size,
+            num_heads,
+        )
+        kernel = flash_varlen_fwd_kernel[grid]
+        args = tuple(getattr(params, k) for k in params.__slots__)
+
+        # We assess which phase the requests are likely to be in and set the config accordingly.
+        total_rows = total_q * num_heads
+        num_sms = torch_device_fn.get_device_properties(
+            flag_gems.device
+        ).multi_processor_count
+        avg_rows_per_sm = total_rows / num_sms
+        avg_rows_per_batch = total_q / batch_size
+        avg_rows_per_cta = min(avg_rows_per_batch, avg_rows_per_sm)
+        # Heuristic: if avg_rows_per_sm >= 128, we are likely in prefill phase.
+        # This is a rough heuristic and may not be accurate for all scenarios.
+        if avg_rows_per_cta > 64:
+            varlen_fwd_config_str = "mha_block_128"
+        elif avg_rows_per_cta > 32:
+            varlen_fwd_config_str = "mha_block_64"
+        elif avg_rows_per_cta > 16:
+            varlen_fwd_config_str = "mha_block_32"
+        else:
+            varlen_fwd_config_str = "mha_block_16"
+        if flag_gems.vendor_name == "mthreads":
+            varlen_fwd_config_str = "mha_block_32"
+
+        cfg = runtime.get_heuristic_config(varlen_fwd_config_str)
+        cfg_params = {
+            "BLOCK_M": cfg["BLOCK_M"](args),
+            "BLOCK_N": cfg["BLOCK_N"](args),
+            "BLOCK_K": triton.next_power_of_2(head_size),
+            "num_warps": cfg["num_warps"](args),
+            "num_stages": 1 if not is_paged else cfg["num_stages"](args),
+        }
+
+        logger.debug("Running flash_varlen_fwd_kernel with config: %s", cfg_params)
+        kernel(*args, **cfg_params)
+
+        if seqlenq_ngroups_swapped:
+            out = out.reshape(
+                batch_size, max_seqlen_q, num_heads_k, head_size
+            ).transpose(1, 2)
+            if out_ is not None:
+                out_.view(batch_size, num_heads_k, max_seqlen_q, head_size).copy_(out)
+                out = out_
+            else:
+                out = out.reshape(batch_size, num_heads_k * max_seqlen_q, head_size)
+            lse = lse.reshape(num_heads_k, batch_size, max_seqlen_q)
+            lse = lse.reshape(num_heads_k * max_seqlen_q, batch_size)
+
+        # unused = torch.empty((), dtype=torch.int64, device=q_device)
+        unused = None
+    return out, q, k, v, lse, philox_args, unused, p
+
+
+def mha_fwd(
+    q,
+    k,
+    v,
+    out,
+    alibi_slopes,
+    p_dropout,
+    softmax_scale,
+    is_causal,
+    window_size_left,
+    window_size_right,
+    softcap,
+    return_softmax,
+    disable_splitkv=False,
+):
+    CHECK_DEVICE(q), CHECK_DEVICE(k), CHECK_DEVICE(v)
+    q_dtype = q.dtype
+    q_device = q.device
+    assert q_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), "FlashAttention only support fp16 and bf16 data type"
+    assert q_dtype == k.dtype
+    assert q_dtype == v.dtype
+    assert q.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert k.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    assert v.stride(-1) == 1, "Input tensor must have contiguous last dimension"
+    batch_size, seqlen_q, num_heads, head_size = q.size()
+    _, seqlen_k, num_heads_k, _ = k.size()
+
+    # Check output shape
+    if out is not None:
+        assert out.stride(-1) == 1
+        assert out.dtype == q.dtype
+        assert out.size() == (batch_size, seqlen_q, num_heads, head_size)
+        CHECK_DEVICE(out)
+
+    assert (
+        head_size % 8 == 0
+    ), "head_size must be a multiple of 8, this is ensured by padding!"
+    assert (
+        num_heads % num_heads_k == 0
+    ), "Number of heads in key/value must divide number of heads in query"
+    if window_size_left >= seqlen_k:
+        window_size_left = -1
+    if window_size_right >= seqlen_k:
+        window_size_right = -1
+    if seqlen_q == 1 and alibi_slopes is None:
+        is_causal = False
+    if is_causal:
+        window_size_right = 0
+
+    is_causal = window_size_left < 0 and window_size_right == 0
+    is_local = window_size_left >= 0 and window_size_right >= 0
+
+    seqlenq_ngroups_swapped = (
+        seqlen_q == 1
+        and alibi_slopes is None
+        and num_heads > num_heads_k
+        and window_size_left < 0
+        and window_size_right < 0
+        and p_dropout == 0
+    )
+    q_groups = num_heads // num_heads_k
+
+    if seqlenq_ngroups_swapped:
+        logger.debug("q_kg swapped.")
+        q = q.reshape(batch_size, num_heads_k, q_groups, head_size).transpose(1, 2)
+        seqlen_q = q_groups
+        num_heads = num_heads_k
+
+    round_multiple = lambda x, m: (x + m - 1) // m * m
+    head_size_rounded = round_multiple(head_size, 32)
+    seqlen_q_rounded = round_multiple(seqlen_q, 128)
+    seqlen_k_rounded = round_multiple(seqlen_k, 32)
+
+    assert (
+        head_size <= 256
+    ), "FlashAttention forward only supports head dimension at most 256"
+    assert head_size == head_size_rounded, "head_size must be rounded to 32"
+
+    def splits_heuristic(num_tasks, num_sms, n_blocks):
+        # splits when wave efficiency is low
+        n_waves = triton.cdiv(num_tasks, num_sms)
+        eff = (num_tasks / num_sms) / n_waves
+        if eff > 0.8 or n_waves > 1:
+            return 1
+
+        min_blocks_per_split = 2
+        best_splits = min(
+            triton.cdiv(n_blocks, min_blocks_per_split),
+            int(math.floor(1.0 / eff)),
+            num_sms,
+        )
+
+        return best_splits
+
+    with torch_device_fn.device(q_device):
+        # Set softmax params
+        lse = torch.empty(
+            (batch_size, num_heads, seqlen_q), dtype=torch.float, device=q_device
+        )
+
+        if out is not None:
+            if seqlenq_ngroups_swapped:
+                out = out.reshape(
+                    batch_size, num_heads_k, q_groups, head_size
+                ).transpose(1, 2)
+        else:
+            out = torch.empty_like(q, dtype=v.dtype)
+
+        # Set dropout params
+        if p_dropout > 0:
+            is_dropout = True
+            increment = batch_size * num_heads * 32
+            philox_seed, philox_offset = philox_backend_seed_offset(increment)
+            philox_args = torch.tensor(
+                [philox_seed, philox_offset], dtype=torch.int64, device=q_device
+            )
+        else:
+            is_dropout = False
+            philox_args = torch.empty((2,), dtype=torch.int64, device=q_device)
+
+        p_dropout = 1 - p_dropout
+        p_dropout_in_uint8_t = math.floor(p_dropout * 255.0)
+        rp_dropout = 1.0 / p_dropout
+
+        if return_softmax:
+            assert is_dropout, "Only supported with non-zero dropout."
+            p = torch.empty(
+                (batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded),
+                device=q_device,
+            )
+        else:
+            p = torch.empty((), device=q_device)
+
+        M_LOG2E = 1.4426950408889634074
+        if softcap > 0.0:
+            is_softcap = True
+            adjusted_scale_softmax = softcap
+            adjusted_softcap = softmax_scale / softcap
+            adjusted_scale_softmax_log2e = softcap * M_LOG2E
+        else:
+            is_softcap = False
+            adjusted_softcap = 0.0
+            adjusted_scale_softmax = softmax_scale
+            adjusted_scale_softmax_log2e = softmax_scale * M_LOG2E
+
+        # Set alibi params
+        if alibi_slopes is not None:
+            assert alibi_slopes.device == q_device
+            assert alibi_slopes.dtype in (torch.float,)
+            assert alibi_slopes.stride(-1) == 1
+            assert alibi_slopes.shape == (num_heads,) or alibi_slopes.shape == (
+                batch_size,
+                num_heads,
+            )
+            alibi_slopes_batch_stride = (
+                alibi_slopes.stride(0) if alibi_slopes.ndim == 2 else 0
+            )
+            is_alibi = True
+        else:
+            alibi_slopes_batch_stride = 0
+            is_alibi = False
+
+        # ONLY EVEN_K IS SUPPORTED
+        assert head_size == head_size_rounded
+
+        # Do kernel dispatching
+        def dispatch(B, H, Q, K, D, params):
+            num_sms = torch_device_fn.get_device_properties(
+                "cuda"
+            ).multi_processor_count
+
+            # Try bh parallel
+            # if B * H > 0.8 * num_sms:
+            #     kernel = flash_fwd_bh_parallel_kernel[(H, B)]
+            #     # Yield kernel and prefilled args
+            #     return kernel, default_args, None, None
+
+            # Try splitkv
+            if not is_dropout and not is_local and not disable_splitkv:
+                BM = block_m_splitkv_heuristic(D)
+                n_tasks = B * H * triton.cdiv(seqlen_q, BM)
+                BN = block_n_splitkv_heuristic(D)
+                n_blocks = triton.cdiv(seqlen_k, BN)
+                n_splits = splits_heuristic(n_tasks, num_sms, n_blocks)
+
+                if n_splits > 1:
+                    logger.debug("kernel: flash_fwd_splitkv")
+                    lse_splits = torch.empty(
+                        (n_splits, B, H, Q), dtype=torch.float, device=q_device
+                    )
+                    out_splits = torch.empty(
+                        (n_splits, B, H, Q, D), dtype=torch.float, device=q_device
+                    )
+                    grid = lambda args: (
+                        triton.cdiv(Q, args["BLOCK_M"]),
+                        n_splits,
+                        B * H,
+                    )
+                    splitkv_kernel = flash_fwd_splitkv_kernel[grid]
+                    params.o_ptr = out_splits
+                    params.softmax_lse_ptr = lse_splits
+                    extra_args = {"blocks_per_split": triton.cdiv(n_blocks, n_splits)}
+                    kernel = splitkv_kernel(*params.args(), **extra_args)
+
+                    if D >= 128:
+                        BLOCK_M = 4
+                    elif D >= 64:
+                        BLOCK_M = 8
+                    else:
+                        BLOCK_M = 16
+                    BLOCK_K = triton.next_power_of_2(D)
+                    grid = lambda args: (triton.cdiv(B * H * Q, BLOCK_M),)
+                    combine_kernel = flash_fwd_splitkv_combine_kernel[grid]
+                    combine_args = {
+                        "out_ptr": out,
+                        "lse_ptr": lse,
+                        "head_size": head_size,
+                        "out_split_stride": out_splits.stride(0),
+                        "lse_split_stride": lse_splits.stride(0),
+                        "out_b_stride": out.stride(0),
+                        "out_s_stride": out.stride(-3),
+                        "out_h_stride": out.stride(-1),
+                        "out_splits_ptr": out_splits,
+                        "lse_splits_ptr": lse_splits,
+                        "n_splits": n_splits,
+                        "BLOCK_M": BLOCK_M,
+                        "BLOCK_K": BLOCK_K,
+                        "q_total": B * H * Q,
+                        "MAX_N_SPLITS": triton.next_power_of_2(n_splits),
+                    }
+                    combine_kernel(**combine_args)
+                    return kernel
+
+            # Last option: flash_fwd
+            logger.debug("kernel: flash_fwd")
+            grid = lambda args: (
+                triton.cdiv(Q, args["BLOCK_M"]),
+                H * B,
+            )
+            kernel = flash_fwd_kernel[grid]
+            kernel = kernel(*params.args())
+            return kernel
+
+        if _debug:
+            p = torch.empty(
+                (batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded),
+                dtype=torch.float32,
+                device=q_device,
+            )
+            return_softmax = True
+
+        params = fwd_params(
+            q,  # q_ptr,
+            k,  # k_ptr,
+            v,  # v_ptr,
+            out,  # o_ptr,
+            p,  # p_ptr,
+            lse,  # softmax_lse_ptr,
+            q.stride(-3),  # q_row_stride,
+            k.stride(-3),  # k_row_stride,
+            v.stride(-3),  # v_row_stride,
+            q.stride(-2),  # q_head_stride,
+            k.stride(-2),  # k_head_stride,
+            v.stride(-2),  # v_head_stride,
+            out.stride(-3),  # o_row_stride,
+            out.stride(-2),  # o_head_stride,
+            q.stride(0),  # q_batch_stride,
+            k.stride(0),  # k_batch_stride,
+            v.stride(0),  # v_batch_stride,
+            out.stride(0),  # o_batch_stride,
+            False,  # is_cu_seqlens_q,
+            None,  # cu_seqlens_q_ptr,
+            False,  # is_cu_seqlens_k,
+            None,  # cu_seqlens_k_ptr,
+            False,  # is_seqused_k,
+            None,  # seqused_k_ptr,
+            # sizes
+            batch_size,  # b,
+            0,  # bk,
+            num_heads,  # h,
+            num_heads_k,  # hk,
+            num_heads // num_heads_k,  # h_hk_ratio,
+            seqlen_q,  # seqlen_q,
+            seqlen_k,  # seqlen_k,
+            seqlen_q_rounded,  # seqlen_q_rounded,
+            seqlen_k_rounded,  # seqlen_k_rounded,
+            head_size,  # d,
+            head_size_rounded,  # d_rounded,
+            # scaling factors
+            is_softcap,
+            adjusted_softcap,  # softcap,
+            adjusted_scale_softmax,  # scale_softmax,
+            adjusted_scale_softmax_log2e,  # scale_softmax_log2,
+            # dropout
+            is_dropout,
+            p_dropout,
+            rp_dropout,
+            p_dropout_in_uint8_t,
+            philox_args,
+            return_softmax,
+            # causal and swa
+            is_causal,  # is_causal,
+            is_local,  # is_local,
+            window_size_left,  # window_size_left,
+            window_size_right,  # window_size_right,
+            seqlenq_ngroups_swapped,  # seqlenq_ngroups_swapped,
+            False,  # is_paged,
+            # alibi
+            is_alibi,  #
+            alibi_slopes,  # alibi_slopes_ptr,
+            alibi_slopes_batch_stride,  # alibi_slopes_batch_stride,
+            # block table params
+            0,  # total_q,
+            None,  # page_table_ptr,
+            0,  # page_table_batch_stride,
+            0,  # block_size,
+            0,  # k_page_stride,
+        )
+
+        # Move TxD to last dims for correct stride in Triton tt.load
+        if flag_gems.vendor_name == "iluvatar":
+            params.q_ptr = q.transpose(1, 2)
+            params.k_ptr = k.transpose(1, 2)
+            params.v_ptr = v.transpose(1, 2)
+        kernel = dispatch(batch_size, num_heads, seqlen_q, seqlen_k, head_size, params)
+
+        if _debug:
+            print(f"{kernel.name} shared memory:", kernel.metadata.shared)
+            print(f"{kernel.name} num_warps:", kernel.metadata.num_warps)
+            print(f"{kernel.name} num_stages:", kernel.metadata.num_stages)
+            # print(kernel.asm['ttgir'])
+
+        if seqlenq_ngroups_swapped:
+            out = out.transpose(1, 2).reshape(
+                (batch_size, 1, num_heads_k * seqlen_q, head_size)
+            )
+            q = q.transpose(1, 2).reshape(
+                (batch_size, 1, num_heads_k * seqlen_q, head_size)
+            )
+            lse = lse.reshape((batch_size, num_heads_k * seqlen_q, 1))
+
+        unused = torch.empty((), dtype=torch.int64, device=q_device)
+
+    return out, q, k, v, lse, philox_args, unused, p

--- a/src/flag_gems/runtime/backend/_metax/ops/flash_kernel.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/flash_kernel.py
@@ -1,0 +1,1780 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry, tl_extra_shim
+
+
+@triton.jit
+def u64_to_lohi(x):
+    return (x >> 32).to(tl.uint32), (x & 0xFFFFFFFF).to(tl.uint32)
+
+
+@triton.jit
+def u64_from_lohi(lo, hi):
+    return hi.to(tl.uint64) << 32 + lo.to(tl.uint64)
+
+
+@triton.jit
+def philox_(seed, subsequence, offset):
+    kPhilox10A: tl.constexpr = 0x9E3779B9
+    kPhilox10B: tl.constexpr = 0xBB67AE85
+    k0, k1 = u64_to_lohi(seed.to(tl.uint64))
+    c0, c1 = u64_to_lohi(offset.to(tl.uint64))
+    c2, c3 = u64_to_lohi(subsequence.to(tl.uint64))
+
+    # pragma unroll
+    kPhiloxSA: tl.constexpr = 0xD2511F53
+    kPhiloxSB: tl.constexpr = 0xCD9E8D57
+    for _ in tl.static_range(6):
+        res0 = kPhiloxSA * c0.to(tl.uint64)
+        res1 = kPhiloxSB * c2.to(tl.uint64)
+        res0_x, res0_y = u64_to_lohi(res0)
+        res1_x, res1_y = u64_to_lohi(res1)
+        c0, c1, c2, c3 = res1_y ^ c1 ^ k0, res1_x, res0_y ^ c3 ^ k1, res0_x
+        k0 += kPhilox10A
+        k1 += kPhilox10B
+
+    res0 = kPhiloxSA * c0.to(tl.uint64)
+    res1 = kPhiloxSB * c2.to(tl.uint64)
+    res0_x, res0_y = u64_to_lohi(res0)
+    res1_x, res1_y = u64_to_lohi(res1)
+    c0, c1, c2, c3 = res1_y ^ c1 ^ k0, res1_x, res0_y ^ c3 ^ k1, res0_x
+
+    return c0, c1, c2, c3
+
+
+@triton.jit
+def apply_dropout_mask(
+    P,
+    mask,
+    encode_dropout_in_sign_bit: tl.constexpr,
+):
+    if encode_dropout_in_sign_bit:
+        P = tl.where(mask, -P, P)
+    else:
+        P = tl.where(mask, (P * 0).to(P.dtype), P)
+    return P
+
+
+@triton.jit
+def apply_dropout(
+    P,
+    row_start,
+    col_start,
+    n_cols,
+    bid,
+    hid,
+    philox_seed,
+    philox_offset,
+    p_dropout_uint8: tl.constexpr,
+    is_dropout: tl.constexpr,
+    encode_dropout_in_sign_bit: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    if is_dropout:
+        row_start = tl.multiple_of(row_start, BLOCK_M)
+        col_start = tl.multiple_of(col_start, BLOCK_N)
+        row = row_start + tl.arange(0, BLOCK_M)[:, None]
+        # Down scale col_idx by 4
+        col = col_start // 4 + tl.arange(0, BLOCK_N // 4)[None, :]
+
+        subsequence = row.to(tl.uint64) * n_cols + col.to(tl.uint64)
+
+        offset = philox_offset + bid * NUM_HEADS + hid
+        offset += subsequence * 0
+        r0, r1, r2, r3 = philox_(philox_seed, subsequence, offset)
+
+        r = tl.join(tl.join(r0, r1), tl.join(r2, r3)).reshape(BLOCK_M, BLOCK_N)
+
+        mask = (r & 0xFF) >= p_dropout_uint8
+
+        P = apply_dropout_mask(
+            P, mask, encode_dropout_in_sign_bit=encode_dropout_in_sign_bit
+        )
+    return P
+
+
+@triton.jit
+def apply_alibi(
+    S,
+    col_idx,
+    row_idx,
+    max_seqlen_q,
+    max_seqlen_k,
+    is_causal: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slope: tl.constexpr = None,
+):
+    if is_alibi:
+        if is_causal:
+            # The row independent alibi bias renders the same attention output
+            # as with the standard alibi because softmax is shift invariant, i.e.,
+            # softmax(A + bias + const) = softamx(A + bias). The following two
+            # biases are no different if causal is true.
+            # bias_1 = [
+            #   -4, -3, -2,  X, X,
+            #   -4, -3, -2, -1, X,
+            #   -4, -3, -2, -1, 0,
+            # ]
+            # bias_2 = [
+            #   -2, -1, 0,  X,  X,
+            #   -3, -2, -1, 0,  X,
+            #   -4, -3, -2, -1, 0,
+            # ]
+            bias = alibi_slope * (-max_seqlen_k + 1 + col_idx[None, :]).to(tl.float32)
+            S += bias
+        else:
+            bias = -alibi_slope * tl.abs(
+                col_idx[None, :] - max_seqlen_k + max_seqlen_q - row_idx[:, None]
+            ).to(tl.float32)
+            S += bias
+
+    return S
+
+
+@triton.jit
+def apply_mask(
+    S,
+    col_idx,
+    row_idx,
+    max_seqlen_q,
+    max_seqlen_k,
+    window_size_left,
+    window_size_right,
+    is_even_mn: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+):
+    need_mask = is_causal | is_local | (not is_even_mn)
+    # need_mask: tl.constexpr = is_causal | is_local
+    if need_mask:
+        # Extra care should be taken to void one-off errors: both col_lb and col_rb are inclusive!
+        col_lb = max(0, row_idx + max_seqlen_k - max_seqlen_q - window_size_left)
+        col_rb = min(
+            max_seqlen_k - 1, row_idx + max_seqlen_k - max_seqlen_q + window_size_right
+        )
+
+        if is_causal:
+            S = tl.where(col_idx[None, :] > col_rb[:, None], float("-inf"), S)
+
+        if is_local:
+            S = tl.where(
+                (col_idx[None, :] > col_rb[:, None])
+                | (col_idx[None, :] < col_lb[:, None]),
+                float("-inf"),
+                S,
+            )
+
+        if (not is_local) & (not is_causal) & (not is_even_mn):
+            S = tl.where(col_idx[None, :] >= max_seqlen_k, float("-inf"), S)
+
+    return S
+
+
+@triton.jit
+def softmax_rescale(
+    O_acc,
+    S,
+    row_max,
+    row_sum,
+    softmax_scale_log2e: tl.constexpr,
+    is_border: tl.constexpr,
+    # is_init: tl.constexpr
+):
+    prev_max = row_max
+    row_max = tl.maximum(row_max, tl.max(S, 1))
+
+    if is_border:
+        cur_max = tl.where(row_max == float("-inf"), 0, row_max)
+    else:
+        cur_max = row_max
+
+    p_scale = tl.math.exp2((prev_max - cur_max) * softmax_scale_log2e)
+    row_sum *= p_scale
+    O_acc *= p_scale[:, None]
+
+    max_scaled = tl.where(row_max == float("-inf"), 0, row_max * softmax_scale_log2e)
+    P = tl.math.exp2(S * softmax_scale_log2e - max_scaled[:, None])
+    row_sum = row_sum + tl.sum(P, 1)
+    return O_acc, P, row_max, row_sum
+
+
+@triton.jit
+def apply_softcap(S, softcap, is_softcap: tl.constexpr):
+    if is_softcap:
+        S = tl_extra_shim.tanh(S * softcap)
+
+    return S
+
+
+def block_m_splitkv_heuristic(headdim):
+    return 128 if headdim <= 128 else 64
+
+
+def block_n_splitkv_heuristic(headdim):
+    return 64 if headdim <= 64 else 32
+
+
+def is_even_mn(M, N, BM, BN, WL, WR):
+    if M % BM == 0 and N % BN == 0:
+        if M % N == 0 or N % M == 0:
+            if (WL == -1 or WL % BN == 0) and (WR == -1 or WR % BN == 0):
+                return True
+    return False
+
+
+def block_m_splitkv_heuristic_spec_args(args):
+    return 128 if args["d"] <= 128 else 64
+
+
+def block_n_splitkv_heuristic_spec_args(args):
+    return 64 if args["d"] <= 64 else 32
+
+
+def is_even_mn_spec_args(args):
+    if (
+        args["seqlen_q"] % args["BLOCK_M"] == 0
+        and args["seqlen_k"] % args["BLOCK_N"] == 0
+    ):
+        if (
+            args["seqlen_q"] % args["seqlen_k"] == 0
+            or args["seqlen_k"] % args["seqlen_q"] == 0
+        ):
+            if (
+                args["window_size_left"] == -1
+                or args["window_size_left"] % args["BLOCK_N"] == 0
+            ) and (
+                args["window_size_right"] == -1
+                or args["window_size_right"] % args["BLOCK_N"] == 0
+            ):
+                return True
+    return False
+
+
+def keep(cfg, must_keep=None):
+    BM = cfg.kwargs["BLOCK_M"]
+    BN = cfg.kwargs["BLOCK_N"]
+    w = cfg.num_warps
+
+    # we always keep configurations in `must_keep`
+    return (BM, BN, w) in ((128, 32, 4), (128, 128, 8)) or (
+        must_keep and cfg in must_keep
+    )
+
+
+def prune_fwd_configs(configs, nargs, **kwargs):
+    is_dropout = nargs["is_dropout"]
+    if is_dropout:
+        return list(
+            filter(lambda cfg: cfg.num_warps == 4 and cfg.num_stages < 4, configs)
+        )
+    else:
+        return configs
+
+
+def flash_fwd_kernel_heur_block_k(args):
+    return triton.next_power_of_2(args["d"])
+
+
+@libentry()
+@triton.autotune(
+    configs=list(filter(keep, runtime.get_tuned_config("attention"))),
+    prune_configs_by={"early_config_prune": prune_fwd_configs},
+    key=["d", "is_dropout"],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": flash_fwd_kernel_heur_block_k,
+        "PRE_LOAD_V": lambda args: False,
+        "IS_EVEN_MN": lambda args: is_even_mn(
+            args["seqlen_q"],
+            args["seqlen_k"],
+            args["BLOCK_M"],
+            args["BLOCK_N"],
+            args["window_size_left"],
+            args["window_size_right"],
+        ),
+    }
+)
+@triton.jit(
+    do_not_specialize=["seqlen_q", "seqlen_k", "seqlen_q_rounded", "seqlen_k_rounded"]
+)
+def flash_fwd_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k,
+    cu_seqlens_k_ptr,
+    is_seqused_k,
+    seqused_k_ptr,
+    # sizes
+    b: tl.constexpr,
+    bk: tl.constexpr,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    # scaling factors
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    # dropout
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    # causal and swa
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    # alibi
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    # block table
+    total_q: tl.constexpr,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    k_page_stride: tl.constexpr,
+    # kernel params
+    IS_EVEN_MN: tl.constexpr,
+    PRE_LOAD_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    num_warps: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    m_block = tl.program_id(0)
+    bh = tl.program_id(1)
+    hid = bh % h
+    bid = bh // h
+    num_m_blocks = tl.cdiv(seqlen_q, BLOCK_M)
+
+    # We draw a minimum covering frame on the attention map that this CTA is assigned to process.
+    # The frame edges are rounded to multiples of BLOCK_M and BLOCK_N for rows and columns respectively.
+
+    col_min = 0
+    if is_local:
+        col_min = max(0, m_block * BLOCK_M + seqlen_k - seqlen_q - window_size_left)
+        if not IS_EVEN_MN:
+            # round left
+            col_min = (col_min // BLOCK_N) * BLOCK_N
+
+    col_max = seqlen_k
+    if is_causal or is_local:
+        col_max += (m_block - num_m_blocks + 1) * BLOCK_M
+        if is_local:
+            col_max += window_size_right
+        col_max = min(seqlen_k, col_max)
+
+    if not IS_EVEN_MN:
+        # round right
+        col_max = tl.cdiv(col_max, BLOCK_N) * BLOCK_N
+
+    if (not is_causal) and (not is_local):
+        if IS_EVEN_MN:
+            masking_cols: tl.constexpr = 0
+        else:
+            masking_cols: tl.constexpr = BLOCK_N
+    elif (
+        is_causal | is_local
+    ) and IS_EVEN_MN:  # causal implies window_size_right is zero
+        masking_cols: tl.constexpr = tl.cdiv(BLOCK_M, BLOCK_N) * BLOCK_N
+    else:
+        # local
+        masking_cols: tl.constexpr = (tl.cdiv(BLOCK_M, BLOCK_N) + 1) * BLOCK_N
+
+    if is_dropout:
+        philox_seed = tl.load(philox_args).to(tl.uint64)
+        philox_offset = tl.load(philox_args + 1).to(tl.uint64)
+
+    if is_alibi:
+        alibi_offset = bid * alibi_slopes_batch_stride + hid
+        alibi_slope = tl.load(alibi_slopes_ptr + alibi_offset)
+        alibi_slope /= scale_softmax
+    else:
+        alibi_slope = 0.0
+
+    q_batch_stride = tl.multiple_of(q_batch_stride, d * h)
+    q_ptr += bid * q_batch_stride + hid * q_head_stride
+    row_start = m_block * BLOCK_M
+    row_idx = row_start + tl.arange(0, BLOCK_M)
+    q_off = row_idx[:, None] * q_row_stride + tl.arange(0, BLOCK_K)[None, :]
+    dmask = tl.arange(0, BLOCK_K) < d
+    qmask = dmask[None, :] & (row_idx[:, None] < seqlen_q)
+    if IS_EVEN_MN & d == BLOCK_K:
+        Q = tl.load(q_ptr + q_off, cache_modifier=".cg")
+    else:
+        Q = tl.load(q_ptr + q_off, mask=qmask, cache_modifier=".cg")
+
+    if return_softmax:
+        p_ptr += (
+            (bid * h + hid) * seqlen_q_rounded + m_block * BLOCK_M
+        ) * seqlen_k_rounded
+        p_offset = tl.arange(0, BLOCK_M)[:, None] * seqlen_k_rounded + tl.arange(
+            0, BLOCK_N
+        )
+        p_bp0 = p_ptr + p_offset
+
+    acc_ = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+    rowmax_ = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    rowsum_ = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    k_batch_stride = tl.multiple_of(k_batch_stride, d * hk)
+    h_hk_ratio = h // hk
+    k_ptr += bid * k_batch_stride
+    k_ptr += (hid // h_hk_ratio) * k_head_stride
+    v_ptr += bid * k_batch_stride
+    v_ptr += (hid // h_hk_ratio) * k_head_stride
+
+    k_offset = (
+        tl.arange(0, BLOCK_N)[None, :] * k_row_stride + tl.arange(0, BLOCK_K)[:, None]
+    )
+    v_offset = (
+        tl.arange(0, BLOCK_N)[:, None] * k_row_stride + tl.arange(0, BLOCK_K)[None, :]
+    )
+
+    p_bk0 = k_ptr + k_offset
+    p_bv0 = v_ptr + v_offset
+
+    if is_causal | is_local | (not IS_EVEN_MN):
+        # Cut short masking cols if there's not enough cols out there
+        masking_cols = min(col_max - col_min, masking_cols)
+        for col_shift in tl.range(0, masking_cols, step=BLOCK_N):
+            col_start = col_max - col_shift - BLOCK_N
+            col_start = tl.multiple_of(col_start, BLOCK_N)
+            off = col_start * k_row_stride
+            if IS_EVEN_MN & d == BLOCK_K:
+                K = tl.load(p_bk0 + off, cache_modifier=".cg")
+                if PRE_LOAD_V:
+                    V = tl.load(p_bv0 + off, cache_modifier=".cg")
+            elif d == BLOCK_K:
+                col_idx = col_start + tl.arange(0, BLOCK_N)
+                kvmask = col_idx < seqlen_k
+                K = tl.load(p_bk0 + off, mask=kvmask[None, :], cache_modifier=".cg")
+                if PRE_LOAD_V:
+                    V = tl.load(p_bv0 + off, mask=kvmask[:, None], cache_modifier=".cg")
+            else:
+                col_idx = col_start + tl.arange(0, BLOCK_N)
+                kvmask = col_idx < seqlen_k
+                K = tl.load(
+                    p_bk0 + off,
+                    mask=kvmask[None, :] & dmask[:, None],
+                    cache_modifier=".cg",
+                )
+                if PRE_LOAD_V:
+                    V = tl.load(
+                        p_bv0 + off,
+                        mask=kvmask[:, None] & dmask[None, :],
+                        cache_modifier=".cg",
+                    )
+            S = tl.dot(Q, K, allow_tf32=False)
+            S = apply_softcap(S, softcap, is_softcap)
+            col_idx = col_start + tl.arange(0, BLOCK_N)
+            row_idx = row_start + tl.arange(0, BLOCK_M)
+            S = apply_alibi(
+                S,
+                col_idx,
+                row_idx,
+                seqlen_q,
+                seqlen_k,
+                is_causal=is_causal,
+                is_alibi=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            # tl.store(p_bp0 + col_start, S)
+            S = apply_mask(
+                S,
+                col_idx,
+                row_idx,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                is_even_mn=IS_EVEN_MN,
+                is_causal=is_causal,
+                is_local=is_local,
+            )
+
+            acc_, P, rowmax_, rowsum_ = softmax_rescale(
+                acc_,
+                S,
+                rowmax_,
+                rowsum_,
+                softmax_scale_log2e=scale_softmax_log2,
+                is_border=(is_causal or is_local),
+            )
+            P = P.to(v_ptr.type.element_ty)
+
+            if is_dropout:
+                if return_softmax:
+                    P_drop = P
+
+                    P_drop = apply_dropout(
+                        P_drop,
+                        row_start,
+                        col_start,
+                        seqlen_k,
+                        bid,
+                        hid,
+                        philox_seed,
+                        philox_offset,
+                        p_dropout_in_uint8_t,
+                        is_dropout,
+                        encode_dropout_in_sign_bit=True,
+                        NUM_HEADS=h,
+                        BLOCK_M=BLOCK_M,
+                        BLOCK_N=BLOCK_N,
+                    )
+                    if IS_EVEN_MN:
+                        tl.store(p_bp0 + col_start, P_drop)
+                    else:
+                        kvmask = col_idx < seqlen_k
+                        tl.store(
+                            p_bp0 + col_start, P_drop, mask=qmask & kvmask[None, :]
+                        )
+
+                P = apply_dropout(
+                    P,
+                    row_start,
+                    col_start,
+                    seqlen_k,
+                    bid,
+                    hid,
+                    philox_seed,
+                    philox_offset,
+                    p_dropout_in_uint8_t,
+                    is_dropout,
+                    encode_dropout_in_sign_bit=False,
+                    NUM_HEADS=h,
+                    BLOCK_M=BLOCK_M,
+                    BLOCK_N=BLOCK_N,
+                )
+
+            if not PRE_LOAD_V:
+                off = col_start * k_row_stride
+                if IS_EVEN_MN & d == BLOCK_K:
+                    V = tl.load(p_bv0 + off, cache_modifier=".cg")
+                elif d == BLOCK_K:
+                    kvmask = col_idx < seqlen_k
+                    V = tl.load(p_bv0 + off, mask=kvmask[:, None], cache_modifier=".cg")
+                else:
+                    kvmask = col_idx < seqlen_k
+                    V = tl.load(
+                        p_bv0 + off,
+                        mask=kvmask[:, None] & dmask[None, :],
+                        cache_modifier=".cg",
+                    )
+            acc_ = tl.dot(P, V, acc_, allow_tf32=False)
+
+    for col_start in tl.range(
+        col_min, col_max - masking_cols, step=BLOCK_N, num_stages=num_stages
+    ):
+        col_start = tl.multiple_of(col_start, BLOCK_N)
+        off = col_start * k_row_stride
+        if d == BLOCK_K:
+            K = tl.load(p_bk0 + off, cache_modifier=".cg")
+            if PRE_LOAD_V:
+                V = tl.load(p_bv0 + off, cache_modifier=".cg")
+        else:
+            K = tl.load(p_bk0 + off, mask=dmask[:, None], cache_modifier=".cg")
+            if PRE_LOAD_V:
+                V = tl.load(p_bv0 + off, mask=dmask[None, :], cache_modifier=".cg")
+
+        S = tl.dot(Q, K)
+        S = apply_softcap(S, softcap, is_softcap)
+        col_idx = col_start + tl.arange(0, BLOCK_N)
+        row_idx = row_start + tl.arange(0, BLOCK_M)
+        S = apply_alibi(
+            S,
+            col_idx,
+            row_idx,
+            seqlen_q,
+            seqlen_k,
+            is_causal=is_causal,
+            is_alibi=is_alibi,
+            alibi_slope=alibi_slope,
+        )
+        S = apply_mask(
+            S,
+            col_idx,
+            row_idx,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+            is_even_mn=True,
+            is_causal=False,
+            is_local=is_local,
+        )
+
+        acc_, P, rowmax_, rowsum_ = softmax_rescale(
+            acc_,
+            S,
+            rowmax_,
+            rowsum_,
+            softmax_scale_log2e=scale_softmax_log2,
+            is_border=is_local,
+        )
+        P = P.to(v_ptr.type.element_ty)
+
+        if is_dropout:
+            if return_softmax:
+                P_drop = P
+                P_drop = apply_dropout(
+                    P_drop,
+                    row_start,
+                    col_start,
+                    seqlen_k,
+                    bid,
+                    hid,
+                    philox_seed,
+                    philox_offset,
+                    p_dropout_in_uint8_t,
+                    is_dropout,
+                    encode_dropout_in_sign_bit=True,
+                    NUM_HEADS=h,
+                    BLOCK_M=BLOCK_M,
+                    BLOCK_N=BLOCK_N,
+                )
+                if IS_EVEN_MN:
+                    tl.store(p_bp0 + col_start, P_drop)
+                else:
+                    kvmask = col_idx < seqlen_k
+                    tl.store(p_bp0 + col_start, P_drop, mask=qmask & kvmask[None, :])
+
+            P = apply_dropout(
+                P,
+                row_start,
+                col_start,
+                seqlen_k,
+                bid,
+                hid,
+                philox_seed,
+                philox_offset,
+                p_dropout_in_uint8_t,
+                is_dropout,
+                encode_dropout_in_sign_bit=False,
+                NUM_HEADS=h,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+
+        if not PRE_LOAD_V:
+            off = col_start * k_row_stride
+            if d == BLOCK_K:
+                V = tl.load(p_bv0 + off, cache_modifier=".cg")
+            else:
+                V = tl.load(p_bv0 + off, mask=dmask[None, :], cache_modifier=".cg")
+        acc_ = tl.dot(P, V, acc_)
+
+    # LSE
+    # Note, rowsum = exp(-rowmax) * exp(lse), therefore rowmax + log(rowsum) cancels
+    # the effect of rowmax and outputs lse only.
+    lse = tl.where(
+        rowsum_ == 0 | (rowsum_ != rowsum_),
+        float("inf"),
+        rowmax_ * scale_softmax + tl.log(rowsum_),
+    )
+    inv_sum = tl.where(rowsum_ == 0 | (rowsum_ != rowsum_), 1.0, 1.0 / rowsum_)
+
+    if is_dropout:
+        acc_ *= inv_sum[:, None] * rp_dropout
+    else:
+        acc_ *= inv_sum[:, None]
+
+    out = acc_.to(o_ptr.type.element_ty)  # noqa
+
+    # Write back output
+    o_batch_stride = tl.multiple_of(o_batch_stride, d * h)
+    o_ptr += bid * o_batch_stride
+    o_ptr += hid * o_head_stride
+    o_offset = row_idx[:, None] * o_row_stride + tl.arange(0, BLOCK_K)
+
+    if IS_EVEN_MN & d == BLOCK_K:
+        tl.store(o_ptr + o_offset, out)
+    else:
+        tl.store(o_ptr + o_offset, out, mask=qmask)
+
+    # Write back lse
+    p_lse = softmax_lse_ptr + (bid * h + hid) * seqlen_q
+    row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    if IS_EVEN_MN:
+        tl.store(p_lse + row_idx, lse)
+    else:
+        tl.store(p_lse + row_idx, lse, mask=row_idx < seqlen_q)
+
+
+@triton.jit(do_not_specialize=["seqlen_q", "seqlen_k"])
+def flash_fwd_bh_parallel_kernel():
+    # (TODO)
+    pass
+
+
+def flash_fwd_splitkv_kernel_heur_block_k(args):
+    return triton.next_power_of_2(args["d"])
+
+
+@libentry()
+@triton.heuristics(
+    values={
+        "BLOCK_M": block_m_splitkv_heuristic_spec_args,
+        "BLOCK_N": block_n_splitkv_heuristic_spec_args,
+        "BLOCK_K": flash_fwd_splitkv_kernel_heur_block_k,
+        "num_warps": lambda args: 4,
+        "num_stages": lambda args: 3,
+        "PRE_LOAD_V": lambda args: True,
+        "IS_EVEN_MN": is_even_mn_spec_args,
+    }
+)
+@triton.jit(
+    do_not_specialize=["seqlen_q", "seqlen_k", "seqlen_q_rounded", "seqlen_k_rounded"]
+)
+def flash_fwd_splitkv_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    # sizes
+    b: tl.constexpr,
+    bk: tl.constexpr,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    # scaling factors
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    # dropout
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    # causal and swa
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    # alibi
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    # block table
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    k_page_stride: tl.constexpr,
+    # kernel params
+    IS_EVEN_MN: tl.constexpr,
+    PRE_LOAD_V: tl.constexpr,
+    blocks_per_split: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    num_warps: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    m_block = tl.program_id(0)
+    split_id = tl.program_id(1)
+    bid = tl.program_id(2) // h
+    hid = tl.program_id(2) % h
+
+    split_block_min = split_id * blocks_per_split
+    split_block_max = split_block_min + blocks_per_split
+
+    n_block_max = tl.cdiv(seqlen_k, BLOCK_N)
+    if is_causal:
+        n_block_max = min(
+            n_block_max,
+            tl.cdiv(
+                (m_block + 1) * BLOCK_M + seqlen_k - seqlen_q + window_size_right,
+                BLOCK_N,
+            ),
+        )
+
+    if is_alibi:
+        alibi_offset = bid * alibi_slopes_batch_stride + hid
+        alibi_slope = tl.load(alibi_slopes_ptr + alibi_offset)
+        alibi_slope /= scale_softmax
+    else:
+        alibi_slope = 0
+
+    if not is_causal:
+        if IS_EVEN_MN:
+            masking_block_min = n_block_max
+        else:
+            masking_block_min = n_block_max - 1
+    elif is_causal and IS_EVEN_MN:  # causal implies window_size_right is zero
+        masking_block_min = n_block_max - tl.cdiv(BLOCK_M, BLOCK_N)
+    else:
+        masking_block_min = n_block_max - tl.cdiv(BLOCK_M, BLOCK_N) - 1
+
+    q_ptr += bid * q_batch_stride
+    q_ptr += hid * q_head_stride
+    row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    q_off = row_idx[:, None] * q_row_stride + tl.arange(0, BLOCK_K)[None, :]
+    p_qm = q_ptr + q_off
+    dmask = tl.arange(0, BLOCK_K) < d
+    qmask = dmask[None, :] & (row_idx[:, None] < seqlen_q)
+    if IS_EVEN_MN & BLOCK_K == d:
+        Q = tl.load(p_qm, cache_modifier=".cg")
+    else:
+        Q = tl.load(p_qm, mask=qmask, cache_modifier=".cg")
+
+    h_hk_ratio = h // hk
+    k_ptr += bid * k_batch_stride
+    k_ptr += (hid // h_hk_ratio) * k_head_stride
+    v_ptr += bid * k_batch_stride
+    v_ptr += (hid // h_hk_ratio) * k_head_stride
+
+    k_offset = (
+        tl.arange(0, BLOCK_N)[None, :] * k_row_stride + tl.arange(0, BLOCK_K)[:, None]
+    )
+    p_k0 = k_ptr + k_offset
+
+    v_offset = (
+        tl.arange(0, BLOCK_N)[:, None] * k_row_stride + tl.arange(0, BLOCK_K)[None, :]
+    )
+    p_v0 = v_ptr + v_offset
+
+    acc_ = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+    rowmax_ = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    rowsum_ = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    if split_block_max <= masking_block_min:
+        # no masking needed
+        for n_block in tl.range(
+            split_block_min, split_block_max, num_stages=num_stages
+        ):
+            kv_off = n_block * BLOCK_N * k_row_stride
+            if d == BLOCK_K:
+                K = tl.load(p_k0 + kv_off, cache_modifier=".cg")
+            else:
+                K = tl.load(
+                    p_k0 + kv_off, mask=dmask[:, None], cache_modifier=".cg", other=0.0
+                )
+            if PRE_LOAD_V:
+                if d == BLOCK_K:
+                    V = tl.load(p_v0 + kv_off, cache_modifier=".cg")
+                else:
+                    V = tl.load(
+                        p_v0 + kv_off,
+                        mask=dmask[None, :],
+                        cache_modifier=".cg",
+                        other=0.0,
+                    )
+            S = tl.dot(Q, K)
+            S = apply_softcap(S, softcap, is_softcap)
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+            row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+            S = apply_alibi(
+                S,
+                col_idx,
+                row_idx,
+                seqlen_q,
+                seqlen_k,
+                is_causal=is_causal,
+                is_alibi=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            acc_, P, rowmax_, rowsum_ = softmax_rescale(
+                acc_,
+                S,
+                rowmax_,
+                rowsum_,
+                softmax_scale_log2e=scale_softmax_log2,
+                is_border=False,
+            )
+
+            if not PRE_LOAD_V:
+                if d == BLOCK_K:
+                    V = tl.load(p_v0 + kv_off, cache_modifier=".cg")
+                else:
+                    V = tl.load(
+                        p_v0 + kv_off,
+                        mask=dmask[None, :],
+                        cache_modifier=".cg",
+                        other=0.0,
+                    )
+            P = P.to(v_ptr.type.element_ty)
+            acc_ = tl.dot(P, V, acc_)
+    else:
+        for n_block in tl.range(split_block_min, min(split_block_max, n_block_max)):
+            kv_off = n_block * BLOCK_N * k_row_stride
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+            row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+            if IS_EVEN_MN & d == BLOCK_K:
+                K = tl.load(p_k0 + kv_off, cache_modifier=".cg")
+                if PRE_LOAD_V:
+                    V = tl.load(p_v0 + kv_off, cache_modifier=".cg")
+            elif d == BLOCK_K:
+                kvmask = col_idx < seqlen_k
+                K = tl.load(p_k0 + kv_off, mask=kvmask[None, :], cache_modifier=".cg")
+                if PRE_LOAD_V:
+                    V = tl.load(
+                        p_v0 + kv_off, mask=kvmask[:, None], cache_modifier=".cg"
+                    )
+            else:
+                kvmask = col_idx < seqlen_k
+                K = tl.load(
+                    p_k0 + kv_off,
+                    mask=dmask[:, None] & kvmask[None, :],
+                    cache_modifier=".cg",
+                    other=0.0,
+                )
+                if PRE_LOAD_V:
+                    V = tl.load(
+                        p_v0 + kv_off,
+                        mask=dmask[None, :] & kvmask[:, None],
+                        cache_modifier=".cg",
+                        other=0.0,
+                    )
+
+            S = tl.dot(Q, K)
+            S = apply_softcap(S, softcap, is_softcap)
+            S = apply_alibi(
+                S,
+                col_idx,
+                row_idx,
+                seqlen_q,
+                seqlen_k,
+                is_causal=is_causal,
+                is_alibi=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            S = apply_mask(
+                S,
+                col_idx,
+                row_idx,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                is_even_mn=IS_EVEN_MN,
+                is_causal=is_causal,
+                is_local=False,
+            )
+
+            acc_, P, rowmax_, rowsum_ = softmax_rescale(
+                acc_,
+                S,
+                rowmax_,
+                rowsum_,
+                softmax_scale_log2e=scale_softmax_log2,
+                is_border=(is_causal or is_local),
+            )
+
+            if not PRE_LOAD_V:
+                if IS_EVEN_MN & d == BLOCK_K:
+                    V = tl.load(p_v0 + kv_off, cache_modifier=".cg")
+                elif d == BLOCK_K:
+                    V = tl.load(
+                        p_v0 + kv_off, mask=kvmask[:, None], cache_modifier=".cg"
+                    )
+                else:
+                    V = tl.load(
+                        p_v0 + kv_off,
+                        mask=dmask[None, :] & kvmask[:, None],
+                        cache_modifier=".cg",
+                        other=0.0,
+                    )
+            P = P.to(v_ptr.type.element_ty)
+            acc_ = tl.dot(P, V, acc_)
+
+    # LSE
+    lse = tl.where(
+        rowsum_ == 0 | (rowsum_ != rowsum_),
+        float("-inf"),
+        rowmax_ * scale_softmax + tl.log(rowsum_),
+    )
+    inv_sum = tl.where(rowsum_ == 0 | (rowsum_ != rowsum_), 1.0, 1.0 / rowsum_)
+
+    # Rescale output
+    acc_ *= inv_sum[:, None]
+
+    # Write back output
+    # o_splits layout = (n_splits, batch_size, num_heads, seqlen_q, head_size)
+    # grid = (seq_block, split, batch * head)
+    o_split_ptr = o_ptr
+    # + split, batch, head offsets, seq_block offsets are already added in row_idx
+    o_split_ptr += (split_id * tl.num_programs(2) + tl.program_id(2)) * seqlen_q * d
+    o_split_offset = row_idx[:, None] * d + tl.arange(0, BLOCK_K)
+    o_split_ptr = tl.multiple_of(o_split_ptr, d)
+    p_om = o_split_ptr + o_split_offset
+
+    if IS_EVEN_MN & BLOCK_K == d:
+        tl.store(p_om, acc_, cache_modifier=".cg")
+    else:
+        tl.store(p_om, acc_, mask=qmask, cache_modifier=".cg")
+
+    # Write back lse
+    # lse_splits layout = (n_splits, batch_size, num_heads, seqlen_q)
+    lse_split_ptr = softmax_lse_ptr
+    # + split, batch, head, seq_block offsets
+    lse_split_ptr += (
+        split_id * tl.num_programs(2) + tl.program_id(2)
+    ) * seqlen_q + m_block * BLOCK_M
+
+    if IS_EVEN_MN:
+        tl.store(lse_split_ptr + tl.arange(0, BLOCK_M), lse, cache_modifier=".cg")
+    else:
+        tl.store(
+            lse_split_ptr + tl.arange(0, BLOCK_M),
+            lse,
+            mask=row_idx < seqlen_q,
+            cache_modifier=".cg",
+        )
+
+
+@libentry()
+@triton.jit
+def flash_fwd_splitkv_combine_kernel(
+    out_ptr,
+    lse_ptr,
+    out_splits_ptr,
+    lse_splits_ptr,
+    head_size: tl.constexpr,
+    out_split_stride,
+    lse_split_stride,
+    out_b_stride,
+    out_s_stride,
+    out_h_stride,
+    n_splits,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    q_total,
+    MAX_N_SPLITS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    lse_splits_ptr += pid * BLOCK_M
+    lse_ptr += pid * BLOCK_M
+    out_splits_ptr += pid * BLOCK_M * head_size
+    out_ptr += pid * BLOCK_M * head_size
+
+    # Subtracting maximum from each of the split lse's for better numerical stability
+    lse_split_offset = (
+        tl.arange(0, BLOCK_M)[:, None]
+        + tl.arange(0, MAX_N_SPLITS)[None, :] * lse_split_stride
+    )
+    lse_split_mask = (pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None] < q_total) & (
+        tl.arange(0, MAX_N_SPLITS)[None, :] < n_splits
+    )
+    lse_splits = tl.load(
+        lse_splits_ptr + lse_split_offset, mask=lse_split_mask, other=float("-inf")
+    )
+    max_lse = tl.max(lse_splits, 1)
+
+    # Sum exp(lse(i) - max_lse) over all split i to obtain Z=sumexp(QK) up to a scaled factor exp(-max_lse)
+    Zi_scaled = tl.exp(lse_splits - max_lse[:, None])
+    Z_scaled = tl.sum(Zi_scaled, 1)
+    Zi_Z = Zi_scaled / Z_scaled[:, None]
+
+    # Write back LSE
+    lse = tl.log(Z_scaled) + max_lse
+    out_mask = pid * BLOCK_M + tl.arange(0, BLOCK_M) < q_total
+    tl.store(lse_ptr + tl.arange(0, BLOCK_M), lse, mask=out_mask)
+
+    out_split_offset = (
+        tl.arange(0, BLOCK_M)[:, None, None] * head_size
+        + tl.arange(0, MAX_N_SPLITS)[None, :, None] * out_split_stride
+        + tl.arange(0, BLOCK_K)[None, None, :]
+    )
+    out_split_mask = (
+        (pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None, None] < q_total)
+        & (tl.arange(0, MAX_N_SPLITS)[None, :, None] < n_splits)
+        & (tl.arange(0, BLOCK_K)[None, None, :] < head_size)
+    )
+    out_splits = tl.load(
+        out_splits_ptr + out_split_offset, mask=out_split_mask, other=0.0
+    )
+    out = tl.sum(Zi_Z[:, :, None] * out_splits, 1)
+    out = out.to(out_ptr.type.element_ty)
+
+    # Write back output
+    out_offset = tl.arange(0, BLOCK_M)[:, None] * out_s_stride + tl.arange(0, BLOCK_K)
+    dmask = tl.arange(0, BLOCK_K) < head_size
+    tl.store(out_ptr + out_offset, out, mask=out_mask[:, None] & dmask[None, :])
+
+
+@triton.jit
+def virtual_to_cache_offset(
+    virtual_index,
+    max_virtual_index,
+    page_table_ptr,
+    block_size,
+    k_row_stride,
+    k_page_stride,
+    boundary_check: tl.constexpr = False,
+):
+    # virtual_index is the kv sequence index in the current batch element
+    # page_table_ptr is already pointed at current batch element's block table entry
+    # block_size is the size of each block in the page table
+    virtual_page_index = virtual_index // block_size
+    page_offset = virtual_index % block_size
+    if boundary_check:
+        page_block_index = tl.load(
+            page_table_ptr + virtual_page_index,
+            mask=virtual_index < max_virtual_index,
+            other=0,
+        ).to(tl.int64)
+    else:
+        page_block_index = tl.load(page_table_ptr + virtual_page_index).to(tl.int64)
+    return page_block_index * k_page_stride + page_offset * k_row_stride
+
+
+@triton.jit
+def load_from_kvcache(
+    n_start,
+    max_virtual_index,
+    page_table_ptr,
+    k_ptr_base,
+    v_ptr_base,
+    block_size: tl.constexpr,
+    d: tl.constexpr,
+    k_row_stride,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    k_page_stride=0,
+    boundary_check: tl.constexpr = False,
+):
+    virtual_index = n_start + tl.arange(0, BLOCK_N)
+    # A tile that stays inside one page needs only one page-table load.
+    if BLOCK_N <= block_size and block_size % BLOCK_N == 0:
+        virtual_page_index = n_start // block_size
+        page_offset = n_start % block_size + tl.arange(0, BLOCK_N)
+        if boundary_check:
+            page_block_index = tl.load(
+                page_table_ptr + virtual_page_index,
+                mask=n_start < max_virtual_index,
+                other=0,
+            ).to(tl.int64)
+        else:
+            page_block_index = tl.load(
+                page_table_ptr + virtual_page_index
+            ).to(tl.int64)
+        cache_offset = (
+            page_block_index * k_page_stride + page_offset * k_row_stride
+        )
+    elif BLOCK_N % block_size == 0:
+        page_group: tl.constexpr = BLOCK_N // block_size
+        page_lane = tl.arange(0, page_group)
+        virtual_page_index = n_start // block_size + page_lane
+        if boundary_check:
+            page_block_index = tl.load(
+                page_table_ptr + virtual_page_index,
+                mask=n_start + page_lane * block_size < max_virtual_index,
+                other=0,
+            ).to(tl.int64)
+        else:
+            page_block_index = tl.load(
+                page_table_ptr + virtual_page_index
+            ).to(tl.int64)
+        page_block_index = tl.reshape(
+            tl.broadcast_to(
+                page_block_index[:, None], (page_group, block_size)
+            ),
+            (BLOCK_N,),
+        )
+        page_offset = tl.arange(0, BLOCK_N) % block_size
+        cache_offset = (
+            page_block_index * k_page_stride + page_offset * k_row_stride
+        )
+    else:
+        cache_offset = virtual_to_cache_offset(
+            virtual_index,
+            max_virtual_index,
+            page_table_ptr,
+            block_size,
+            k_row_stride,
+            k_page_stride,
+            boundary_check,
+        )
+    k_offset = tl.arange(0, BLOCK_K)[:, None] + cache_offset[None, :]
+    v_offset = tl.arange(0, BLOCK_K)[None, :] + cache_offset[:, None]
+    if d == BLOCK_K:
+        bK_mask = virtual_index[None, :] < max_virtual_index[None, :]
+        bV_mask = virtual_index[:, None] < max_virtual_index[:, None]
+        bK = tl.load(k_ptr_base + k_offset, mask=bK_mask, other=0.0)
+        bV = tl.load(v_ptr_base + v_offset, mask=bV_mask, other=0.0)
+    else:
+        bK_mask = (tl.arange(0, BLOCK_K)[:, None] < d) & (
+            virtual_index[None, :] < max_virtual_index[None, :]
+        )
+        bV_mask = (tl.arange(0, BLOCK_K)[None, :] < d) & (
+            virtual_index[:, None] < max_virtual_index[:, None]
+        )
+        bK = tl.load(k_ptr_base + k_offset, mask=bK_mask, other=0.0)
+        bV = tl.load(v_ptr_base + v_offset, mask=bV_mask, other=0.0)
+    return bK, bV
+
+
+@triton.jit
+def _compact_ragged_tile_coords(
+    tile_idx,
+    cu_seqlens_q_ptr,
+    batch_size,
+    num_heads: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    LPT_RAGGED: tl.constexpr,
+):
+    """Map a compact ragged work id to M block, batch, and Q head."""
+
+    lane = tl.arange(0, 32)
+    group_bid = 0
+    group_start = 0
+    found = False
+    selected_bid = 0
+    selected_m_blocks = 1
+    selected_within = 0
+
+    while (group_bid < batch_size) & (~found):
+        bids = group_bid + lane
+        valid = (lane < 31) & (bids < batch_size)
+        q_bos = tl.load(cu_seqlens_q_ptr + bids, mask=valid, other=0)
+        q_eos = tl.load(cu_seqlens_q_ptr + bids + 1, mask=valid, other=0)
+        q_len = q_eos - q_bos
+        m_blocks = tl.cdiv(q_len, BLOCK_M)
+        batch_work = tl.where(valid, m_blocks * num_heads, 0)
+        work_prefix = tl.cumsum(batch_work, axis=0)
+        work_before = work_prefix - batch_work
+        group_work = tl.sum(batch_work, axis=0)
+        local_idx = tile_idx - group_start
+        in_group = local_idx < group_work
+        hit = valid & (local_idx >= work_before) & (local_idx < work_prefix)
+
+        hit_bid = tl.sum(tl.where(hit, bids, 0), axis=0)
+        hit_m_blocks = tl.sum(tl.where(hit, m_blocks, 0), axis=0)
+        hit_within = tl.sum(
+            tl.where(hit, local_idx - work_before, 0), axis=0
+        )
+        selected_bid = tl.where(in_group, hit_bid, selected_bid)
+        selected_m_blocks = tl.where(
+            in_group, hit_m_blocks, selected_m_blocks
+        )
+        selected_within = tl.where(in_group, hit_within, selected_within)
+        found = found | in_group
+        group_start += group_work
+        group_bid += 31
+
+    safe_m_blocks = tl.maximum(selected_m_blocks, 1)
+    if LPT_RAGGED:
+        m_rank = selected_within // num_heads
+        hid = selected_within - m_rank * num_heads
+        m_block = safe_m_blocks - 1 - m_rank
+    else:
+        hid = selected_within // safe_m_blocks
+        m_block = selected_within - hid * safe_m_blocks
+    return m_block, selected_bid, hid, found
+
+
+@libentry()
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    # sizes
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    # scaling factors
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    # dropout
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    # causal and swa
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    # alibi
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    # block table
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    k_page_stride,
+    # kernel params
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    num_warps: tl.constexpr,
+    num_stages: tl.constexpr,
+    COMPACT_RAGGED: tl.constexpr = False,
+    LPT_RAGGED: tl.constexpr = False,
+):
+    if COMPACT_RAGGED:
+        m_block, bid, hid, work_valid = _compact_ragged_tile_coords(
+            tl.program_id(0),
+            cu_seqlens_q_ptr,
+            b,
+            h,
+            BLOCK_M,
+            LPT_RAGGED,
+        )
+        if work_valid == 0:
+            return
+    else:
+        m_block = tl.program_id(0)
+        bid = tl.program_id(1)
+        hid = tl.program_id(2)
+    # num_m_blocks = tl.cdiv(seqlen_q, BLOCK_M)
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        # Current request's start offset in the batched Q
+        q_offset = q_bos * q_row_stride
+        o_offset = q_bos * o_row_stride
+        lse_offset = q_bos * 1
+    else:
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        o_offset = bid * o_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+        # k_offset = k_bos * k_row_stride
+    else:
+        k_len_cache = seqlen_k
+        # k_offset = bid * k_batch_stride
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    # Noop CTA
+    if m_block * BLOCK_M > q_len:
+        return
+
+    # is_even_mn = (q_len % BLOCK_M == 0) and (k_len % BLOCK_N == 0)
+    is_even_mn: tl.constexpr = False
+
+    if is_local:
+        n_block_min = max(
+            0, (m_block * BLOCK_M + k_len - q_len - window_size_left) // BLOCK_N
+        )
+    else:
+        n_block_min = 0
+
+    n_block_max = tl.cdiv(k_len, BLOCK_N)
+    if is_causal or is_local:
+        n_block_max = min(
+            n_block_max,
+            tl.cdiv(
+                (m_block + 1) * BLOCK_M + k_len - q_len + window_size_right, BLOCK_N
+            ),
+        )
+
+    if is_dropout:
+        philox_seed = tl.load(philox_args).to(tl.uint64)
+        philox_offset = tl.load(philox_args + 1).to(tl.uint64)
+
+    # Locate the page table entry for the current batch element
+    if is_paged:
+        page_table_ptr += bid * page_table_batch_stride
+    # Calculate the starting offset of q for the current head
+    q_row_offset = hid * q_head_stride
+    # Calculate the starting offset of k and v for the current head
+    k_row_offset = (hid // h_hk_ratio) * k_head_stride
+    # Shift the k, v pointers to align with the current head
+    k_ptr_base = k_ptr + k_row_offset
+    v_ptr_base = v_ptr + k_row_offset
+
+    gQ = tl.make_block_ptr(
+        base=q_ptr + q_offset + q_row_offset,
+        shape=(q_len, d),
+        strides=(q_row_stride, 1),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_K),
+        order=(1, 0),
+    )
+    bQ = tl.load(gQ.advance([m_block * BLOCK_M, 0]), boundary_check=(0, 1))
+
+    acc_ = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+    rowmax_ = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    rowsum_ = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    if is_alibi:
+        alibi_offset = bid * alibi_slopes_batch_stride + hid
+        alibi_slope = tl.load(alibi_slopes_ptr + alibi_offset)
+        alibi_slope /= scale_softmax
+    else:
+        alibi_slope = 0.0
+
+    if not is_causal and not is_local:
+        n_masking_steps = 1
+    elif is_even_mn:
+        n_masking_steps = tl.cdiv(BLOCK_M, BLOCK_N)
+    else:
+        n_masking_steps = tl.cdiv(BLOCK_M, BLOCK_N) + 1
+
+    n_masking_steps = min(n_block_max - n_block_min, n_masking_steps)
+
+    row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_block = n_block_max - 1
+    for step in tl.range(0, n_masking_steps):
+        start_n = n_block * BLOCK_N
+        col_idx = start_n + tl.arange(0, BLOCK_N)
+        if is_paged:
+            bK, bV = load_from_kvcache(
+                start_n,
+                k_len,
+                page_table_ptr,
+                k_ptr_base,
+                v_ptr_base,
+                block_size,
+                d,
+                k_row_stride,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+                k_page_stride=k_page_stride,
+                boundary_check=True,
+            )
+        else:
+            k_ptr_seq = k_ptr_base + k_bos * k_row_stride
+            v_ptr_seq = v_ptr_base + k_bos * k_row_stride
+            gK = tl.make_block_ptr(
+                base=k_ptr_seq,
+                shape=(k_len, d),
+                strides=(k_row_stride, 1),
+                offsets=(start_n, 0),
+                block_shape=(BLOCK_N, BLOCK_K),
+                order=(0, 1),
+            )
+            gV = tl.make_block_ptr(
+                base=v_ptr_seq,
+                shape=(k_len, d),
+                strides=(k_row_stride, 1),
+                offsets=(start_n, 0),
+                block_shape=(BLOCK_N, BLOCK_K),
+                order=(0, 1),
+            )
+            bK = tl.load(gK, boundary_check=(0, 1))
+            bK = tl.trans(bK)
+            bV = tl.load(gV, boundary_check=(0, 1))
+        S = tl.dot(bQ, bK, out_dtype=tl.float32)
+        S = apply_softcap(S, softcap, is_softcap)
+        S = apply_alibi(
+            S,
+            col_idx,
+            row_idx,
+            q_len,
+            k_len,
+            is_causal=is_causal,
+            is_alibi=is_alibi,
+            alibi_slope=alibi_slope,
+        )
+        S = apply_mask(
+            S,
+            col_idx,
+            row_idx,
+            q_len,
+            k_len,
+            window_size_left,
+            window_size_right,
+            is_even_mn=is_even_mn,
+            is_causal=is_causal,
+            is_local=is_local,
+        )
+
+        acc_, P, rowmax_, rowsum_ = softmax_rescale(
+            acc_,
+            S,
+            rowmax_,
+            rowsum_,
+            softmax_scale_log2e=scale_softmax_log2,
+            is_border=True,
+        )
+        P = P.to(v_ptr.type.element_ty)
+
+        if is_dropout:
+            P = apply_dropout(
+                P,
+                n_block * BLOCK_N,
+                m_block * BLOCK_M,
+                k_len,
+                bid,
+                hid,
+                philox_seed,
+                philox_offset,
+                p_dropout_in_uint8_t,
+                is_dropout,
+                encode_dropout_in_sign_bit=False,
+                NUM_HEADS=h,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+
+        acc_ = tl.dot(P, bV, acc_)
+        n_block -= 1
+
+    for n_block in tl.range(
+        n_block_max - n_masking_steps - 1, n_block_min - 1, step=-1
+    ):
+        start_n = n_block * BLOCK_N
+        col_idx = start_n + tl.arange(0, BLOCK_N)
+        if is_paged:
+            bK, bV = load_from_kvcache(
+                start_n,
+                k_len,
+                page_table_ptr,
+                k_ptr_base,
+                v_ptr_base,
+                block_size,
+                d,
+                k_row_stride,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+                k_page_stride=k_page_stride,
+            )
+        else:
+            k_ptr_seq = k_ptr_base + k_bos * k_row_stride
+            v_ptr_seq = v_ptr_base + k_bos * k_row_stride
+            gK = tl.make_block_ptr(
+                base=k_ptr_seq,
+                shape=(k_len, d),
+                strides=(k_row_stride, 1),
+                offsets=(start_n, 0),
+                block_shape=(BLOCK_N, BLOCK_K),
+                order=(0, 1),
+            )
+            gV = tl.make_block_ptr(
+                base=v_ptr_seq,
+                shape=(k_len, d),
+                strides=(k_row_stride, 1),
+                offsets=(start_n, 0),
+                block_shape=(BLOCK_N, BLOCK_K),
+                order=(0, 1),
+            )
+            bK = tl.load(gK)
+            bK = tl.trans(bK)
+            bV = tl.load(gV)
+        S = tl.dot(bQ, bK, out_dtype=tl.float32)
+        S = apply_softcap(S, softcap, is_softcap)
+        S = apply_alibi(
+            S,
+            col_idx,
+            row_idx,
+            q_len,
+            k_len,
+            is_causal=is_causal,
+            is_alibi=is_alibi,
+            alibi_slope=alibi_slope,
+        )
+        S = apply_mask(
+            S,
+            col_idx,
+            row_idx,
+            q_len,
+            k_len,
+            window_size_left,
+            window_size_right,
+            is_even_mn=True,
+            is_causal=False,
+            is_local=is_local,
+        )
+
+        acc_, P, rowmax_, rowsum_ = softmax_rescale(
+            acc_,
+            S,
+            rowmax_,
+            rowsum_,
+            softmax_scale_log2e=scale_softmax_log2,
+            is_border=is_local,
+        )
+        P = P.to(v_ptr.type.element_ty)
+
+        if is_dropout:
+            P = apply_dropout(
+                P,
+                m_block * BLOCK_M,
+                n_block * BLOCK_N,
+                k_len,
+                bid,
+                hid,
+                philox_seed,
+                philox_offset,
+                p_dropout_in_uint8_t,
+                is_dropout,
+                encode_dropout_in_sign_bit=False,
+                NUM_HEADS=h,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+        acc_ = tl.dot(P, bV, acc_)
+
+    # LSE
+    lse = tl.where(
+        rowsum_ == 0 | (rowsum_ != rowsum_),
+        float("inf"),
+        rowmax_ * scale_softmax + tl.log(rowsum_),
+    )
+    inv_sum = tl.where(rowsum_ == 0 | (rowsum_ != rowsum_), 1.0, 1.0 / rowsum_)
+
+    acc_ *= inv_sum[:, None]
+
+    out = acc_.to(o_ptr.type.element_ty)  # noqa
+
+    # Write back output
+    o_row_offset = hid * o_head_stride
+
+    gO = tl.make_block_ptr(
+        base=o_ptr + o_offset + o_row_offset,
+        shape=(q_len, d),
+        strides=(o_row_stride, 1),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_K),
+        order=(1, 0),
+    )
+    tl.store(gO.advance([m_block * BLOCK_M, 0]), out, boundary_check=(0, 1))
+
+    # Write back lse
+    # lse shape: [h, total_q]
+    softmax_lse_ptr += hid * total_q
+    lse_row_offset = lse_offset + m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    tl.store(
+        softmax_lse_ptr + lse_row_offset,
+        lse,
+        mask=lse_row_offset < (lse_offset + q_len),
+    )


### PR DESCRIPTION
### PR Category

Operator, Benchmark

### Type of Change

Performance Optimization

### Description

This PR adds a MetaX-specific optimized implementation of `flash_attn_varlen_func`.
https://ocnv3389d5fd.feishu.cn/wiki/SSCrwYy8iisg4BkO6tKcf11mnXf
The main changes include:

- Add the optimized MetaX FlashAttention implementation under `runtime/backend/_metax/ops`.
- Register `flash_attn_varlen_func` in the MetaX backend.
- Adjust the MetaX FlashAttention `BLOCK_N` configuration from 32 to 16.
- Add a MetaX-specific performance benchmark for variable-length FlashAttention.

### Issue

N/A. There is currently no associated issue.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

Test environment:

- Device: MetaX C550
- Backend: MetaX
- Test file: `benchmark/test_flash_attn_varlen_func_metax.py`
- Test mode: performance benchmark with CUDA Graph enabled

Benchmark command:

```bash
python -m pytest benchmark/test_flash_attn_varlen_func_metax.py -q -s -p _cudagraph_plugin
