### PR TITLE
[KMCompiler][Ascend][MetaX] Add nansum operator with triton kernel

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -67,6 +67,7 @@ from .mean import mean, mean_dim
 from .min import min, min_dim
 from .mm import mm, mm_out
 from .multinomial import multinomial
+from .nansum import nansum, nansum_out
 from .nonzero_static import nonzero_static, nonzero_static_out
 from .ones import ones
 from .ones_like import ones_like
@@ -178,6 +179,8 @@ __all__ = [
     "mm",
     "mm_out",
     "multinomial",
+    "nansum",
+    "nansum_out",
     "nonzero_static",
     "nonzero_static_out",
     "normed_cumsum",

--- a/src/flag_gems/runtime/backend/_ascend/ops/nansum.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/nansum.py
@@ -1,0 +1,843 @@
+import logging
+import math
+import threading
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_NUM_VECTOR_CORES = 40
+_num_vector_cores_cache = None
+
+_MAX_UB_INNER = 8192
+_MAX_UB_NON_INNER = 8192
+_MAX_UB_GLOBAL = 10240
+_MAX_UB_GLOBAL_FP16 = 12288
+
+
+def _global_ub_cap(dtype):
+    if dtype in (torch.float16, torch.bfloat16):
+        return _MAX_UB_GLOBAL_FP16
+    return _MAX_UB_GLOBAL
+
+
+_SAFE_TILE_N_NON_INNER = 1024
+
+
+def _get_num_vector_cores() -> int:
+    global _num_vector_cores_cache
+    if _num_vector_cores_cache is not None:
+        return _num_vector_cores_cache
+    try:
+        from triton.backends.ascend import driver
+
+        device_id = torch.npu.current_device()
+        _num_vector_cores_cache = driver.active.utils.get_device_properties(
+            device_id
+        ).get("num_vectorcore", _DEFAULT_NUM_VECTOR_CORES)
+    except Exception:
+        _num_vector_cores_cache = _DEFAULT_NUM_VECTOR_CORES
+    return _num_vector_cores_cache
+
+
+_precompiled_inner: dict = {}
+_precompiled_non_inner: dict = {}
+_precompiled_multi_dim: dict = {}
+_precompiled_lock = threading.Lock()
+
+
+def _launch_inner_cached(
+    out_flat, work, M, N, tile_m, tile_n, num_warps, num_stages, grid
+):
+    cache_key = (tile_m, tile_n, work.dtype)
+    device = torch_device_fn.current_device()
+    device_cache = _precompiled_inner.get(device)
+    if device_cache is None:
+        device_cache = {}
+        _precompiled_inner[device] = device_cache
+
+    compiled = device_cache.get(cache_key)
+    if compiled is None:
+        with _precompiled_lock:
+            compiled = device_cache.get(cache_key)
+            if compiled is None:
+                compiled, _ = nansum_dim_kernel_inner.run(
+                    out_flat,
+                    work,
+                    M,
+                    N,
+                    TILE_M=tile_m,
+                    TILE_N=tile_n,
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                    grid=grid,
+                    warmup=True,
+                )
+                device_cache[cache_key] = compiled
+
+    g = grid + (1, 1) if len(grid) == 1 else grid + (1,) if len(grid) == 2 else grid
+    compiled[g[:3]](out_flat, work, M, N)
+
+
+def _launch_non_inner_cached(
+    out_flat, work, M, N, K, tile_n, tile_k, one_tile, num_warps, num_stages, grid
+):
+    cache_key = (tile_n, tile_k, one_tile, work.dtype)
+    device = torch_device_fn.current_device()
+    device_cache = _precompiled_non_inner.get(device)
+    if device_cache is None:
+        device_cache = {}
+        _precompiled_non_inner[device] = device_cache
+
+    compiled = device_cache.get(cache_key)
+    if compiled is None:
+        with _precompiled_lock:
+            compiled = device_cache.get(cache_key)
+            if compiled is None:
+                compiled, _ = nansum_dim_kernel_non_inner.run(
+                    out_flat,
+                    work,
+                    M,
+                    N,
+                    K,
+                    TILE_N=tile_n,
+                    TILE_K=tile_k,
+                    ONE_TILE_PER_CTA=one_tile,
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                    grid=grid,
+                    warmup=True,
+                )
+                device_cache[cache_key] = compiled
+
+    g = grid + (1, 1) if len(grid) == 1 else grid + (1,) if len(grid) == 2 else grid
+    compiled[g[:3]](out_flat, work, M, N, K)
+
+
+def _launch_multi_dim_cached(
+    work, out_flat, M, N, block_m, block_n, num_warps, num_stages, grid
+):
+    cache_key = (block_m, block_n, work.dtype)
+    device = torch_device_fn.current_device()
+    device_cache = _precompiled_multi_dim.get(device)
+    if device_cache is None:
+        device_cache = {}
+        _precompiled_multi_dim[device] = device_cache
+
+    compiled = device_cache.get(cache_key)
+    if compiled is None:
+        with _precompiled_lock:
+            compiled = device_cache.get(cache_key)
+            if compiled is None:
+                compiled, _ = nansum_dim_kernel.run(
+                    work,
+                    out_flat,
+                    M,
+                    N,
+                    BLOCK_M=block_m,
+                    BLOCK_N=block_n,
+                    num_warps=num_warps,
+                    num_stages=num_stages,
+                    grid=grid,
+                    warmup=True,
+                )
+                device_cache[cache_key] = compiled
+
+    g = grid + (1, 1) if len(grid) == 1 else grid + (1,) if len(grid) == 2 else grid
+    compiled[g[:3]](work, out_flat, M, N)
+
+
+def _nansum_heur_tile_n_inner(args):
+    N = args["N"]
+    M = args.get("M", 1)
+    ub_tile_n = min(triton.next_power_of_2(N), _MAX_UB_INNER)
+
+    # Small-N fast path: one tile covers the whole row, skip dynamic balancing
+    if N <= 256:
+        return ub_tile_n
+
+    # Base min_tile_m from N (SIMD ops within a single row)
+    if N >= 8192:
+        min_tile_m = 1
+    elif N >= 4096:
+        min_tile_m = 2
+    elif N >= 2048:
+        min_tile_m = 4
+    elif N >= 1024:
+        min_tile_m = 8
+    else:
+        min_tile_m = 32
+
+    if M > 262144:
+        min_tile_m = max(min_tile_m, 32)
+    elif M > 65536:
+        min_tile_m = max(min_tile_m, 16)
+    elif M > 16384:
+        min_tile_m = max(min_tile_m, 8)
+
+    return min(ub_tile_n, _MAX_UB_INNER // min_tile_m)
+
+
+def _nansum_heur_tile_m_inner(args):
+    M, N = args["M"], args["N"]
+    num_cores = _get_num_vector_cores()
+    tile_n = _nansum_heur_tile_n_inner(args)
+    iters_per_row = max(1, (N + tile_n - 1) // tile_n)
+
+    # Small-N fast path: one iteration per row, pack rows to UB limit
+    if N <= 256:
+        max_tile_m = max(_MAX_UB_INNER // tile_n, 1)
+        tile_m = max(1, min(max_tile_m, M // max(1, num_cores)))
+        return min(tile_m, max_tile_m, 512)
+
+    if iters_per_row >= 4:
+        target_waves = 4
+    elif iters_per_row >= 2:
+        target_waves = 2
+    else:
+        target_waves = 1
+
+    target_grid = max(1, num_cores * target_waves)
+    tile_m = triton.next_power_of_2(max(1, M // target_grid))
+
+    # UB constraint: inner kernel ~5x buffer overhead
+    max_tile_m = max(_MAX_UB_INNER // tile_n, 1)
+
+    # Min work per block to avoid excessive grid for small N (e.g. [1024,16])
+    MIN_WORK_PER_BLOCK = 2048
+    min_tile_m = max(1, MIN_WORK_PER_BLOCK // tile_n)
+    tile_m = max(tile_m, min(min_tile_m, max_tile_m))
+
+    return min(tile_m, max_tile_m, 512)
+
+
+def _nansum_heur_tile_k(args):
+    M, K = args["M"], args["K"]
+    num_cores = _get_num_vector_cores()
+    MAX_TILE_K = min(_MAX_UB_NON_INNER, K)
+    MIN_TILE_N = 8
+
+    if M <= 1:
+        if K > 1024:
+            MIN_TILE_K_FOR_BW = 16
+        else:
+            MIN_TILE_K_FOR_BW = 64
+        MIN_TILE_K = max(8, MIN_TILE_K_FOR_BW)
+        effective_max_tk = min(MAX_TILE_K, _MAX_UB_NON_INNER // MIN_TILE_N)
+        if K > 131072:
+            TARGET_WAVES = 16
+        elif K > 32768:
+            TARGET_WAVES = 8
+        elif K > 8192:
+            TARGET_WAVES = 4
+        elif K > 1024:
+            TARGET_WAVES = 2
+        else:
+            TARGET_WAVES = 1
+    elif M <= 4:
+        MIN_TILE_K = 8
+        TARGET_WAVES = 4
+        effective_max_tk = MAX_TILE_K
+    elif M <= 64:
+        MIN_TILE_K = 1
+        TARGET_WAVES = 2
+        effective_max_tk = MAX_TILE_K
+    else:
+        min_total_blocks = num_cores * 16
+        effective_upper = max(1, (M * K) // min_total_blocks)
+        upper = min(K, MAX_TILE_K, effective_upper)
+        tile_k = max(1, triton.cdiv(_MAX_UB_NON_INNER, _SAFE_TILE_N_NON_INNER))
+        while tile_k <= upper:
+            if tile_k * 2 <= upper:
+                tile_k *= 2
+            else:
+                break
+        return tile_k
+
+    tile_k = MIN_TILE_K
+    upper = min(K, effective_max_tk)
+    best = tile_k
+    while tile_k <= upper:
+        num_blocks = M * triton.cdiv(K, tile_k)
+        if num_blocks / num_cores >= TARGET_WAVES:
+            best = tile_k
+            if tile_k * 2 <= upper:
+                tile_k *= 2
+            else:
+                break
+        else:
+            break
+    return best
+
+
+def _nansum_heur_tile_n_non_inner(args):
+    M = args.get("M", 1)
+    if M <= 1:
+        tile_budget = min(_MAX_UB_NON_INNER * 3 // 2, 11520)
+        tile_n = triton.cdiv(tile_budget, args["TILE_K"])
+        tile_n = min(tile_n, args["N"])
+        tile_n = triton.next_power_of_2(tile_n + 1) // 2
+    else:
+        tile_n = triton.cdiv(_MAX_UB_NON_INNER, args["TILE_K"])
+    return min(tile_n, _SAFE_TILE_N_NON_INNER)
+
+
+def _nansum_heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
+def _nansum_heur_num_warps_inner(args):
+    tile_size = args.get("TILE_M", 1) * args.get("TILE_N", 1)
+    # Small-N fast path: tile covers one or few rows → minimal warps needed
+    if args.get("N", 0) <= 256:
+        return 4
+    if tile_size <= 1024:
+        return 4
+    elif tile_size <= 4096:
+        return 8
+    else:
+        return 8
+
+
+def _nansum_heur_num_warps_non_inner(args):
+    tile_size = args.get("TILE_N", 1) * args.get("TILE_K", 1)
+    if args.get("ONE_TILE_PER_CTA") and args.get("M", 1) <= 1:
+        return 4
+    if tile_size <= 1024:
+        return 4
+    elif tile_size <= 4096:
+        return 8
+    else:
+        return 8
+
+
+def _nansum_heur_multi_dim_config(args):
+    M, N = args["M"], args["N"]
+    if M == 1:
+        if N <= 1024:
+            return 1, triton.next_power_of_2(N), 4
+        elif N <= 4096:
+            return 1, 2048, 4
+        elif N <= 16384:
+            return 1, 4096, 4
+        else:
+            return 1, 4096, 8
+    if M <= 4:
+        if N <= 64:
+            return 8, 32, 2
+        elif N <= 256:
+            return 4, 128, 4
+        elif N <= 1024:
+            return 1, 512, 4
+        elif N <= 4096:
+            return 1, 1024, 4
+        else:
+            return 1, 2048, 8
+    if M <= 16:
+        if N <= 64:
+            return 8, 64, 4
+        elif N <= 256:
+            return 8, 256, 4
+        elif N <= 1024:
+            return 4, 512, 8
+        elif N <= 4096:
+            return 4, 1024, 8
+        else:
+            return 2, 2048, 8
+    if M <= 64:
+        if N <= 64:
+            return 8, 64, 4
+        elif N <= 256:
+            return 8, 256, 8
+        elif N <= 1024:
+            return 4, 512, 8
+        else:
+            return 4, 1024, 8
+    if N <= 64:
+        return 8, 64, 4
+    elif N <= 256:
+        return 8, 256, 8
+    elif N <= 1024:
+        return 4, 512, 8
+    elif N <= 4096:
+        return 4, 1024, 8
+    else:
+        return 2, 2048, 8
+
+
+def _normalize_dims(dim, ndim):
+    if isinstance(dim, int):
+        d = dim if dim >= 0 else dim + ndim
+        return [d]
+    if isinstance(dim, (list, tuple)):
+        if len(dim) == 0:
+            return []
+        if len(dim) == 1:
+            d = dim[0]
+            return [d if d >= 0 else d + ndim]
+        dims = [d if d >= 0 else d + ndim for d in dim]
+        return sorted(set(dims), reverse=True)
+    # dim is None → reduce all dims
+    return list(range(ndim))
+
+
+def _squeeze_dims(result, dims):
+    # dims is already sorted in descending order from _normalize_dims
+    for d in dims:
+        result = result.squeeze(dim=d)
+    return result
+
+
+@libentry()
+@triton.jit
+def _nan_to_zero_kernel(
+    inp,
+    out,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    num_blocks = ext.num_programs(0)
+    for start in range(pid * BLOCK_SIZE, N, num_blocks * BLOCK_SIZE):
+        offsets = start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        val = tl.load(inp + offsets, mask=mask, other=0.0)
+        val = tl.where(val != val, 0.0, val)
+        tl.store(out + offsets, val, mask=mask)
+
+
+@libentry()
+@triton.jit
+def nansum_global_reduce(
+    inp,
+    out,
+    M,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    num_blocks = ext.num_programs(0)
+    _sum = tl.zeros((), dtype=tl.float32)
+
+    for start in range(pid * BLOCK_SIZE, M, num_blocks * BLOCK_SIZE):
+        offsets = start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < M
+        x = tl.load(inp + offsets, mask=mask, other=0.0)
+        x = tl.where(x != x, 0.0, x)
+        _sum += tl.sum(x, axis=0)
+    tl.atomic_add(out, _sum)
+
+
+@libentry()
+@triton.jit
+def nansum_kernel_1(
+    inp,
+    mid,
+    M,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    num_blocks = ext.num_programs(0)
+    _sum = tl.zeros((), dtype=tl.float32)
+
+    for start in range(pid * BLOCK_SIZE, M, num_blocks * BLOCK_SIZE):
+        offsets = start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < M
+        x = tl.load(inp + offsets, mask=mask, other=0.0)
+        x = tl.where(x != x, 0.0, x)
+        _sum += tl.sum(x, axis=0)
+    tl.store(mid + pid, _sum)
+
+
+@libentry()
+@triton.jit
+def nansum_kernel_2(
+    mid,
+    out,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    _sum = tl.zeros((), dtype=tl.float32)
+
+    for start in range(0, N, BLOCK_SIZE):
+        offsets = start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < N
+        val = tl.load(mid + offsets, mask=mask, other=0.0)
+        _sum += tl.sum(val, axis=0)
+    tl.store(out, _sum)
+
+
+@libentry()
+@triton.jit
+def nansum_dim_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    stride = ext.num_programs(0)
+
+    for m_start in range(pid * TILE_M, M, stride * TILE_M):
+        m_offsets = m_start + tl.arange(0, TILE_M)[:, None]
+        m_mask = m_offsets < M
+
+        _sum = tl.zeros([TILE_M, TILE_N], dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[None, :]
+            inp_offsets = m_offsets * N + n_offsets
+            mask = m_mask & (n_offsets < N)
+            val = tl.load(input_ptr + inp_offsets, mask=mask, other=0.0)
+            if tl.constexpr(input_ptr.dtype.element_ty != tl.float32):
+                val = val.to(tl.float32)
+            val = tl.where(val != val, 0.0, val)
+            _sum += val
+
+        result = tl.sum(_sum, axis=1)[:, None]
+        tl.store(output_ptr + m_offsets, result, mask=m_mask)
+
+
+@libentry()
+@triton.jit
+def nansum_dim_kernel_non_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = ext.program_id(0)
+    pid_k = ext.program_id(1)
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)[None, :]
+
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)[:, None]
+        inp_offset = pid_m * N * K + n_offsets * K + k_offsets
+        mask = (n_offsets < N) & (k_offsets < K)
+        val = tl.load(input_ptr + inp_offset, mask=mask, other=0.0)
+        if tl.constexpr(input_ptr.dtype.element_ty != tl.float32):
+            val = val.to(tl.float32)
+        val = tl.where(val != val, 0.0, val)
+        out = tl.sum(val, axis=0, keep_dims=True)
+        out_offset = pid_m * K + k_offsets
+        tl.store(output_ptr + out_offset, out, mask=k_offsets < K)
+    else:
+        _sum = tl.zeros([TILE_N, TILE_K], dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[:, None]
+            inp_offsets = pid_m * N * K + n_offsets * K + k_offsets
+            mask = (n_offsets < N) & (k_offsets < K)
+            val = tl.load(input_ptr + inp_offsets, mask=mask, other=0.0)
+            if tl.constexpr(input_ptr.dtype.element_ty != tl.float32):
+                val = val.to(tl.float32)
+            val = tl.where(val != val, 0.0, val)
+            _sum += val
+        out = tl.sum(_sum, axis=0, keep_dims=True)
+        out_offset = pid_m * K + k_offsets
+        tl.store(output_ptr + out_offset, out, mask=k_offsets < K)
+
+
+@libentry()
+@triton.jit
+def nansum_dim_kernel(
+    inp,
+    out,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = ext.program_id(0) * BLOCK_M
+    stride = ext.num_programs(0) * BLOCK_M
+
+    for m_start in range(pid, M, stride):
+        m_offsets = m_start + tl.arange(0, BLOCK_M)[:, None]
+        m_mask = m_offsets < M
+
+        _sum = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        for start_n in range(0, N, BLOCK_N):
+            n_offsets = start_n + tl.arange(0, BLOCK_N)[None, :]
+            val = tl.load(
+                inp + m_offsets * N + n_offsets,
+                mask=m_mask & (n_offsets < N),
+                other=0.0,
+            )
+            val = tl.where(val != val, 0.0, val)
+            _sum += val
+
+        result = tl.sum(_sum, axis=1)[:, None]
+        tl.store(out + m_offsets, result, mask=m_mask)
+
+
+def nansum(inp, dim=None, keepdim=False, *, dtype=None):
+    logger.debug("GEMS_ASCEND NANSUM")
+
+    if dim is not None:
+        return nansum_dim(inp, dim=dim, keepdim=keepdim, dtype=dtype)
+
+    if dtype is None:
+        dtype = inp.dtype
+
+    if inp.numel() == 0:
+        return torch.tensor(0, dtype=dtype, device=inp.device)
+
+    if not inp.is_contiguous():
+        work = inp.contiguous()
+    else:
+        work = inp
+    if inp.dtype == torch.bool:
+        work = work.to(torch.int64)
+    M = work.numel()
+
+    num_cores = _get_num_vector_cores()
+
+    _TWO_STAGE_THRESHOLD = 100 * 1024 * 1024
+    use_two_stage = M > _TWO_STAGE_THRESHOLD
+
+    if M <= 4096:
+        grid_size = 4
+        block_size = triton.next_power_of_2(M)
+        num_warps = 4
+    elif M <= 32768:
+        grid_size = 4
+        block_size = max(4096, triton.next_power_of_2(max(1, math.ceil(M / grid_size))))
+        block_size = min(block_size, _global_ub_cap(work.dtype))
+        num_warps = 4 if block_size <= 4096 else 8
+    elif M <= 131072:
+        grid_size = 16
+        block_size = max(4096, triton.next_power_of_2(max(1, math.ceil(M / grid_size))))
+        block_size = min(block_size, _global_ub_cap(work.dtype))
+        num_warps = 8
+    else:
+        grid_size = num_cores * 2 if use_two_stage else num_cores
+        block_size = max(4096, triton.next_power_of_2(max(1, math.ceil(M / grid_size))))
+        block_size = min(block_size, _global_ub_cap(work.dtype))
+        num_warps = 8
+
+    with torch_device_fn.device(work.device):
+        if use_two_stage:
+            mid = torch.empty(grid_size, dtype=torch.float32, device=work.device)
+            nansum_kernel_1[(grid_size,)](
+                work,
+                mid,
+                M,
+                block_size,
+                num_warps=num_warps,
+                num_stages=2,
+            )
+            final_block = triton.next_power_of_2(min(grid_size, _MAX_UB_GLOBAL))
+            out = torch.zeros([], dtype=torch.float32, device=work.device)
+            nansum_kernel_2[(1,)](
+                mid,
+                out,
+                grid_size,
+                final_block,
+                num_warps=4,
+                num_stages=2,
+            )
+        else:
+            out = torch.zeros([], dtype=torch.float32, device=work.device)
+            nansum_global_reduce[(grid_size,)](
+                work,
+                out,
+                M,
+                block_size,
+                num_warps=num_warps,
+                num_stages=2,
+            )
+
+    return out.to(dtype)
+
+
+def nansum_out(inp, dim=None, keepdim=False, *, dtype=None, out=None):
+    logger.debug("GEMS_ASCEND NANSUM_OUT")
+    result = nansum(inp, dim=dim, keepdim=keepdim, dtype=dtype)
+    out.copy_(result)
+    return out
+
+
+def nansum_dim(inp, dim=None, keepdim=False, *, dtype=None):
+    logger.debug("GEMS_ASCEND NANSUM_DIM")
+
+    if dtype is None:
+        dtype = inp.dtype
+
+    if inp.numel() == 0:
+        out_shape = list(inp.shape)
+        if dim is None:
+            out_shape = [1] * inp.ndim if keepdim else []
+        else:
+            dims = _normalize_dims(dim, inp.ndim)
+            if keepdim:
+                for d in dims:
+                    out_shape[d] = 1
+            else:
+                for d in dims:  # already sorted descending
+                    out_shape.pop(d)
+        return torch.zeros(out_shape, dtype=dtype, device=inp.device)
+
+    dims = _normalize_dims(dim, inp.ndim)
+
+    if len(dims) == inp.ndim:
+        result = nansum(inp, dtype=dtype)
+        if keepdim:
+            result = result.reshape([1] * inp.ndim)
+        return result
+
+    if not inp.is_contiguous():
+        work = inp.contiguous()
+    else:
+        work = inp
+    if work.dtype == torch.bool:
+        work = work.to(torch.int64)
+
+    shape = work.shape
+    ndim = len(shape)
+
+    if len(dims) == 1:
+        dim = dims[0]
+        N = shape[dim]
+
+        M = 1
+        for i in range(dim):
+            M *= shape[i]
+        K = 1
+        for i in range(dim + 1, ndim):
+            K *= shape[i]
+
+        out_shape = list(shape)
+        out_shape[dim] = 1
+        num_cores = _get_num_vector_cores()
+
+        if N <= 1:
+            out = torch.empty_like(work, dtype=torch.float32)
+            numel = work.numel()
+            nz_block_size = triton.next_power_of_2(min(numel, 8192))
+            grid = (min(triton.cdiv(numel, nz_block_size), num_cores),)
+            with torch_device_fn.device(work.device):
+                _nan_to_zero_kernel[grid](
+                    work,
+                    out,
+                    numel,
+                    BLOCK_SIZE=nz_block_size,
+                    num_warps=4,
+                    num_stages=2,
+                )
+            out = out.reshape(out_shape)
+            if not keepdim:
+                out = out.squeeze(dim=dim)
+            return out.to(dtype)
+
+        out_flat = torch.empty(out_shape, dtype=torch.float32, device=work.device)
+
+        if K > 1:
+            tile_k = _nansum_heur_tile_k({"M": M, "K": K, "N": N})
+            tile_n = _nansum_heur_tile_n_non_inner({"M": M, "N": N, "TILE_K": tile_k})
+            one_tile = _nansum_heur_one_tile_per_cta({"TILE_N": tile_n, "N": N})
+            nw = _nansum_heur_num_warps_non_inner(
+                {
+                    "TILE_N": tile_n,
+                    "TILE_K": tile_k,
+                    "ONE_TILE_PER_CTA": one_tile,
+                    "M": M,
+                }
+            )
+            _launch_non_inner_cached(
+                out_flat,
+                work,
+                M,
+                N,
+                K,
+                tile_n,
+                tile_k,
+                one_tile,
+                nw,
+                2,
+                (M, triton.cdiv(K, tile_k)),
+            )
+        else:
+            tile_n = _nansum_heur_tile_n_inner({"N": N, "M": M})
+            tile_m = _nansum_heur_tile_m_inner({"M": M, "N": N, "TILE_N": tile_n})
+            nw = _nansum_heur_num_warps_inner(
+                {"TILE_M": tile_m, "TILE_N": tile_n, "N": N}
+            )
+            MIN_DATA_PER_BLOCK = 256 * 1024
+            total_elems = M * N
+            max_grid = max(
+                num_cores * 8,
+                min(num_cores * 256, max(1, total_elems // MIN_DATA_PER_BLOCK)),
+            )
+            grid_size = min(triton.cdiv(M, tile_m), max_grid)
+            _launch_inner_cached(
+                out_flat,
+                work,
+                M,
+                N,
+                tile_m,
+                tile_n,
+                nw,
+                2,
+                (grid_size,),
+            )
+
+        result = out_flat.to(dtype)
+        return result if keepdim else _squeeze_dims(result, dims)
+
+    # Multi-dim reduction: dim_compress + 2D tile kernel
+    work = dim_compress(work, dims)
+    N = 1
+    shape_list = list(shape)  # shape may be tuple (torch.Size), need mutable list
+    for d in dims:
+        N *= shape_list[d]
+        shape_list[d] = 1
+    M = work.numel() // N
+    num_cores = _get_num_vector_cores()
+
+    if N <= 1:
+        out = torch.empty_like(work, dtype=torch.float32)
+        numel = work.numel()
+        nz_block_size = triton.next_power_of_2(min(numel, 8192))
+        grid = (min(triton.cdiv(numel, nz_block_size), num_cores),)
+        with torch_device_fn.device(work.device):
+            _nan_to_zero_kernel[grid](
+                work,
+                out,
+                numel,
+                BLOCK_SIZE=nz_block_size,
+                num_warps=4,
+                num_stages=2,
+            )
+        out = out.reshape(shape_list)
+        result = out.to(dtype)
+        return result if keepdim else _squeeze_dims(result, dims)
+
+    out_flat = torch.empty(M, dtype=torch.float32, device=work.device)
+    block_m, block_n, nw = _nansum_heur_multi_dim_config({"M": M, "N": N})
+    max_tasks = triton.cdiv(M, block_m)
+    grid_size = max_tasks if max_tasks <= num_cores else min(max_tasks, num_cores * 6)
+
+    _launch_multi_dim_cached(
+        work,
+        out_flat,
+        M,
+        N,
+        block_m,
+        block_n,
+        nw,
+        2,
+        (grid_size,),
+    )
+
+    out_flat = out_flat.reshape(shape_list)
+    result = out_flat.to(dtype)
+    return result if keepdim else _squeeze_dims(result, dims)

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -24,6 +24,7 @@ from .matmul_bf16 import matmul_bf16
 from .matmul_int8 import matmul_int8
 from .min import min, min_dim
 from .mm import mm, mm_out
+from .nansum import nansum, nansum_out
 from .nonzero import nonzero
 from .ones import ones
 from .ones_like import ones_like
@@ -81,6 +82,8 @@ __all__ = [
     "min",
     "mm",
     "mm_out",
+    "nansum",
+    "nansum_out",
     "nonzero",
     "ones",
     "ones_like",

--- a/src/flag_gems/runtime/backend/_metax/ops/nansum.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/nansum.py
@@ -1,0 +1,494 @@
+import logging
+import math
+from functools import reduce
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def _nan_to_zero_kernel(
+    inp,
+    out,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+    val = tl.load(inp + offsets, mask=mask, other=0.0)
+    val = tl.where(val != val, 0.0, val)
+    tl.store(out + offsets, val, mask=mask)
+
+
+@libentry()
+@triton.jit
+def nansum_kernel_1(
+    inp,
+    mid,
+    M,
+    BLOCK_SIZE: tl.constexpr,
+):
+    if tl.constexpr(inp.dtype.element_ty == tl.float64):
+        cdtype = tl.float64
+    else:
+        cdtype = tl.float32
+
+    pid = ext.program_id(0)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    inp_ptrs = inp + offset
+    mask = offset < M
+
+    x = tl.load(inp_ptrs, mask=mask, other=0.0).to(cdtype)
+    x = tl.where(x != x, 0.0, x)
+
+    sum_val = tl.sum(x, axis=0)
+    mid_ptr = mid + pid
+    tl.store(mid_ptr, sum_val)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("nansum_final_reduce"),
+    key=["mid_size"],
+)
+@triton.jit
+def nansum_kernel_2(
+    mid,
+    out,
+    mid_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    if tl.constexpr(mid.dtype.element_ty == tl.float64):
+        cdtype = tl.float64
+    else:
+        cdtype = tl.float32
+
+    _sum = tl.zeros((), dtype=cdtype)
+
+    for start in range(0, mid_size, BLOCK_SIZE):
+        idx = start + tl.arange(0, BLOCK_SIZE)
+        mask = idx < mid_size
+        val = tl.load(mid + idx, mask=mask, other=0.0).to(cdtype)
+        val = tl.where(val != val, 0.0, val)
+        _sum += tl.sum(val, axis=0)
+
+    tl.store(out, _sum)
+
+
+def _nansum_global(inp, *, dtype=None):
+    if dtype is None:
+        dtype = inp.dtype
+        if dtype == torch.bool:
+            inp = inp.to(torch.int64)
+            dtype = torch.int64
+
+    if inp.numel() == 0:
+        return torch.tensor(0, dtype=dtype, device=inp.device)
+
+    if not inp.is_contiguous():
+        inp = inp.contiguous()
+    M = inp.numel()
+
+    if M <= 32768:
+        out = torch.zeros([], dtype=dtype, device=inp.device)
+        with torch_device_fn.device(inp.device):
+            nansum_kernel_2[(1,)](inp, out, M)
+        return out
+
+    compute_dtype = (
+        torch.float64
+        if inp.dtype == torch.float64 or dtype == torch.float64
+        else torch.float32
+    )
+    block_size = max(triton.next_power_of_2(math.ceil(math.sqrt(M))), 4096)
+    mid_size = triton.cdiv(M, block_size)
+    mid = torch.empty(mid_size, dtype=compute_dtype, device=inp.device)
+
+    with torch_device_fn.device(inp.device):
+        nansum_kernel_1[(mid_size, 1, 1)](inp, mid, M, block_size)
+        out = torch.zeros([], dtype=dtype, device=inp.device)
+        nansum_kernel_2[(1,)](mid, out, mid_size)
+
+    return out
+
+
+def nansum(inp, dim=None, keepdim=False, *, dtype=None):
+    logger.debug("GEMS_METAX NANSUM")
+    if dim is None:
+        return _nansum_global(inp, dtype=dtype)
+    return nansum_dim(inp, dim=dim, keepdim=keepdim, dtype=dtype)
+
+
+def nansum_out(inp, dim=None, keepdim=False, *, dtype=None, out=None):
+    logger.debug("GEMS_METAX NANSUM_OUT")
+    result = nansum(inp, dim=dim, keepdim=keepdim, dtype=dtype)
+    out.copy_(result)
+    return out
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("nansum_dim"),
+    key=["M", "N"],
+)
+@triton.jit
+def nansum_dim_kernel(
+    inp,
+    out,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    if tl.constexpr(inp.dtype.element_ty == tl.float64):
+        cdtype = tl.float64
+    else:
+        cdtype = tl.float32
+
+    pid = ext.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    inp = inp + pid * N
+    out = out + pid
+    row_mask = pid < M
+
+    _sum = tl.zeros([BLOCK_M, BLOCK_N], dtype=cdtype)
+
+    for off in range(0, N, BLOCK_N):
+        cols = off + tl.arange(0, BLOCK_N)[None, :]
+        col_mask = cols < N
+        mask = row_mask & col_mask
+        val = tl.load(inp + cols, mask, other=0.0).to(cdtype)
+        val = tl.where(val != val, 0.0, val)
+        _sum += val
+
+    result = tl.sum(_sum, axis=1)[:, None]
+    tl.store(out, result, row_mask)
+
+
+def _nansum_heur_tile_k(args):
+    MAX_TILE_K = 8192
+    NUM_SMS = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+
+    if args["M"] <= 4:
+        MIN_TILE_K = 8
+        if args["M"] <= 1 and args["K"] > 32768 and args["N"] > 256:
+            if args["input_ptr"].dtype == torch.float32:
+                TARGET_WAVES = 8
+            else:
+                # Prefer heavier blocks (TARGET_WAVES=4) unless iterations
+                # per block would exceed 16, then use 8 for more parallelism.
+                test_tk = MIN_TILE_K
+                ub = min(args["K"], MAX_TILE_K)
+                while test_tk <= ub:
+                    n_blocks = args["M"] * triton.cdiv(args["K"], test_tk)
+                    if n_blocks / NUM_SMS >= 4:
+                        if test_tk * 2 <= ub:
+                            test_tk *= 2
+                        else:
+                            break
+                    else:
+                        break
+                test_tn = triton.cdiv(32768, test_tk)
+                test_tn = min(test_tn, args["N"])
+                test_tn = triton.next_power_of_2(test_tn + 1) // 2
+                test_iters = triton.cdiv(args["N"], test_tn)
+                TARGET_WAVES = 8 if test_iters > 16 else 4
+        else:
+            TARGET_WAVES = 4
+
+        tile_k = MIN_TILE_K
+        upper_bound = min(args["K"], MAX_TILE_K)
+        best_tile_k = tile_k
+        while tile_k <= upper_bound:
+            num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+            num_waves = num_blocks / NUM_SMS
+            if num_waves >= TARGET_WAVES:
+                best_tile_k = tile_k
+                if tile_k * 2 <= upper_bound:
+                    tile_k *= 2
+                else:
+                    break
+            else:
+                break
+        return best_tile_k
+    elif args["M"] <= 64:
+        TARGET_WAVES = 2
+        tile_k = 1
+        upper_bound = min(args["K"], MAX_TILE_K)
+        prev_tile_k = tile_k
+        while tile_k <= upper_bound:
+            num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+            num_waves = num_blocks / NUM_SMS
+            if num_waves > TARGET_WAVES:
+                prev_tile_k = tile_k
+                if tile_k * 2 <= upper_bound:
+                    tile_k *= 2
+                else:
+                    break
+            else:
+                break
+        return prev_tile_k
+    else:
+        tile_k = 1
+        upper_bound = min(args["K"], MAX_TILE_K)
+        while tile_k <= upper_bound:
+            num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+            num_waves = num_blocks / NUM_SMS
+            if (num_waves > 1) and (tile_k * 2 <= upper_bound):
+                tile_k *= 2
+            else:
+                break
+        return tile_k
+
+
+def _nansum_heur_tile_n_non_inner(args):
+    tile_budget = 32768 if args["M"] <= 1 else 8192
+    tile_n = triton.cdiv(tile_budget, args["TILE_K"])
+    if args["M"] <= 1:
+        tile_n = min(tile_n, args["N"])
+        return triton.next_power_of_2(tile_n + 1) // 2
+    return tile_n
+
+
+def _nansum_heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
+def _nansum_heur_tile_n_inner(args):
+    if args["N"] <= (32 * 1024):
+        return triton.next_power_of_2(args["N"])
+    else:
+        return 4096
+
+
+def _nansum_heur_tile_m_inner(args):
+    NUM_SMS = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+
+    if args["M"] <= NUM_SMS * 16 or args["N"] > 256:
+        return 1
+
+    TARGET_GRID = NUM_SMS * 6
+    tile_m = triton.next_power_of_2(max(args["M"] // TARGET_GRID, 1))
+    max_tile_m = max(16384 // args["TILE_N"], 1)
+    return min(tile_m, max_tile_m, 256)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("nansum_dim_non_inner"),
+    key=["M", "N", "K"],
+)
+@triton.heuristics(
+    values=dict(
+        TILE_K=_nansum_heur_tile_k,
+        TILE_N=_nansum_heur_tile_n_non_inner,
+        ONE_TILE_PER_CTA=_nansum_heur_one_tile_per_cta,
+    ),
+)
+@triton.jit
+def nansum_dim_kernel_non_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    if tl.constexpr(input_ptr.dtype.element_ty == tl.float64):
+        cdtype = tl.float64
+    else:
+        cdtype = tl.float32
+
+    pid_m = ext.program_id(0)
+    pid_k = ext.program_id(1)
+
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)[None, :]
+
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)[:, None]
+        inp_offset = pid_m * N * K + n_offsets * K + k_offsets
+        mask = (n_offsets < N) & (k_offsets < K)
+        inp = tl.load(input_ptr + inp_offset, mask=mask, other=0.0).to(cdtype)
+        inp = tl.where(inp != inp, 0.0, inp)
+        out = tl.sum(inp, axis=0, keep_dims=True)
+        out_offset = pid_m * K + k_offsets
+        tl.store(output_ptr + out_offset, out, mask=k_offsets < K)
+    else:
+        _sum = tl.zeros([TILE_N, TILE_K], dtype=cdtype)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[:, None]
+            inp_offsets = pid_m * N * K + n_offsets * K + k_offsets
+            mask = (n_offsets < N) & (k_offsets < K)
+            inp = tl.load(input_ptr + inp_offsets, mask=mask, other=0.0).to(cdtype)
+            inp = tl.where(inp != inp, 0.0, inp)
+            _sum += inp
+        out = tl.sum(_sum, axis=0, keep_dims=True)
+        out_offset = pid_m * K + k_offsets
+        tl.store(output_ptr + out_offset, out, mask=k_offsets < K)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("nansum_dim_inner"),
+    key=["M", "N"],
+)
+@triton.heuristics(
+    values=dict(
+        TILE_N=_nansum_heur_tile_n_inner,
+        TILE_M=_nansum_heur_tile_m_inner,
+    ),
+)
+@triton.jit
+def nansum_dim_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+):
+    if tl.constexpr(input_ptr.dtype.element_ty == tl.float64):
+        cdtype = tl.float64
+    else:
+        cdtype = tl.float32
+
+    pid = ext.program_id(0)
+    m_start = pid * TILE_M + tl.arange(0, TILE_M)[:, None]
+    m_mask = m_start < M
+
+    _sum = tl.zeros([TILE_M, TILE_N], dtype=cdtype)
+    for start_n in range(0, N, TILE_N):
+        n_offsets = start_n + tl.arange(0, TILE_N)[None, :]
+        inp_offsets = m_start * N + n_offsets
+        mask = m_mask & (n_offsets < N)
+        inp = tl.load(input_ptr + inp_offsets, mask=mask, other=0.0).to(cdtype)
+        inp = tl.where(inp != inp, 0.0, inp)
+        _sum += inp
+
+    result = tl.sum(_sum, axis=1)[:, None]
+    tl.store(output_ptr + m_start, result, mask=m_mask)
+
+
+def _normalize_dims(dim, ndim):
+    if isinstance(dim, (list, tuple)) and len(dim) == 0:
+        return []
+    if dim is None:
+        return list(range(ndim))
+    if isinstance(dim, int):
+        dim = [dim]
+    dims = [d if d >= 0 else d + ndim for d in dim]
+    return sorted(set(dims), reverse=True)
+
+
+def _squeeze_dims(result, dims):
+    for d in sorted(dims, reverse=True):
+        result = result.squeeze(dim=d)
+    return result
+
+
+def nansum_dim(inp, dim=None, keepdim=False, *, dtype=None):
+    if dtype is None:
+        dtype = inp.dtype
+        if dtype == torch.bool:
+            inp = inp.to(torch.int64)
+            dtype = torch.int64
+
+    dims = _normalize_dims(dim, inp.ndim)
+
+    if len(dims) == 0:
+        result = _nansum_global(inp, dtype=dtype)
+        if keepdim:
+            result = result.reshape([1] * inp.ndim)
+        return result
+
+    if inp.numel() == 0:
+        out_shape = list(inp.shape)
+        if keepdim:
+            for d in dims:
+                out_shape[d] = 1
+        else:
+            for d in dims:
+                out_shape.pop(d)
+        return torch.zeros(out_shape, dtype=dtype, device=inp.device)
+
+    if len(dims) == inp.ndim:
+        result = _nansum_global(inp, dtype=dtype)
+        if keepdim:
+            result = result.reshape([1] * inp.ndim)
+        return result
+
+    shape = list(inp.shape)
+
+    if len(dims) == 1:
+        dim = dims[0]
+        if not inp.is_contiguous():
+            inp = inp.contiguous()
+        N = shape[dim]
+        M = reduce(lambda x, y: x * y, shape[:dim], 1)
+        K = inp.numel() // (M * N)
+
+        out_shape = list(shape)
+        out_shape[dim] = 1
+
+        if N <= 1:
+            NANZERO_BLOCK = 4096
+            grid = (triton.cdiv(inp.numel(), NANZERO_BLOCK),)
+            out = torch.empty_like(inp, dtype=dtype)
+            with torch_device_fn.device(inp.device):
+                _nan_to_zero_kernel[grid](
+                    inp, out, inp.numel(), BLOCK_SIZE=NANZERO_BLOCK
+                )
+            out = out.reshape(out_shape)
+            return out if keepdim else _squeeze_dims(out, dims)
+
+        out = torch.empty(out_shape, dtype=dtype, device=inp.device)
+
+        with torch_device_fn.device(inp.device):
+            if K > 1:
+                grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+                nansum_dim_kernel_non_inner[grid](out, inp, M, N, K)
+            else:
+                grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+                nansum_dim_kernel_inner[grid](out, inp, M, N)
+
+        return out if keepdim else _squeeze_dims(out, dims)
+
+    inp = dim_compress(inp, dims)
+    N = 1
+    for d in dims:
+        N *= shape[d]
+        shape[d] = 1
+    M = inp.numel() // N
+
+    if N <= 1:
+        NANZERO_BLOCK = 4096
+        grid = (triton.cdiv(inp.numel(), NANZERO_BLOCK),)
+        out = torch.empty_like(inp, dtype=dtype)
+        with torch_device_fn.device(inp.device):
+            _nan_to_zero_kernel[grid](inp, out, inp.numel(), BLOCK_SIZE=NANZERO_BLOCK)
+        out = out.reshape(shape)
+        return out if keepdim else _squeeze_dims(out, dims)
+
+    out = torch.empty(M, dtype=dtype, device=inp.device)
+
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    with torch_device_fn.device(inp.device):
+        nansum_dim_kernel[grid](inp, out, M, N)
+
+    out = out.reshape(shape)
+    return out if keepdim else _squeeze_dims(out, dims)

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -1240,3 +1240,70 @@ add_rms_norm_loop:
     tile_n:
       - 512
       - 1024
+nansum_final_reduce:
+- META:
+    BLOCK_SIZE: 256
+  num_warps: 4
+- META:
+    BLOCK_SIZE: 512
+  num_warps: 8
+- META:
+    BLOCK_SIZE: 1024
+  num_warps: 8
+- META:
+    BLOCK_SIZE: 2048
+  num_warps: 8
+- META:
+    BLOCK_SIZE: 4096
+  num_warps: 8
+nansum_dim:
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 32
+  num_warps: 2
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 64
+  num_warps: 4
+- META:
+    BLOCK_M: 4
+    BLOCK_N: 128
+  num_warps: 4
+- META:
+    BLOCK_M: 4
+    BLOCK_N: 256
+  num_warps: 4
+- META:
+    BLOCK_M: 4
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 1
+    BLOCK_N: 256
+  num_warps: 4
+- META:
+    BLOCK_M: 1
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 1
+    BLOCK_N: 1024
+  num_warps: 8
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+nansum_dim_non_inner:
+- META: {}
+  num_warps: 4
+- META: {}
+  num_warps: 8
+- META: {}
+  num_warps: 16
+nansum_dim_inner:
+- META: {}
+  num_warps: 4
+- META: {}
+  num_warps: 8
+- META: {}
+  num_warps: 16


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add nansum operator with triton kernel, supporting both Ascend and MetaX backends.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Benchmark on Ascend 910B
```
root@bm-ctyun-wq-910b-64g-0-13:/home/secure/qhait/FlagGems# pytest benchmark/test_nansum.py -v -s --mode=operator
============================================================================================================================ test session starts =============================================================================================================================
platform linux -- Python 3.11.13, pytest-8.3.2, pluggy-1.6.0 -- /usr/local/python3.11.13/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/secure/qhait/FlagGems
configfile: pytest.ini
plugins: xdist-3.6.1, anyio-4.10.0
collected 1 item                                                                                                                                                                                                                                                             

benchmark/test_nansum.py::test_benchmark_nansum 
Operator: nansum  Performance Test (dtype=torch.float16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.019466            0.191371               0.102             215.466              21.917          [torch.Size([1048576])]
SUCCESS               0.018533            0.176941               0.105               0.884               0.093          [torch.Size([64, 64])]
SUCCESS               0.019232            0.146995               0.131               0.852               0.111          [torch.Size([64, 64]), -1]
SUCCESS               0.019538            0.148155               0.132               0.839               0.111          [torch.Size([64, 64]), 0]
SUCCESS               0.141048            0.179254               0.787             475.787             374.379          [torch.Size([4096, 4096])]
SUCCESS               0.138583            0.150588               0.920             484.249             445.646          [torch.Size([4096, 4096]), -1]
SUCCESS               0.171928            0.148080               1.161             390.332             453.193          [torch.Size([4096, 4096]), 0]
SUCCESS               0.141100            0.182019               0.775             475.614             368.692          [torch.Size([64, 512, 512])]
SUCCESS               0.135311            0.151787               0.891             495.960             442.125          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.172913            0.151255               1.143             388.108             443.682          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.170302            0.148240               1.149             394.059             452.704          [torch.Size([64, 512, 512]), 1]
SUCCESS              10.111756            2.849519               3.549             424.750            1507.260          [torch.Size([1024, 1024, 1024])]
SUCCESS               8.653207            3.563695               2.428             496.344            1205.200          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               9.165454            3.400740               2.695             468.604            1262.951          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               8.377704            3.251537               2.577             512.666            1320.904          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.016775            0.182496               0.092             250.275              23.005          [torch.Size([1049600])]
SUCCESS              10.115094            2.825365               3.580             424.610            1520.146          [torch.Size([1073741824])]
SUCCESS               0.017248            0.173254               0.100               0.237               0.024          [torch.Size([1024, 1])]
SUCCESS               0.017894            0.199206               0.090               0.229               0.021          [torch.Size([1024, 1]), -1]
SUCCESS               0.017760            0.149344               0.119               0.231               0.027          [torch.Size([1024, 1]), 0]
SUCCESS               0.017167            0.180810               0.095               3.817               0.362          [torch.Size([1024, 16])]
SUCCESS               0.018134            0.146203               0.124               3.614               0.448          [torch.Size([1024, 16]), -1]
SUCCESS               0.017862            0.147247               0.121               3.669               0.445          [torch.Size([1024, 16]), 0]
SUCCESS               0.017482            0.179831               0.097              59.981               5.831          [torch.Size([1024, 256])]
SUCCESS               0.016793            0.145163               0.116              62.442               7.223          [torch.Size([1024, 256]), -1]
SUCCESS               0.030008            0.143019               0.210              34.943               7.332          [torch.Size([1024, 256]), 0]
SUCCESS               0.041442            0.182311               0.227             404.837              92.025          [torch.Size([1024, 4096])]
SUCCESS               0.040100            0.151500               0.265             418.380             110.741          [torch.Size([1024, 4096]), -1]
SUCCESS               0.057088            0.149898               0.381             293.884             111.924          [torch.Size([1024, 4096]), 0]
SUCCESS               0.539156            0.185810               2.902             497.881            1444.674          [torch.Size([1024, 65536])]
SUCCESS               0.480075            0.199057               2.412             559.153            1348.538          [torch.Size([1024, 65536]), -1]
SUCCESS               0.624557            0.200281               3.118             429.801            1340.297          [torch.Size([1024, 65536]), 0]
SUCCESS              10.113663            2.824454               3.581             424.670            1520.636          [torch.Size([1024, 1048576])]
SUCCESS               8.445393            3.286230               2.570             508.557            1306.959          [torch.Size([1024, 1048576]), -1]
SUCCESS               9.234667            3.390133               2.724             465.092            1266.902          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.017291            0.178720               0.097               0.948               0.092          [torch.Size([64, 1, 64])]
SUCCESS               0.019390            0.144198               0.134               0.845               0.114          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.018306            0.144023               0.127               0.895               0.114          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.017499            0.199098               0.088               0.936               0.082          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.016387            0.178779               0.092              15.997               1.466          [torch.Size([64, 16, 64])]
SUCCESS               0.017700            0.145695               0.121              14.810               1.799          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.018058            0.142914               0.126              14.517               1.834          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.018427            0.145889               0.126              14.226               1.797          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.017115            0.182310               0.094             245.063              23.006          [torch.Size([64, 256, 64])]
SUCCESS               0.017833            0.143896               0.124             235.201              29.148          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.025297            0.145605               0.174             165.804              28.806          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.018375            0.141931               0.129             228.256              29.552          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.141114            0.184513               0.765             475.566             363.708          [torch.Size([64, 4096, 64])]
SUCCESS               0.143982            0.145864               0.987             466.090             460.079          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.172894            0.150345               1.150             388.149             446.366          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.154324            0.147844               1.044             434.858             453.918          [torch.Size([64, 4096, 64]), 1]


Operator: nansum  Performance Test (dtype=torch.float32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.024503            0.153045               0.160             342.351              54.812          [torch.Size([1048576])]
SUCCESS               0.017214            0.144178               0.119               1.904               0.227          [torch.Size([64, 64])]
SUCCESS               0.017371            0.109286               0.159               1.886               0.300          [torch.Size([64, 64]), -1]
SUCCESS               0.018262            0.110547               0.165               1.794               0.296          [torch.Size([64, 64]), 0]
SUCCESS               0.134129            0.147833               0.907            1000.664             907.903          [torch.Size([4096, 4096])]
SUCCESS               0.137947            0.113036               1.220             972.968            1187.385          [torch.Size([4096, 4096]), -1]
SUCCESS               0.159451            0.110964               1.437             841.749            1209.557          [torch.Size([4096, 4096]), 0]
SUCCESS               0.134287            0.146558               0.916             999.486             915.800          [torch.Size([64, 512, 512])]
SUCCESS               0.130709            0.113125               1.155            1026.846            1186.453          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.160072            0.111861               1.431             838.483            1199.863          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.165965            0.107703               1.541             808.711            1246.184          [torch.Size([64, 512, 512]), 1]
SUCCESS              11.069924            3.941073               2.809             775.971            2179.593          [torch.Size([1024, 1024, 1024])]
SUCCESS               8.457292            3.658551               2.312            1015.684            2347.906          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               8.896394            3.773888               2.357             965.552            2276.150          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               8.543795            3.275411               2.608            1005.400            2622.552          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.017103            0.149778               0.114             490.960              56.062          [torch.Size([1049600])]
SUCCESS              11.073053            3.923674               2.822             775.751            2189.258          [torch.Size([1073741824])]
SUCCESS               0.017398            0.145423               0.120               0.471               0.056          [torch.Size([1024, 1])]
SUCCESS               0.017741            0.160430               0.111               0.462               0.051          [torch.Size([1024, 1]), -1]
SUCCESS               0.017843            0.114522               0.156               0.459               0.072          [torch.Size([1024, 1]), 0]
SUCCESS               0.017337            0.149223               0.116               7.560               0.878          [torch.Size([1024, 16])]
SUCCESS               0.018080            0.111244               0.163               7.250               1.178          [torch.Size([1024, 16]), -1]
SUCCESS               0.018193            0.111801               0.163               7.204               1.172          [torch.Size([1024, 16]), 0]
SUCCESS               0.017269            0.150770               0.115             121.438              13.910          [torch.Size([1024, 256])]
SUCCESS               0.018482            0.110107               0.168             113.473              19.047          [torch.Size([1024, 256]), -1]
SUCCESS               0.027082            0.109323               0.248              77.438              19.183          [torch.Size([1024, 256]), 0]
SUCCESS               0.039835            0.149249               0.267             842.338             224.822          [torch.Size([1024, 4096])]
SUCCESS               0.041154            0.112456               0.366             815.336             298.378          [torch.Size([1024, 4096]), -1]
SUCCESS               0.056426            0.109441               0.516             594.664             306.598          [torch.Size([1024, 4096]), 0]
SUCCESS               0.561979            0.223948               2.509             955.322            2397.305          [torch.Size([1024, 65536])]
SUCCESS               0.521977            0.212571               2.456            1028.534            2525.605          [torch.Size([1024, 65536]), -1]
SUCCESS               0.574830            0.237630               2.419             933.964            2259.273          [torch.Size([1024, 65536]), 0]
SUCCESS              11.078387            3.933509               2.816             775.378            2183.784          [torch.Size([1024, 1048576])]
SUCCESS               8.891778            3.267026               2.722             966.054            2629.283          [torch.Size([1024, 1048576]), -1]
SUCCESS               8.891691            3.759797               2.365             966.063            2284.681          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.016808            0.145669               0.115               1.950               0.225          [torch.Size([64, 1, 64])]
SUCCESS               0.018105            0.110003               0.165               1.810               0.298          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.016681            0.107074               0.156               1.964               0.306          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.017386            0.158278               0.110               1.885               0.207          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.017286            0.148360               0.117              30.331               3.534          [torch.Size([64, 16, 64])]
SUCCESS               0.018212            0.109174               0.167              28.788               4.802          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.017759            0.107046               0.166              29.522               4.898          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.018139            0.111060               0.163              28.904               4.721          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.016798            0.150980               0.111             499.373              55.561          [torch.Size([64, 256, 64])]
SUCCESS               0.017799            0.112606               0.158             471.301              74.495          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.019206            0.111515               0.172             436.762              75.224          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.017656            0.109241               0.162             475.101              76.790          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.134015            0.150506               0.890            1001.510             891.777          [torch.Size([64, 4096, 64])]
SUCCESS               0.138050            0.110198               1.253             972.243            1217.968          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.159221            0.111225               1.432             842.966            1206.726          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.149261            0.108565               1.375             899.214            1236.289          [torch.Size([64, 4096, 64]), 1]


Operator: nansum  Performance Test (dtype=torch.bfloat16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.021607            0.187045               0.116             194.121              22.424          [torch.Size([1048576])]
SUCCESS               0.017496            0.178667               0.098               0.936               0.092          [torch.Size([64, 64])]
SUCCESS               0.017953            0.148464               0.121               0.913               0.110          [torch.Size([64, 64]), -1]
SUCCESS               0.017846            0.150886               0.118               0.918               0.109          [torch.Size([64, 64]), 0]
SUCCESS               0.141028            0.184900               0.763             475.856             362.946          [torch.Size([4096, 4096])]
SUCCESS               0.138282            0.151868               0.911             485.304             441.889          [torch.Size([4096, 4096]), -1]
SUCCESS               0.171030            0.152390               1.122             392.381             440.376          [torch.Size([4096, 4096]), 0]
SUCCESS               0.141122            0.183194               0.770             475.537             366.326          [torch.Size([64, 512, 512])]
SUCCESS               0.135079            0.153604               0.879             496.810             436.897          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.172541            0.153578               1.123             388.945             436.969          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.170095            0.147069               1.157             394.537             456.307          [torch.Size([64, 512, 512]), 1]
SUCCESS              10.110325            3.165984               3.193             424.810            1356.598          [torch.Size([1024, 1024, 1024])]
SUCCESS               8.651798            3.563148               2.428             496.425            1205.386          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               9.163666            3.398318               2.697             468.695            1263.851          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               8.374171            3.248636               2.578             512.883            1322.083          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.017334            0.183911               0.094             242.205              22.828          [torch.Size([1049600])]
SUCCESS              10.110325            3.141244               3.219             424.810            1367.282          [torch.Size([1073741824])]
SUCCESS               0.017306            0.177993               0.097               0.237               0.023          [torch.Size([1024, 1])]
SUCCESS               0.017940            0.205340               0.087               0.228               0.020          [torch.Size([1024, 1]), -1]
SUCCESS               0.018114            0.152100               0.119               0.226               0.027          [torch.Size([1024, 1]), 0]
SUCCESS               0.017397            0.185732               0.094               3.767               0.353          [torch.Size([1024, 16])]
SUCCESS               0.017824            0.148464               0.120               3.677               0.441          [torch.Size([1024, 16]), -1]
SUCCESS               0.018307            0.147237               0.124               3.580               0.445          [torch.Size([1024, 16]), 0]
SUCCESS               0.016006            0.182334               0.088              65.512               5.751          [torch.Size([1024, 256])]
SUCCESS               0.017665            0.146951               0.120              59.360               7.136          [torch.Size([1024, 256]), -1]
SUCCESS               0.030335            0.143534               0.211              34.567               7.305          [torch.Size([1024, 256]), 0]
SUCCESS               0.041409            0.180659               0.229             405.159              92.867          [torch.Size([1024, 4096])]
SUCCESS               0.040136            0.145962               0.275             418.008             114.943          [torch.Size([1024, 4096]), -1]
SUCCESS               0.058095            0.146758               0.396             288.790             114.319          [torch.Size([1024, 4096]), 0]
SUCCESS               0.538562            0.184208               2.924             498.430            1457.243          [torch.Size([1024, 65536])]
SUCCESS               0.480093            0.198691               2.416             559.132            1351.016          [torch.Size([1024, 65536]), -1]
SUCCESS               0.627683            0.201134               3.121             427.661            1334.613          [torch.Size([1024, 65536]), 0]
SUCCESS              10.111041            3.147936               3.212             424.780            1364.376          [torch.Size([1024, 1048576])]
SUCCESS               8.441210            3.284019               2.570             508.809            1307.839          [torch.Size([1024, 1048576]), -1]
SUCCESS               9.245539            3.390142               2.727             464.545            1266.899          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.016936            0.175578               0.096               0.967               0.093          [torch.Size([64, 1, 64])]
SUCCESS               0.017710            0.142186               0.125               0.925               0.115          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.017093            0.143874               0.119               0.959               0.114          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.017986            0.202454               0.089               0.911               0.081          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.016901            0.180041               0.094              15.510               1.456          [torch.Size([64, 16, 64])]
SUCCESS               0.017874            0.147272               0.121              14.666               1.780          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.017656            0.144479               0.122              14.847               1.814          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.017741            0.146616               0.121              14.776               1.788          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.016874            0.182917               0.092             248.564              22.930          [torch.Size([64, 256, 64])]
SUCCESS               0.017863            0.151325               0.118             234.809              27.717          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.024559            0.148363               0.166             170.785              28.270          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.017772            0.146834               0.121             236.009              28.565          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.141119            0.184094               0.767             475.548             364.536          [torch.Size([64, 4096, 64])]
SUCCESS               0.144702            0.146126               0.990             463.774             459.253          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.172651            0.147617               1.170             388.696             454.615          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.154183            0.145133               1.062             435.254             462.397          [torch.Size([64, 4096, 64]), 1]

PASSED
```
Benchmark on MetaX C550
```
root@bm-zksg-wx-zone1-d-mc550-64g-2-110:/data/qhait/FlagGems# pytest benchmark/test_nansum.py -v -s
============================================================================================================================ test session starts =============================================================================================================================
platform linux -- Python 3.12.11, pytest-9.1.1, pluggy-1.6.0 -- /opt/conda/bin/python3
cachedir: .pytest_cache
rootdir: /data/qhait/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdist-3.8.0
collected 1 item                                                                                                                                                                                                                                                             

benchmark/test_nansum.py::test_benchmark_nansum 
Operator: nansum  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.032000            0.021248               1.506             131.072             197.398          [torch.Size([1048576])]
SUCCESS               0.017664            0.017408               1.015               0.928               0.941          [torch.Size([64, 64])]
SUCCESS               0.017152            0.014336               1.196               0.955               1.143          [torch.Size([64, 64]), -1]
SUCCESS               0.020224            0.014080               1.436               0.810               1.164          [torch.Size([64, 64]), 0]
SUCCESS               0.051968            0.042240               1.230            1291.350            1588.751          [torch.Size([4096, 4096])]
SUCCESS               0.047872            0.037888               1.264            1401.840            1771.243          [torch.Size([4096, 4096]), -1]
SUCCESS               0.054272            0.191488               0.283            1236.528             350.460          [torch.Size([4096, 4096]), 0]
SUCCESS               0.051968            0.042240               1.230            1291.350            1588.751          [torch.Size([64, 512, 512])]
SUCCESS               0.065280            0.099328               0.657            1028.016             675.629          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.116224            0.049408               2.352             577.410            1358.259          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.067072            0.039936               1.679            1000.550            1680.410          [torch.Size([64, 512, 512]), 1]
SUCCESS               1.339392            1.346816               0.994            3206.655            3188.979          [torch.Size([1024, 1024, 1024])]
SUCCESS               1.693440            2.971904               0.570            2536.238            1445.190          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               1.360640            1.359616               1.001            3156.579            3158.956          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               1.361792            1.318272               1.033            3153.908            3258.028          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.032256            0.021248               1.518             130.159             197.590          [torch.Size([1049600])]
SUCCESS               1.338112            1.347072               0.993            3209.722            3188.372          [torch.Size([1073741824])]
SUCCESS               0.017152            0.016896               1.015               0.239               0.242          [torch.Size([1024, 1])]
SUCCESS               0.017408            0.013568               1.283               0.235               0.302          [torch.Size([1024, 1]), -1]
SUCCESS               0.017152            0.014336               1.196               0.239               0.286          [torch.Size([1024, 1]), 0]
SUCCESS               0.018944            0.021248               0.892               3.459               3.084          [torch.Size([1024, 16])]
SUCCESS               0.019712            0.016384               1.203               3.325               4.000          [torch.Size([1024, 16]), -1]
SUCCESS               0.022528            0.016384               1.375               2.909               4.000          [torch.Size([1024, 16]), 0]
SUCCESS               0.025344            0.019456               1.303              41.374              53.895          [torch.Size([1024, 256])]
SUCCESS               0.020480            0.016640               1.231              51.200              63.015          [torch.Size([1024, 256]), -1]
SUCCESS               0.028160            0.018432               1.528              37.236              56.889          [torch.Size([1024, 256]), 0]
SUCCESS               0.036352            0.026112               1.392             461.521             642.510          [torch.Size([1024, 4096])]
SUCCESS               0.032000            0.021760               1.471             524.288             771.012          [torch.Size([1024, 4096]), -1]
SUCCESS               0.038144            0.060928               0.626             439.839             275.361          [torch.Size([1024, 4096]), 0]
SUCCESS               0.122368            0.104448               1.172            2193.674            2570.039          [torch.Size([1024, 65536])]
SUCCESS               0.108544            0.097024               1.119            2473.057            2766.691          [torch.Size([1024, 65536]), -1]
SUCCESS               0.135424            0.122368               1.107            1982.185            2193.674          [torch.Size([1024, 65536]), 0]
SUCCESS               1.338112            1.348096               0.993            3209.722            3185.951          [torch.Size([1024, 1048576])]
SUCCESS               1.327360            1.317376               1.008            3235.721            3260.244          [torch.Size([1024, 1048576]), -1]
SUCCESS               1.361664            1.360896               1.001            3154.205            3155.985          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.017408            0.017408               1.000               0.941               0.941          [torch.Size([64, 1, 64])]
SUCCESS               0.017152            0.014080               1.218               0.955               1.164          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.019968            0.014080               1.418               0.821               1.164          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.017408            0.013824               1.259               0.941               1.185          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.024832            0.019712               1.260              10.557              13.299          [torch.Size([64, 16, 64])]
SUCCESS               0.020480            0.016384               1.250              12.800              16.000          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.020480            0.015616               1.311              12.800              16.787          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.024064            0.018176               1.324              10.894              14.423          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.031744            0.020992               1.512             132.129             199.805          [torch.Size([64, 256, 64])]
SUCCESS               0.028672            0.015616               1.836             146.286             268.590          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.028928            0.021504               1.345             144.991             195.048          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.034304            0.019712               1.740             122.269             212.779          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.051712            0.041984               1.232            1297.743            1598.439          [torch.Size([64, 4096, 64])]
SUCCESS               0.099584            0.039168               2.542             673.892            1713.359          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.117760            0.049408               2.383             569.878            1358.259          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.054528            0.059392               0.918            1230.723            1129.931          [torch.Size([64, 4096, 64]), 1]


Operator: nansum  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.032512            0.022528               1.443             258.016             372.364          [torch.Size([1048576])]
SUCCESS               0.017664            0.017664               1.000               1.855               1.855          [torch.Size([64, 64])]
SUCCESS               0.017152            0.013824               1.241               1.910               2.370          [torch.Size([64, 64]), -1]
SUCCESS               0.018432            0.014080               1.309               1.778               2.327          [torch.Size([64, 64]), 0]
SUCCESS               0.071424            0.062208               1.148            1879.168            2157.564          [torch.Size([4096, 4096])]
SUCCESS               0.070144            0.056832               1.234            1913.460            2361.658          [torch.Size([4096, 4096]), -1]
SUCCESS               0.073472            0.202752               0.362            1826.787             661.980          [torch.Size([4096, 4096]), 0]
SUCCESS               0.071424            0.062208               1.148            1879.168            2157.564          [torch.Size([64, 512, 512])]
SUCCESS               0.070912            0.098816               0.718            1892.736            1358.259          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.079616            0.058368               1.364            1685.813            2299.509          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.074496            0.057600               1.293            1801.677            2330.169          [torch.Size([64, 512, 512]), 1]
SUCCESS               2.690944            2.578176               1.044            3192.164            3331.787          [torch.Size([1024, 1024, 1024])]
SUCCESS               2.655744            3.308416               0.803            3234.474            2596.389          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               2.688000            2.642688               1.017            3195.660            3250.454          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               2.650368            2.626048               1.009            3241.035            3271.050          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.033024            0.023040               1.433             254.264             364.444          [torch.Size([1049600])]
SUCCESS               2.701952            2.578432               1.048            3179.159            3331.457          [torch.Size([1073741824])]
SUCCESS               0.016896            0.017152               0.985               0.485               0.478          [torch.Size([1024, 1])]
SUCCESS               0.016384            0.014080               1.164               0.500               0.582          [torch.Size([1024, 1]), -1]
SUCCESS               0.016896            0.014336               1.179               0.485               0.571          [torch.Size([1024, 1]), 0]
SUCCESS               0.019968            0.022016               0.907               6.564               5.953          [torch.Size([1024, 16])]
SUCCESS               0.019712            0.016128               1.222               6.649               8.127          [torch.Size([1024, 16]), -1]
SUCCESS               0.021248            0.015616               1.361               6.169               8.393          [torch.Size([1024, 16]), 0]
SUCCESS               0.025856            0.019968               1.295              81.109             105.026          [torch.Size([1024, 256])]
SUCCESS               0.021504            0.016896               1.273              97.524             124.121          [torch.Size([1024, 256]), -1]
SUCCESS               0.027392            0.018944               1.446              76.561             110.703          [torch.Size([1024, 256]), 0]
SUCCESS               0.040448            0.031744               1.274             829.570            1057.032          [torch.Size([1024, 4096])]
SUCCESS               0.038912            0.026624               1.462             862.316            1260.308          [torch.Size([1024, 4096]), -1]
SUCCESS               0.041216            0.104960               0.393             814.112             319.688          [torch.Size([1024, 4096]), 0]
SUCCESS               0.210432            0.183296               1.148            2551.280            2928.983          [torch.Size([1024, 65536])]
SUCCESS               0.187392            0.178176               1.052            2864.962            3013.149          [torch.Size([1024, 65536]), -1]
SUCCESS               0.210176            0.192000               1.095            2554.387            2796.203          [torch.Size([1024, 65536]), 0]
SUCCESS               2.701312            2.577664               1.048            3179.912            3332.449          [torch.Size([1024, 1048576])]
SUCCESS               2.855040            2.586368               1.104            3008.691            3321.235          [torch.Size([1024, 1048576]), -1]
SUCCESS               2.689536            2.642432               1.018            3193.835            3250.768          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.017664            0.017408               1.015               1.855               1.882          [torch.Size([64, 1, 64])]
SUCCESS               0.016896            0.013824               1.222               1.939               2.370          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.018432            0.014080               1.309               1.778               2.327          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.016640            0.014336               1.161               1.969               2.286          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.029952            0.019712               1.519              17.504              26.597          [torch.Size([64, 16, 64])]
SUCCESS               0.020480            0.016384               1.250              25.600              32.000          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.019968            0.016128               1.238              26.256              32.508          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.023808            0.017152               1.388              22.022              30.567          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.032768            0.022784               1.438             256.000             368.180          [torch.Size([64, 256, 64])]
SUCCESS               0.029696            0.017152               1.731             282.483             489.075          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.028672            0.019712               1.455             292.571             425.558          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.035584            0.019456               1.829             235.741             431.158          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.071424            0.062208               1.148            1879.168            2157.564          [torch.Size([64, 4096, 64])]
SUCCESS               0.108800            0.059392               1.832            1233.619            2259.862          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.079872            0.058624               1.362            1680.410            2289.467          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.072960            0.082688               0.882            1839.607            1623.183          [torch.Size([64, 4096, 64]), 1]


Operator: nansum  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.032000            0.020992               1.524             131.072             199.805          [torch.Size([1048576])]
SUCCESS               0.017920            0.017408               1.029               0.914               0.941          [torch.Size([64, 64])]
SUCCESS               0.017408            0.014080               1.236               0.941               1.164          [torch.Size([64, 64]), -1]
SUCCESS               0.019968            0.014080               1.418               0.821               1.164          [torch.Size([64, 64]), 0]
SUCCESS               0.051968            0.041984               1.238            1291.350            1598.439          [torch.Size([4096, 4096])]
SUCCESS               0.048384            0.038144               1.268            1387.005            1759.356          [torch.Size([4096, 4096]), -1]
SUCCESS               0.054016            0.218112               0.248            1242.389             307.681          [torch.Size([4096, 4096]), 0]
SUCCESS               0.051968            0.041984               1.238            1291.350            1598.439          [torch.Size([64, 512, 512])]
SUCCESS               0.066560            0.103936               0.640            1008.246             645.675          [torch.Size([64, 512, 512]), -1]
SUCCESS               0.118528            0.046848               2.530             566.186            1432.481          [torch.Size([64, 512, 512]), 0]
SUCCESS               0.067584            0.039936               1.692             992.970            1680.410          [torch.Size([64, 512, 512]), 1]
SUCCESS               1.337856            1.309184               1.022            3210.336            3280.645          [torch.Size([1024, 1024, 1024])]
SUCCESS               1.723776            3.026432               0.570            2491.604            1419.152          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               1.366144            1.337600               1.021            3143.861            3210.950          [torch.Size([1024, 1024, 1024]), 0]
SUCCESS               1.365760            1.319424               1.035            3144.745            3255.183          [torch.Size([1024, 1024, 1024]), 1]
SUCCESS               0.032256            0.021248               1.518             130.159             197.590          [torch.Size([1049600])]
SUCCESS               1.339136            1.309696               1.022            3207.267            3279.362          [torch.Size([1073741824])]
SUCCESS               0.017408            0.017280               1.007               0.235               0.237          [torch.Size([1024, 1])]
SUCCESS               0.017152            0.013568               1.264               0.239               0.302          [torch.Size([1024, 1]), -1]
SUCCESS               0.017408            0.014080               1.236               0.235               0.291          [torch.Size([1024, 1]), 0]
SUCCESS               0.019200            0.021504               0.893               3.413               3.048          [torch.Size([1024, 16])]
SUCCESS               0.019968            0.016384               1.219               3.282               4.000          [torch.Size([1024, 16]), -1]
SUCCESS               0.022528            0.016128               1.397               2.909               4.063          [torch.Size([1024, 16]), 0]
SUCCESS               0.025344            0.019456               1.303              41.374              53.895          [torch.Size([1024, 256])]
SUCCESS               0.020736            0.016896               1.227              50.568              62.061          [torch.Size([1024, 256]), -1]
SUCCESS               0.028160            0.018688               1.507              37.236              56.110          [torch.Size([1024, 256]), 0]
SUCCESS               0.036352            0.026112               1.392             461.521             642.510          [torch.Size([1024, 4096])]
SUCCESS               0.032000            0.022016               1.453             524.288             762.047          [torch.Size([1024, 4096]), -1]
SUCCESS               0.038400            0.061184               0.628             436.907             274.209          [torch.Size([1024, 4096]), 0]
SUCCESS               0.122880            0.104704               1.174            2184.533            2563.755          [torch.Size([1024, 65536])]
SUCCESS               0.109056            0.097024               1.124            2461.446            2766.691          [torch.Size([1024, 65536]), -1]
SUCCESS               0.136704            0.118016               1.158            1963.625            2274.568          [torch.Size([1024, 65536]), 0]
SUCCESS               1.338880            1.309184               1.023            3207.881            3280.645          [torch.Size([1024, 1048576])]
SUCCESS               1.328640            1.317504               1.008            3232.604            3259.927          [torch.Size([1024, 1048576]), -1]
SUCCESS               1.364480            1.337600               1.020            3147.695            3210.950          [torch.Size([1024, 1048576]), 0]
SUCCESS               0.017920            0.017664               1.014               0.914               0.928          [torch.Size([64, 1, 64])]
SUCCESS               0.017408            0.014080               1.236               0.941               1.164          [torch.Size([64, 1, 64]), -1]
SUCCESS               0.019968            0.014080               1.418               0.821               1.164          [torch.Size([64, 1, 64]), 0]
SUCCESS               0.017152            0.013824               1.241               0.955               1.185          [torch.Size([64, 1, 64]), 1]
SUCCESS               0.025344            0.019456               1.303              10.343              13.474          [torch.Size([64, 16, 64])]
SUCCESS               0.020736            0.016384               1.266              12.642              16.000          [torch.Size([64, 16, 64]), -1]
SUCCESS               0.020480            0.015616               1.311              12.800              16.787          [torch.Size([64, 16, 64]), 0]
SUCCESS               0.024576            0.018688               1.315              10.667              14.027          [torch.Size([64, 16, 64]), 1]
SUCCESS               0.032000            0.020992               1.524             131.072             199.805          [torch.Size([64, 256, 64])]
SUCCESS               0.029184            0.015616               1.869             143.719             268.590          [torch.Size([64, 256, 64]), -1]
SUCCESS               0.028928            0.021504               1.345             144.991             195.048          [torch.Size([64, 256, 64]), 0]
SUCCESS               0.034560            0.020224               1.709             121.363             207.392          [torch.Size([64, 256, 64]), 1]
SUCCESS               0.051968            0.042240               1.230            1291.350            1588.751          [torch.Size([64, 4096, 64])]
SUCCESS               0.101632            0.039168               2.595             660.312            1713.359          [torch.Size([64, 4096, 64]), -1]
SUCCESS               0.118784            0.046848               2.536             564.966            1432.481          [torch.Size([64, 4096, 64]), 0]
SUCCESS               0.054784            0.059136               0.926            1224.972            1134.823          [torch.Size([64, 4096, 64]), 1]

PASSED

======================================================================================================================= 1 passed in 140.05s (0:02:20) ========================================================================================================================
```