### PR TITLE
ci: support python version matrix in test and release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,18 +52,17 @@ jobs:
             quay.io/pypa/manylinux_2_28_x86_64)
           echo "CONTAINER=$container" >> $GITHUB_ENV
 
-      - name: Install build tools inside container
+      - name: Build wheels for all supported Python versions
         run: |
           docker exec -t $CONTAINER bash -c "
             set -e
-            /opt/python/cp38-cp38/bin/python -m pip install --upgrade pip setuptools wheel build
-          "
-
-      - name: Build wheel for Python 3.8
-        run: |
-          docker exec -t $CONTAINER bash -c "
-            set -e
-            /opt/python/cp38-cp38/bin/python -m build --wheel --outdir /wheelhouse
+            for py in cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313; do
+              if [ -d /opt/python/\$py ]; then
+                /opt/python/\$py/bin/python -m pip install --upgrade pip setuptools wheel build
+                /opt/python/\$py/bin/python -m build --wheel --outdir /wheelhouse
+              fi
+            done
+            ls -1 /wheelhouse
           "
 
       - name: Upload wheel as artifact

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -98,6 +98,40 @@ jobs:
             };
             core.setOutput('matrix', JSON.stringify(matrix));
 
+  # Build/verify the package wheel on each supported Python version.
+  # Note: `import flag_gems` is intentionally not run here — it requires
+  # triton with an active GPU driver, which is not available on ubuntu-latest.
+  python-matrix:
+    name: python-matrix (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip wheel . --no-deps -w wheelhouse
+
+      - name: Verify wheel
+        run: |
+          python - <<'EOF'
+          import glob, zipfile
+          wheel = glob.glob('wheelhouse/*.whl')[0]
+          names = zipfile.ZipFile(wheel).namelist()
+          assert any(n.startswith('flag_gems/') for n in names), names[:5]
+          print('OK:', wheel)
+          EOF
+
   build-doc:
     needs: preprocess
     if: (contains(needs.preprocess.outputs.labels, 'documentation') &&


### PR DESCRIPTION
Add a python-version matrix to unittest.yaml (build/verify the wheel via actions/setup-python on Python 3.10-3.13) and build release wheels for all supported CPython versions in the manylinux container, following the ONNX CI approach, to increase CI coverage across Python versions.



### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

- Resolves #1182 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
