### PR TITLE
[MThreads] Optimize AddMM layouts and bias epilogue

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -290,6 +290,24 @@ BlasBenchmark:
     - [16, 4096, 4096, 4096]
   shape_desc: "B, M, N, K"   # shapes are defined as (B, M, N, K)
 
+addmm_vector_bias:
+  shapes:
+    - [1, 64, 256, 184]
+    - [1, 128, 512, 512]
+    - [1, 256, 256, 1024]
+    - [1, 512, 1024, 1024]
+    - [1, 1024, 512, 1536]
+  shape_desc: "B, M, N, K"
+
+addmm_out_vector_bias:
+  shapes:
+    - [1, 64, 256, 184]
+    - [1, 128, 512, 512]
+    - [1, 256, 256, 1024]
+    - [1, 512, 1024, 1024]
+    - [1, 1024, 512, 1536]
+  shape_desc: "B, M, N, K"
+
 grouped_mm:
   shapes:
     - [16, 512, 2048]

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -15,6 +15,8 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base, consts, utils
 
 
@@ -29,11 +31,62 @@ def _input_fn(b, m, n, k, dtype, device, b_column_major):
         yield bias, inp1, inp2,
 
 
+class AddmmVectorBiasBenchmark(base.BlasBenchmark):
+    def set_more_shapes(self):
+        return []
+
+    def get_input_iter(self, dtype):
+        for b, m, n, k in self.shapes:
+            yield from self.input_fn(b, m, n, k, dtype, self.device, True)
+
+    def get_tflops(self, op, *args, **kwargs):
+        _, mat1, mat2 = args
+        return mat1.shape[0] * mat2.shape[1] * (2 * mat1.shape[1] + 1)
+
+    def record_shapes(self, bias, mat1, mat2, **kwargs):
+        return {
+            "bias": bias.size(),
+            "mat1": mat1.size(),
+            "mat2": mat2.size(),
+            "mat2_layout": ("column-major" if mat2.stride(0) == 1 else "row-major"),
+        }
+
+
+def _input_fn_vector_bias(b, m, n, k, dtype, device, b_column_major):
+    mat1 = torch.randn((m, k), dtype=dtype, device=device)
+    if b_column_major:
+        mat2 = torch.randn((n, k), dtype=dtype, device=device).t()
+    else:
+        mat2 = torch.randn((k, n), dtype=dtype, device=device)
+    bias = torch.randn((n,), dtype=dtype, device=device)
+    yield bias, mat1, mat2
+
+
+def _input_fn_vector_bias_out(b, m, n, k, dtype, device, b_column_major):
+    for bias, mat1, mat2 in _input_fn_vector_bias(
+        b, m, n, k, dtype, device, b_column_major
+    ):
+        out = torch.empty((m, n), dtype=dtype, device=device)
+        yield bias, mat1, mat2, {"out": out}
+
+
 @pytest.mark.addmm
 def test_addmm(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm",
         input_fn=_input_fn,
+        torch_op=torch.addmm,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+@pytest.mark.addmm
+def test_addmm_vector_bias(monkeypatch):
+    bench = AddmmVectorBiasBenchmark(
+        op_name="addmm_vector_bias",
+        input_fn=_input_fn_vector_bias,
         torch_op=torch.addmm,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -56,6 +109,10 @@ def _input_fn_dtype(b, m, n, k, dtype, device, b_column_major):
 @pytest.mark.skipif(
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype was added starting from 2.8.0",
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name in ("ascend", "mthreads"),
+    reason="Issue #5385: Native torch.addmm benchmark does not support out_dtype.",
 )
 def test_addmm_dtype(monkeypatch):
     bench = base.BlasBenchmark(
@@ -84,6 +141,10 @@ def _input_fn_dtype_out(b, m, n, k, dtype, device, b_column_major):
 @pytest.mark.skipif(
     utils.SkipVersion("torch", "<2.8"),
     reason="The operator addmm.dtype_out was added starting from 2.8.0",
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name in ("ascend", "mthreads"),
+    reason="Issue #5385: Native torch.addmm benchmark does not support out_dtype.",
 )
 def test_addmm_dtype_out(monkeypatch):
     bench = base.BlasBenchmark(
@@ -115,6 +176,18 @@ def test_addmm_out(monkeypatch):
     bench = base.BlasBenchmark(
         op_name="addmm_out",
         input_fn=_input_fn_out,
+        torch_op=torch.addmm,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+@pytest.mark.addmm_out
+def test_addmm_out_vector_bias(monkeypatch):
+    bench = AddmmVectorBiasBenchmark(
+        op_name="addmm_out_vector_bias",
+        input_fn=_input_fn_vector_bias_out,
         torch_op=torch.addmm,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -26,11 +26,24 @@ from flag_gems.utils import triton_lang_extension as ext
 logger = logging.getLogger(__name__)
 
 
+@triton.jit
+def _accumulate_dot(
+    accumulator,
+    a,
+    b,
+    IS_FP64: tl.constexpr,
+):
+    if IS_FP64:
+        a = a.to(tl.float32)
+        b = b.to(tl.float32)
+    return accumulator + tl.dot(a, b, allow_tf32=False)
+
+
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
-    strategy=["align32", "align32", "align32"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
     warmup=5,
     rep=10,
     flagtune_op_name="addmm",
@@ -57,52 +70,64 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
+    HAS_K: tl.constexpr,
     IS_FP64: tl.constexpr = False,
 ):
     pid_m = ext.program_id(0)
     pid_n = ext.program_id(1)
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     if IS_FP64:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float64)
     else:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(
-            a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+    if HAS_K:
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            a = tl.load(
+                a_ptrs,
+                mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
+                other=0.0,
+            )
+            accumulator = _accumulate_dot(
+                accumulator,
+                a,
+                b,
+                IS_FP64,
+            )
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    mask = (offs_m < M)[:, None] & (offs_n < N)[None, :]
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            i_ptr + offs_n * stride_in,
+            mask=offs_n < N,
             other=0.0,
-        )
-        b = tl.load(
-            b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
-            other=0.0,
-        )
-        if IS_FP64:
-            a = a.to(tl.float32)
-            b = b.to(tl.float32)
-        accumulator += tl.dot(a, b, allow_tf32=False)
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
+        bias = tl.load(i_ptrs, mask=mask, other=0.0)
 
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
-
-    accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
+    result = accumulator * alpha + bias.to(accumulator.dtype) * beta
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, result.to(c_ptr.dtype.element_ty), mask=mask)
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -110,73 +135,29 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
     M, K = mat1.shape
     _, N = mat2.shape
 
-    logger.debug(
-        "GEMS ADDMM, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
-        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
-        M,
-        N,
-        K,
-        mat1.stride(0) == 1,
-        mat2.stride(0) == 1,
-        bias.stride(0) == 1,
-    )
-    mat1 = mat1.contiguous()
-    # mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape)
-
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
-    )
-    with torch_device_fn.device(mat1.device):
-        addmm_kernel[grid](
-            mat1,
-            mat2,
-            bias,
-            out,
-            alpha,
-            beta,
-            M,
-            N,
-            K,
-            mat1.stride(0),
-            mat1.stride(1),
-            mat2.stride(0),
-            mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
-            out.stride(0),
-            out.stride(1),
-            IS_FP64=mat1.dtype == torch.float64,
-        )
-    return out
-
-
-def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
-    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
-    assert broadcastable_to(
-        bias.shape, (mat1.shape[0], mat2.shape[1])
-    ), "Incompatible input shape"
-    M, K = mat1.shape
-    _, N = mat2.shape
+    # Preserve row- and column-contiguous matrices; materialize general views.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(0) > 1 and mat2.stride(1) > 1:
+        mat2 = mat2.contiguous()
     if out is None:
         out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
     else:
         assert out.shape == (M, N), "Incompatible output shape"
-    logger.debug(
-        "GEMS ADDMM_OUT, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
-        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
-        M,
-        N,
-        K,
-        mat1.stride(0) == 1,
-        mat2.stride(0) == 1,
-        bias.stride(0) == 1,
-    )
-    mat1 = mat1.contiguous()
-    bias = bias.broadcast_to(out.shape)
 
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape)
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]),
         triton.cdiv(N, META["BLOCK_SIZE_N"]),
