### PR TITLE
[KernelGen][Ascend] Fix any_dim: accuracy_fail

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/any.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/any.py
@@ -129,6 +129,7 @@ def any_dim(inp, dim=None, keepdim=False):
         shape[dim] = 1
         M = inp.numel() // N
         out = torch.empty(shape, dtype=torch.bool, device=inp.device)
+        inp = inp.to(torch.bool)
 
         def grid_fn(meta):
             grid = triton.cdiv(M, meta["BLOCK_M"])
@@ -159,6 +160,7 @@ def any_dims(inp, dim=None, keepdim=False):
     M = inp.numel() // N
 
     out = torch.empty(shape, dtype=torch.bool, device=inp.device)
+    inp = inp.to(torch.bool)
 
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
 


### PR DESCRIPTION
## Summary
- **Operator:** any_dim
- **Error type:** accuracy_fail
- **Files modified:**
  - `src/flag_gems/runtime/backend/_ascend/ops/any.py`

## Commit Message
```
Fix 432-internal: any_dim accuracy_fail

Add missing inp.to(torch.bool) conversion in Ascend backend any_dim and any_dims functions to match the fix already applied to the shared implementation in commit b5e6aa01b. This prevents Triton pointer type mismatch when input dtype differs from output dtype (bool).
```

## Verification
- Test command: `pytest -m 'any_dim' tests/ --ref cpu -vs`
- Benchmark command: `pytest -m 'any_dim' benchmark/ --level core --record log`

## Test Plan
- [ ] `pytest -m 'any_dim' tests/ --ref cpu -vs`
- [ ] `pytest -m 'any_dim' benchmark/ --level core --record log`

## Issue
- WEEKTEST-432