@@ -196,13 +177,44 @@ def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
+            HAS_K=K > 0,
             IS_FP64=mat1.dtype == torch.float64,
         )
     return out
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug(
+        "GEMS ADDMM, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
+        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
+        mat1.shape[0],
+        mat2.shape[1],
+        mat1.shape[1],
+        mat1.stride(0) == 1,
+        mat2.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
+    )
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug(
+        "GEMS ADDMM_OUT, [shape info]: [-, %s, %s, %s](batch, M, N, K), "
+        "[A column-major]: %s, [B column-major]: %s, [bias column-major]: %s",
+        mat1.shape[0],
+        mat2.shape[1],
+        mat1.shape[1],
+        mat1.stride(0) == 1,
+        mat2.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
+    )
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
 
 
 def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
@@ -237,5 +249,6 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
     if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
         raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
 
+    # Write directly to the requested dtype instead of using an input-dtype temporary.
     bias_c = bias.to(out_dtype)
     return addmm_out(bias_c, mat1, mat2, beta=beta, alpha=alpha, out=out)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
@@ -46,9 +46,24 @@ def is_sqmma_compatible(a, b, N, K):
         and a.dtype in (torch.float16, torch.bfloat16)
         and is_supported_sqmma_layout(a)
         and is_supported_sqmma_layout(b)
+        and a.shape[0] > 0
+        and N > 0
+        and K > 0
         and N % 8 == 0
         and K % 8 == 0
     )
+
+
+def _prepare_bias(bias, out):
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == out.shape[1]
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        return bias, 0, bias.stride(0), True, False
+    if bias_is_scalar:
+        return bias, 0, 0, False, True
+    bias = bias.broadcast_to(out.shape)
+    return bias, bias.stride(0), bias.stride(1), False, False
 
 
 @libentry()
@@ -96,16 +111,17 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
     IS_FP64: tl.constexpr = False,
 ):
     pid_m = ext.program_id(0)
     pid_n = ext.program_id(1)
-
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     if IS_FP64:
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float64)
@@ -114,12 +130,12 @@ def addmm_kernel(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(
             a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(
             b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
             other=0.0,
         )
         if IS_FP64:
@@ -133,11 +149,20 @@ def addmm_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            i_ptr + stride_in * offs_cn,
+            mask=offs_cn < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(i_ptr)
+    else:
+        i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
+        bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
 
     accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
+    c = accumulator.to(c_ptr.dtype.element_ty)
     tl.store(c_ptrs, c, mask=c_mask)
 
 
@@ -150,11 +175,31 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
     M, K = mat1.shape
     _, N = mat2.shape
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    if out is None or out.dtype != mat1.dtype:
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    mat2_k_contiguous = mat2.stride(0) == 1 and mat2.stride(1) > 1
+    # Direct K-contiguous loads win for small M. With more than eight 128-row
+    # tiles, a coalesced copy is amortized across enough reuse of the B matrix.
+    if (mat2_k_contiguous and M > 8 * 128) or (
+        mat2.stride(0) > 1 and mat2.stride(1) > 1
+    ):
+        mat2 = mat2.contiguous()
+    if out is None:
         out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == N
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        bias_stride_m = 0
+        bias_stride_n = bias.stride(0)
+    elif bias_is_scalar:
+        bias_stride_m = 0
+        bias_stride_n = 0
+    else:
+        bias = bias.broadcast_to(out.shape).contiguous()
+        bias_stride_m = bias.stride(0)
+        bias_stride_n = bias.stride(1)
 
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]),
@@ -175,10 +220,12 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
-            bias.stride(0),
-            bias.stride(1),
+            bias_stride_m,
+            bias_stride_n,
             out.stride(0),
             out.stride(1),
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
             IS_FP64=mat1.dtype == torch.float64,
         )
     return out
@@ -187,7 +234,6 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
 def addmm_sqmma_descriptor_pre_hook(nargs):
     nargs["a_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_K"]]
     nargs["b_desc"].block_shape = [nargs["BLOCK_SIZE_K"], nargs["BLOCK_SIZE_N"]]
-    nargs["bias_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
     nargs["c_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
 
 
@@ -226,17 +272,21 @@ def addmm_sqmma_descriptor_pre_hook(nargs):
 def addmm_sqmma_kernel(
     a_desc,
     b_desc,
-    bias_desc,
+    bias_ptr,
     c_desc,
     M,
     N,
     K,
     alpha,
     beta,
+    stride_im,
+    stride_in,
     DTYPE: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -252,7 +302,21 @@ def addmm_sqmma_kernel(
         b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
         accumulator = tl.dot(a, b, acc=accumulator)
         offs_k += BLOCK_SIZE_K
-    bias = tl.load_tensor_descriptor(bias_desc, [offs_am, offs_bn])
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    if BIAS_IS_VECTOR:
+        bias = tl.load(
+            bias_ptr + offs_n * stride_in,
+            mask=offs_n < N,
+            other=0.0,
+        )[None, :]
+    elif BIAS_IS_SCALAR:
+        bias = tl.load(bias_ptr)
+    else:
+        bias_ptrs = bias_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
+        bias = tl.load(bias_ptrs, mask=mask, other=0.0)
     result = (alpha * accumulator + beta * bias).to(c_desc.dtype)
     tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], result)
 
@@ -271,15 +335,16 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K, out=None):
     b_type = mat2.dtype
     assert a_type == b_type, "Mat A and Mat B should have the same dtype"
     c_type = a_type
-    if out is None or out.dtype != mat1.dtype:
-        C = torch.empty((M, N), dtype=c_type, device=device)
+    if out is None:
+        out = torch.empty((M, N), dtype=c_type, device=device)
     else:
-        C = out
-    bias = bias.broadcast_to(C.shape).contiguous()
+        assert out.shape == (M, N), "Incompatible output shape"
+    bias, stride_im, stride_in, bias_is_vector, bias_is_scalar = _prepare_bias(
+        bias, out
+    )
     desc_a = TensorDescriptor.from_tensor(mat1, [1, 1])
     desc_b = TensorDescriptor.from_tensor(mat2, [1, 1])
-    desc_bias = TensorDescriptor.from_tensor(bias, [1, 1])
-    desc_c = TensorDescriptor.from_tensor(C, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(out, [1, 1])
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         1,
@@ -288,24 +353,38 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K, out=None):
     addmm_sqmma_kernel[grid](
         desc_a,
         desc_b,
-        desc_bias,
+        bias,
         desc_c,
         M,
         N,
         K,
         alpha,
         beta,
+        stride_im,
+        stride_in,
         str(a_type).split(".")[-1],
+        BIAS_IS_VECTOR=bias_is_vector,
+        BIAS_IS_SCALAR=bias_is_scalar,
     )
-    return C
+    return out
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
+    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
+    assert broadcastable_to(
+        bias.shape, (mat1.shape[0], mat2.shape[1])
+    ), "Incompatible input shape"
     a_dtype = mat1.dtype
     M, K = mat1.shape
     _, N = mat2.shape
+    if out is not None:
+        assert out.shape == (M, N), "Incompatible output shape"
 
-    if is_sqmma_compatible(mat1, mat2, N, K):
+    if (
+        is_sqmma_compatible(mat1, mat2, N, K)
+        and bias.dtype == a_dtype
+        and (out is None or out.is_contiguous())
+    ):
         return addmm_sqmma(
             mat1,
             mat2,
@@ -316,9 +395,19 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
             M,
             N,
             K,
+            out=out,
         )
-    else:
-        return addmm_fma(bias, mat1, mat2, alpha=alpha, beta=beta)
+    return addmm_fma(bias, mat1, mat2, alpha=alpha, beta=beta, out=out)
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_MTHREADS ADDMM")
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_MTHREADS ADDMM_OUT")
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
 
 
 def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
@@ -358,8 +447,13 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
     _, N = mat2.shape
     a_dtype = mat1.dtype
 
-    if is_sqmma_compatible(mat1, mat2, N, K):
-        result = addmm_sqmma(
+    # Keep dtype promotion on FMA so FP32 output has no low-precision intermediate.
+    if (
+        out_dtype == mat1.dtype
+        and out.is_contiguous()
+        and is_sqmma_compatible(mat1, mat2, N, K)
+    ):
+        return addmm_sqmma(
             mat1,
             mat2,
             bias_c,
@@ -369,40 +463,6 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
             M,
             N,
             K,
-        )
-    else:
-        result = addmm_fma(bias_c, mat1, mat2, alpha=alpha, beta=beta)
-    out.copy_(result)
-    return out
-
-
-def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
-    logger.debug("GEMS_MTHREADS ADDMM_OUT")
-    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
-    assert broadcastable_to(
-        bias.shape, (mat1.shape[0], mat2.shape[1])
-    ), "Incompatible input shape"
-    M, K = mat1.shape
-    _, N = mat2.shape
-    if out is not None:
-        assert out.shape == (M, N), "Incompatible output shape"
-
-    if is_sqmma_compatible(mat1, mat2, N, K):
-        result = addmm_sqmma(
-            mat1,
-            mat2,
-            bias,
-            mat1.dtype,
-            alpha,
-            beta,
-            M,
-            N,
-            K,
             out=out,
         )
-    else:
-        result = addmm_fma(bias, mat1, mat2, alpha=alpha, beta=beta, out=out)
-    if out is not None and out.dtype != result.dtype:
-        out.copy_(result)
-        return out
-    return result
+    return addmm_fma(bias_c, mat1, mat2, alpha=alpha, beta=beta, out=out)

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -43,9 +43,12 @@ else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
 
 
-_common_addmm_only = pytest.mark.skipif(
-    flag_gems.vendor_name not in ("nvidia", "hygon", "thead"),
-    reason="Issue #5385: Common AddMM coverage",
+_ADDMM_LAYOUT_BIAS_VENDORS = ("ascend", "nvidia", "hygon", "thead")
+
+# Extend this set as vendor implementations gain equivalent layout and bias support.
+_addmm_layout_bias_only = pytest.mark.skipif(
+    flag_gems.vendor_name not in _ADDMM_LAYOUT_BIAS_VENDORS,
+    reason="Issue #5385: AddMM layout and bias coverage is pending on this backend",
 )
 
 
@@ -87,7 +90,7 @@ def test_addmm(monkeypatch, M, N, K, scalar, dtype, b_column_major):
 
 
 @pytest.mark.addmm
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
@@ -111,7 +114,7 @@ def test_addmm_vector_bias_shapes(M, N, K, dtype, b_column_major):
 
 
 @pytest.mark.addmm
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
 def test_addmm_scalar_bias(dtype, b_column_major):
@@ -135,7 +138,7 @@ def test_addmm_scalar_bias(dtype, b_column_major):
 
 
 @pytest.mark.addmm
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
 def test_addmm_padded_vector_bias(dtype, b_column_major):
@@ -196,7 +199,7 @@ def test_addmm_out(M, N, K, scalar, dtype):
 
 
 @pytest.mark.addmm_out
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
@@ -221,7 +224,7 @@ def test_addmm_out_vector_bias_shapes(M, N, K, dtype, b_column_major):
 
 
 @pytest.mark.addmm_out
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
 def test_addmm_out_noncontiguous(dtype, b_column_major):
@@ -247,7 +250,7 @@ def test_addmm_out_noncontiguous(dtype, b_column_major):
 
 
 @pytest.mark.addmm
-@_common_addmm_only
+@_addmm_layout_bias_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("bias_shape", [(), (1, 128), (128, 1)])
 def test_addmm_broadcast_bias(dtype, bias_shape):

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -25,6 +25,7 @@ if QUICK_MODE:
     MNK_SHAPES = [
         (1, 1, 32),
     ]
+    VECTOR_BIAS_MNK_SHAPES = [(64, 256, 184)]
     FLOAT_DTYPES = [torch.float32]
 else:
     MNK_SHAPES = [
@@ -32,7 +33,20 @@ else:
         (15, 160, 1024),
         (495, 5333, 71),
     ]
+    VECTOR_BIAS_MNK_SHAPES = [
+        (64, 256, 184),
+        (128, 512, 512),
+        (256, 256, 1024),
+        (512, 1024, 1024),
+        (1024, 512, 1536),
+    ]
     FLOAT_DTYPES = utils.FLOAT_DTYPES
+
+
+_common_addmm_only = pytest.mark.skipif(
+    flag_gems.vendor_name not in ("nvidia", "hygon", "thead"),
+    reason="Issue #5385: Common AddMM coverage",
+)
 
 
 @pytest.mark.addmm
@@ -73,16 +87,17 @@ def test_addmm(monkeypatch, M, N, K, scalar, dtype, b_column_major):
 
 
 @pytest.mark.addmm
+@_common_addmm_only
+@pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("bias_shape", [(), (1, 128), (128, 1)])
-def test_addmm_broadcast_bias(dtype, bias_shape):
-    if bias_shape == () and flag_gems.vendor_name != "ascend":
-        pytest.skip("Issue #5385: scalar-bias support is landing per backend")
-
-    M, N, K = 128, 128, 128
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_vector_bias_shapes(M, N, K, dtype, b_column_major):
     mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
-    mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
-    bias = torch.randn(bias_shape, dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
 
     ref_out = torch.addmm(
         utils.to_reference(bias, True),
@@ -96,9 +111,34 @@ def test_addmm_broadcast_bias(dtype, bias_shape):
 
 
 @pytest.mark.addmm
+@_common_addmm_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
-def test_addmm_padded_strides(dtype, b_column_major):
+def test_addmm_scalar_bias(dtype, b_column_major):
+    M, N, K = 17, 29, 31
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((1, 1), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        result = torch.addmm(bias, mat1, mat2)
+
+    utils.gems_assert_close(result, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@_common_addmm_only
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_padded_vector_bias(dtype, b_column_major):
     M, N, K, padding = 64, 128, 64, 7
     mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
     if b_column_major:
@@ -156,6 +196,32 @@ def test_addmm_out(M, N, K, scalar, dtype):
 
 
 @pytest.mark.addmm_out
+@_common_addmm_only
+@pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_addmm_out_vector_bias_shapes(M, N, K, dtype, b_column_major):
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((M, N), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+    )
+    with flag_gems.use_gems():
+        torch.addmm(bias, mat1, mat2, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm_out
+@_common_addmm_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.parametrize("b_column_major", [True, False])
 def test_addmm_out_noncontiguous(dtype, b_column_major):
@@ -167,16 +233,35 @@ def test_addmm_out_noncontiguous(dtype, b_column_major):
         mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
     bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
     out = torch.empty((N, M), dtype=dtype, device=flag_gems.device).t()
+
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_bias = utils.to_reference(bias, True)
     ref_out = utils.to_reference(out, True)
 
-    torch.addmm(
-        utils.to_reference(bias, True),
-        utils.to_reference(mat1, True),
-        utils.to_reference(mat2, True),
-        out=ref_out,
-    )
+    torch.addmm(ref_bias, ref_mat1, ref_mat2, out=ref_out)
     with flag_gems.use_gems():
         torch.addmm(bias, mat1, mat2, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@_common_addmm_only
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("bias_shape", [(), (1, 128), (128, 1)])
+def test_addmm_broadcast_bias(dtype, bias_shape):
+    M, N, K = 128, 128, 128
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    mat2 = torch.randn((N, K), dtype=dtype, device=flag_gems.device).t()
+    bias = torch.randn(bias_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_mat1 = utils.to_reference(mat1, True)
+    ref_mat2 = utils.to_reference(mat2, True)
+    ref_bias = utils.to_reference(bias, True)
+    ref_out = torch.addmm(ref_bias, ref_mat1, ref_mat2)
+    with flag_gems.use_gems():
+        out = torch.addmm(bias, mat1, mat2)
 
     utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
 

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -43,7 +43,7 @@ else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
 
 
-_ADDMM_LAYOUT_BIAS_VENDORS = ("ascend", "nvidia", "hygon", "thead")
+_ADDMM_LAYOUT_BIAS_VENDORS = ("ascend", "nvidia", "hygon", "thead", "mthreads")
 
 # Extend this set as vendor implementations gain equivalent layout and bias support.
 _addmm_layout_bias_only = pytest.mark.skipif(


### PR DESCRIPTION
### PR Category

Operator, OP Test

### Type of Change

Performance Optimization

### Description

This is the MThreads-only split of #5282.

This PR optimizes `addmm`, `addmm.out`, `addmm.dtype`, and
`addmm.dtype_out` while preserving the existing AddMM numerical contract. The
implementation:

- builds on the current #5604 SQMMA/FMA and `addmm.out` paths while allowing
  both paths to write directly to caller-provided output tensors;
- keeps vector and scalar bias compact and uses broadcast strides for other
  valid bias shapes instead of materializing a full `[M, N]` tensor;
- preserves supported row- and column-contiguous matrix views and materializes
  general views only when required by the backend;
- keeps the current #5604 FMA tuning while adding layout-aware loads and
  compact bias handling;
- keeps FP16/BF16-to-FP32 accumulation on FMA so the result has no
  low-precision intermediate.

No common or other vendor kernel implementation is changed.

### Issue

#5385

### Merge Sequence

This PR is now rebased on the current #5387 head. Duplicate backend-local test
definitions were removed and the canonical supported-backend set now includes
MThreads. It should merge after #5387 and before #5386.

### Rebase Status

Current head `9ab42a8ca` is reconciled with the recently merged #5604. It
retains #5604's source-local FMA/SQMMA tuning and `addmm.out` registration,
while applying this PR's layout and compact-bias changes. Duplicate tests and
the now-unused YAML tuning additions were removed. CI for this head is in
progress; the measurements below were collected before this conflict-resolution
rebase and should be refreshed if the final MThreads run materially differs.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

MTT S5000, torch 2.9.0, Triton 3.6.0, final candidate source and test files:

- Official source with the PR test harness: `133 passed, 2 failed`
- This PR: `135 passed`

The two Official failures are the FP16-input/FP32-output accumulation cases for
`addmm.dtype` and `addmm.dtype_out`; this PR writes directly to the requested
FP32 output and both pass. Added tests cover FP32, FP16, and BF16 with
scalar/row/column broadcast bias, padded row- and column-major matrix views,
and non-contiguous output tensors.

### Performance

Measurements use the public FlagGems benchmark path in kernel mode/core level,
with 100 ms warmup and 200 ms repetition windows. Speedup is
`Official Gems / This PR`; values above 1 mean this PR is faster.

| Case group (5 cases each) | FP32 | FP16 | BF16 |
|---|---:|---:|---:|
| Upstream AddMM shapes | 1.047x | 1.021x | 0.992x |
| Medium vector-bias, column-major `mat2` | 2.975x | 8.525x | 8.522x |

Selected rows:

| Dtype / shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---:|---:|---:|---:|
| FP32, `[384,384]@[384,384]` | 0.052400 | 0.506840 | 0.434320 | 1.167x |
| FP32, `[4096,4096]@[4096,4096]` | 5.485660 | 82.836823 | 81.069458 | 1.022x |
| FP32, `[64,184]@[184,256]`, vector bias | 0.023680 | 1.406500 | 0.201240 | 6.989x |
| BF16, `[512,1024]@[1024,1024]`, vector bias | 0.015120 | 2.579200 | 0.199060 | 12.957x |

The vector-bias gains primarily remove full `[M, N]` bias materialization;
they are not presented as GEMM-core speedups. The largest upstream
low-precision shapes remain close to Official and range from `0.946x` to
`1.066x`.
