### PR TITLE
[MetaX] Optimize AddMM layouts and bias epilogue

### DIFF
--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -110,19 +110,23 @@ def addmm_kernel(
             b_ptrs += BLOCK_SIZE_K * stride_bk
 
     mask = (offs_m < M)[:, None] & (offs_n < N)[None, :]
-    if BIAS_IS_VECTOR:
-        bias = tl.load(
-            i_ptr + offs_n * stride_in,
-            mask=offs_n < N,
-            other=0.0,
-        )[None, :]
-    elif BIAS_IS_SCALAR:
-        bias = tl.load(i_ptr)
+    # PyTorch ignores bias, including NaN and Inf values, when beta is zero.
+    if beta == 0:
+        result = accumulator * alpha
     else:
-        i_ptrs = i_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
-        bias = tl.load(i_ptrs, mask=mask, other=0.0)
+        if BIAS_IS_VECTOR:
+            bias = tl.load(
+                i_ptr + offs_n * stride_in,
+                mask=offs_n < N,
+                other=0.0,
+            )[None, :]
+        elif BIAS_IS_SCALAR:
+            bias = tl.load(i_ptr)
+        else:
+            i_ptrs = i_ptr + offs_m[:, None] * stride_im + offs_n[None, :] * stride_in
+            bias = tl.load(i_ptrs, mask=mask, other=0.0)
+        result = accumulator * alpha + bias.to(accumulator.dtype) * beta
 
-    result = accumulator * alpha + bias.to(accumulator.dtype) * beta
     c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
     tl.store(c_ptrs, result.to(c_ptr.dtype.element_ty), mask=mask)
 
@@ -249,6 +253,6 @@ def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
     if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
         raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
 
-    # Write directly to the requested dtype instead of using an input-dtype temporary.
-    bias_c = bias.to(out_dtype)
+    # beta=0 must not read bias; otherwise cast it directly to the output dtype.
+    bias_c = bias if beta == 0 else bias.to(out_dtype)
     return addmm_out(bias_c, mat1, mat2, beta=beta, alpha=alpha, out=out)

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import torch
 import triton
 
@@ -29,6 +31,25 @@ def _metax_max_num_warps():
 
 def simple_elementwise_blocksize_heur(args):
     return 512
+
+
+def addmm_heur_upgrade(args):
+    num_tiles = math.ceil(
+        (args["M"] * args["N"]) / (args["BLOCK_SIZE_M"] * args["BLOCK_SIZE_N"])
+    )
+    return num_tiles.bit_length() > 31
+
+
+def addmm_heur_upgrade_a_offs(args):
+    return math.ceil(args["M"] * args["K"]).bit_length() > 31
+
+
+def addmm_heur_upgrade_b_offs(args):
+    return math.ceil(args["K"] * args["N"]).bit_length() > 31
+
+
+def addmm_heur_upgrade_c_offs(args):
+    return math.ceil(args["M"] * args["N"]).bit_length() > 31
 
 
 def argmax_heur_block_m(args):
@@ -400,6 +421,12 @@ def zeros_heur_num_warps(args):
 
 
 HEURISTICS_CONFIGS = {
+    "addmm": {
+        "UPGRADE": addmm_heur_upgrade,
+        "UPGRADE_A_OFFS": addmm_heur_upgrade_a_offs,
+        "UPGRADE_B_OFFS": addmm_heur_upgrade_b_offs,
+        "UPGRADE_C_OFFS": addmm_heur_upgrade_c_offs,
+    },
     "amax": {
         "BLOCK_M": lambda args: 4,
         "BLOCK_N": lambda args: 1024,

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -2,7 +2,7 @@ from ._make_dep_token import _make_dep_token
 from ._nested_view_from_buffer_copy import _nested_view_from_buffer_copy
 from ._thnn_fused_lstm_cell_backward_impl import _thnn_fused_lstm_cell_backward_impl
 from .adaptive_max_pool3d_backward import adaptive_max_pool3d_backward
-from .addmm import addmm
+from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out
 from .alpha_dropout import alpha_dropout
 from .amax import amax
 from .arange import arange, arange_start
@@ -82,6 +82,9 @@ __all__ = [
     "_unique2",
     "adaptive_max_pool3d_backward",
     "addmm",
+    "addmm_dtype",
+    "addmm_dtype_out",
+    "addmm_out",
     "alpha_dropout",
     "amax",
     "arange",

--- a/src/flag_gems/runtime/backend/_metax/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/addmm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import math
 
 import torch
 import triton
@@ -21,6 +20,7 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
+from flag_gems.runtime.backend._metax import heuristics_config_utils as _hcu
 from flag_gems.utils import broadcastable_to, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
 
@@ -35,32 +35,7 @@ logger = logging.getLogger(__name__)
     warmup=5,
     rep=10,
 )
-@triton.heuristics(
-    {
-        "UPGRADE": lambda args: math.ceil(
-            (args["M"] * args["N"]) / (args["BLOCK_SIZE_M"] * args["BLOCK_SIZE_N"])
-        ).bit_length()
-        > 31,
-    }
-)
-@triton.heuristics(
-    {
-        "UPGRADE_A_OFFS": lambda args: math.ceil(args["M"] * args["K"]).bit_length()
-        > 31,
-    }
-)
-@triton.heuristics(
-    {
-        "UPGRADE_B_OFFS": lambda args: math.ceil(args["K"] * args["N"]).bit_length()
-        > 31,
-    }
-)
-@triton.heuristics(
-    {
-        "UPGRADE_C_OFFS": lambda args: math.ceil(args["M"] * args["N"]).bit_length()
-        > 31,
-    }
-)
+@triton.heuristics(_hcu.HEURISTICS_CONFIGS["addmm"])
 @triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_kernel(
     a_ptr,

--- a/src/flag_gems/runtime/backend/_metax/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/addmm.py
@@ -26,24 +26,39 @@ from flag_gems.utils import triton_lang_extension as ext
 
 logger = logging.getLogger(__name__)
 
-# DispatchKeySet to redispatch to the native ATen implementation,
-# bypassing our registered dispatch override (avoids recursion).
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeExplicitAutograd
-)
-
 
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("addmm"),
-    key=["M", "N", "K"],
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=10,
 )
 @triton.heuristics(
     {
         "UPGRADE": lambda args: math.ceil(
             (args["M"] * args["N"]) / (args["BLOCK_SIZE_M"] * args["BLOCK_SIZE_N"])
         ).bit_length()
-        > 32,
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_A_OFFS": lambda args: math.ceil(args["M"] * args["K"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_B_OFFS": lambda args: math.ceil(args["K"] * args["N"]).bit_length()
+        > 31,
+    }
+)
+@triton.heuristics(
+    {
+        "UPGRADE_C_OFFS": lambda args: math.ceil(args["M"] * args["N"]).bit_length()
+        > 31,
     }
 )
 @triton.jit(do_not_specialize=["alpha", "beta"])
@@ -68,51 +83,194 @@ def addmm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
     UPGRADE: tl.constexpr,
+    UPGRADE_A_OFFS: tl.constexpr,
+    UPGRADE_B_OFFS: tl.constexpr,
+    UPGRADE_C_OFFS: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
 ):
     if UPGRADE:
-        pid_m = ext.program_id(0)
-        pid_n = ext.program_id(1)
+        pid = ext.program_id(0)
     else:
-        pid_m = tl.program_id(0)
-        pid_n = tl.program_id(1)
+        pid = tl.program_id(0)
 
-    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    grid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    # Visit neighboring M tiles before advancing N to improve B-tile reuse.
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    if UPGRADE_A_OFFS:
+        offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+    else:
+        offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    if UPGRADE_B_OFFS:
+        offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(
             a_ptrs,
-            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(
             b_ptrs,
-            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_n[None, :] < N),
             other=0.0,
         )
         accumulator += tl.dot(a, b, allow_tf32=False)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    i_ptrs = i_ptr + stride_im * offs_cm[:, None] + stride_in * offs_cn[None, :]
-    bias = tl.load(i_ptrs, mask=c_mask, other=0.0)
+    if UPGRADE_C_OFFS:
+        store_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)).to(tl.int64)
+        store_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)).to(tl.int64)
+    else:
+        store_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        store_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * store_m[:, None] + stride_cn * store_n[None, :]
+    mask = (store_m[:, None] < M) & (store_n[None, :] < N)
+    # PyTorch ignores bias, including NaN and Inf values, when beta is zero.
+    if beta == 0:
+        result = accumulator * alpha
+    else:
+        if BIAS_IS_VECTOR:
+            bias_tile = tl.load(
+                i_ptr + stride_in * store_n,
+                mask=store_n < N,
+                other=0.0,
+            )[None, :]
+        elif BIAS_IS_SCALAR:
+            bias_tile = tl.load(i_ptr)
+        else:
+            i_ptrs = i_ptr + stride_im * store_m[:, None] + stride_in * store_n[None, :]
+            bias_tile = tl.load(i_ptrs, mask=mask, other=0.0)
+        result = accumulator * alpha + bias_tile.to(accumulator.dtype) * beta
+    tl.store(c_ptrs, result.to(c_ptr.dtype.element_ty), mask=mask)
 
-    accumulator = accumulator * alpha + bias * beta
-    c = accumulator.to(bias.dtype)
-    tl.store(c_ptrs, c, mask=c_mask)
+
+@libentry()
+@triton.jit(do_not_specialize=["alpha", "beta"])
+def addmm_fallback_kernel(
+    a_ptr,
+    b_ptr,
+    i_ptr,
+    c_ptr,
+    alpha,
+    beta,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_im,
+    stride_in,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_K: tl.constexpr,
+    BIAS_IS_VECTOR: tl.constexpr,
+    BIAS_IS_SCALAR: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    row = pid // N
+    col = pid % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    accumulator = 0.0
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_offsets = k * BLOCK_SIZE_K + offs_k
+        a = tl.load(
+            a_ptr + row * stride_am + k_offsets * stride_ak,
+            mask=k_offsets < K,
+            other=0.0,
+        ).to(tl.float32)
+        b = tl.load(
+            b_ptr + k_offsets * stride_bk + col * stride_bn,
+            mask=k_offsets < K,
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.sum(a * b, axis=0)
+
+    if beta == 0:
+        result = accumulator * alpha
+    else:
+        if BIAS_IS_VECTOR:
+            bias = tl.load(i_ptr + col * stride_in)
+        elif BIAS_IS_SCALAR:
+            bias = tl.load(i_ptr)
+        else:
+            bias = tl.load(i_ptr + row * stride_im + col * stride_in)
+        result = accumulator * alpha + bias.to(tl.float32) * beta
+    tl.store(
+        c_ptr + row * stride_cm + col * stride_cn,
+        result.to(c_ptr.dtype.element_ty),
+    )
 
 
-def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("GEMS_METAX ADDMM")
+def _prepare_bias(bias, out):
+    bias_is_vector = bias.ndim == 1 and bias.shape[0] == out.shape[1]
+    bias_is_scalar = not bias_is_vector and bias.numel() == 1
+    if bias_is_vector:
+        return bias, 0, bias.stride(0), True, False
+    if bias_is_scalar:
+        return bias, 0, 0, False, True
+    bias = bias.broadcast_to(out.shape)
+    return bias, bias.stride(0), bias.stride(1), False, False
+
+
+def _fallback_addmm(bias, mat1, mat2, out, beta, alpha):
+    M, K = mat1.shape
+    N = mat2.shape[1]
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    if M == 0 or N == 0:
+        return out
+
+    bias, stride_im, stride_in, bias_is_vector, bias_is_scalar = _prepare_bias(
+        bias, out
+    )
+    block_size_k = min(256, triton.next_power_of_2(K)) if K > 0 else 1
+    with torch_device_fn.device(mat1.device):
+        addmm_fallback_kernel[(M * N,)](
+            mat1,
+            mat2,
+            bias,
+            out,
+            alpha,
+            beta,
+            M,
+            N,
+            K,
+            mat1.stride(0),
+            mat1.stride(1),
+            mat2.stride(0),
+            mat2.stride(1),
+            stride_im,
+            stride_in,
+            out.stride(0),
+            out.stride(1),
+            BLOCK_SIZE_K=block_size_k,
+            BIAS_IS_VECTOR=bias_is_vector,
+            BIAS_IS_SCALAR=bias_is_scalar,
+        )
+    return out
+
+
+def _addmm_impl(bias, mat1, mat2, out, beta, alpha):
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -128,29 +286,36 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
         K,
         mat1.stride(0) == 1,
         mat2.stride(0) == 1,
-        bias.stride(0) == 1,
+        bias.ndim > 0 and bias.stride(0) == 1,
     )
 
-    # MetaX workaround: fall back to torch for shapes that trigger genSwiMask
-    # assertion in the MetaX compiler. This happens when M or N < 16 (tl.dot
-    # minimum dimension) or when dimensions are large and non-power-of-2 aligned.
+    # Avoid MetaX dot lowering for output dimensions smaller than one tile.
     MIN_TILE = 32
     if M < MIN_TILE or N < MIN_TILE:
         logger.debug(
-            "GEMS_METAX ADDMM falling back to torch (small M=%s or N=%s)", M, N
+            "GEMS_METAX ADDMM using scalar fallback (small M=%s or N=%s)", M, N
         )
-        return torch.ops.aten.addmm.default.redispatch(
-            _FALLBACK_KEYSET, bias, mat1, mat2, beta=beta, alpha=alpha
-        )
+        return _fallback_addmm(bias, mat1, mat2, out, beta, alpha)
 
-    mat1 = mat1.contiguous()
-    mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
-    bias = bias.broadcast_to(out.shape).contiguous()
-
+    fallback_bias = bias
+    fallback_mat1 = mat1
+    fallback_mat2 = mat2
+    fallback_out = out
+    # MetaX lowers the GEMM load efficiently when B is contiguous in N.
+    if mat1.stride(0) > 1 and mat1.stride(1) > 1:
+        mat1 = mat1.contiguous()
+    if mat2.stride(1) != 1:
+        mat2 = mat2.contiguous()
+    if out is None:
+        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    else:
+        assert out.shape == (M, N), "Incompatible output shape"
+    # Keep vector/scalar bias compact; broadcast strides cover other valid shapes.
+    bias, bias_stride_m, bias_stride_n, bias_is_vector, bias_is_scalar = _prepare_bias(
+        bias, out
+    )
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]),
-        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
     )
     try:
         with torch_device_fn.device(mat1.device):
@@ -168,24 +333,78 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
                 mat1.stride(1),
                 mat2.stride(0),
                 mat2.stride(1),
-                bias.stride(0),
-                bias.stride(1),
+                bias_stride_m,
+                bias_stride_n,
                 out.stride(0),
                 out.stride(1),
+                GROUP_M=8,
+                BIAS_IS_VECTOR=bias_is_vector,
+                BIAS_IS_SCALAR=bias_is_scalar,
             )
         return out
     except RuntimeError as e:
-        # MetaX compiler may fail on certain shape/tile combinations
-        # (e.g., genSwiMask assertion with async pipeline passes).
-        # Fall back to torch.addmm for correctness.
+        # Retry without dot tiling when MetaX async-pipeline lowering rejects
+        # a shape/config combination.
         logger.warning(
             "GEMS_METAX ADDMM kernel compilation failed for shape (%s,%s,%s), "
-            "falling back to torch.addmm: %s",
+            "using scalar fallback: %s",
             M,
             N,
             K,
             e,
         )
-        return torch.ops.aten.addmm.default.redispatch(
-            _FALLBACK_KEYSET, bias, mat1, mat2, beta=beta, alpha=alpha
+        return _fallback_addmm(
+            fallback_bias,
+            fallback_mat1,
+            fallback_mat2,
+            fallback_out,
+            beta,
+            alpha,
         )
+
+
+def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM")
+    return _addmm_impl(bias, mat1, mat2, None, beta, alpha)
+
+
+def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
+    logger.debug("GEMS_METAX ADDMM_OUT")
+    return _addmm_impl(bias, mat1, mat2, out, beta, alpha)
+
+
+def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
+    logger.debug("GEMS_METAX ADDMM_DTYPE")
+    out = torch.empty(
+        (mat1.shape[0], mat2.shape[1]),
+        device=mat1.device,
+        dtype=out_dtype,
+    )
+    return addmm_dtype_out(bias, mat1, mat2, out_dtype, beta=beta, alpha=alpha, out=out)
+
+
+def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
+    logger.debug("GEMS_METAX ADDMM_DTYPE_OUT")
+    if mat1.dtype != mat2.dtype:
+        raise RuntimeError(
+            f"mat1 and mat2 must have the same dtype, but got {mat1.dtype} and {mat2.dtype}"
+        )
+    if out.dtype != out_dtype:
+        raise RuntimeError(
+            "out_dtype must be the same as the dtype of the provided out tensor"
+        )
+    if not (
+        out_dtype == mat1.dtype
+        or (
+            out_dtype == torch.float32 and mat1.dtype in (torch.float16, torch.bfloat16)
+        )
+    ):
+        raise RuntimeError(
+            "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs"
+        )
+    if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
+        raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
+
+    # beta=0 must not read bias; otherwise cast it directly to the output dtype.
+    bias_c = bias if beta == 0 else bias.to(out_dtype)
+    return _addmm_impl(bias_c, mat1, mat2, out, beta, alpha)

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -43,8 +43,15 @@ else:
     FLOAT_DTYPES = utils.FLOAT_DTYPES
 
 
-_ADDMM_LAYOUT_BIAS_VENDORS = ("ascend", "nvidia", "hygon", "thead", "mthreads")
-_COMMON_ADDMM_VENDORS = ("nvidia", "hygon", "thead")
+_ADDMM_LAYOUT_BIAS_VENDORS = (
+    "ascend",
+    "nvidia",
+    "hygon",
+    "thead",
+    "mthreads",
+    "metax",
+)
+_ADDMM_BETA_ZERO_VENDORS = ("nvidia", "hygon", "thead", "metax")
 
 # Extend this set as vendor implementations gain equivalent layout and bias support.
 _addmm_layout_bias_only = pytest.mark.skipif(
@@ -52,9 +59,9 @@ _addmm_layout_bias_only = pytest.mark.skipif(
     reason="Issue #5385: AddMM layout and bias coverage is pending on this backend",
 )
 
-_common_addmm_only = pytest.mark.skipif(
-    flag_gems.vendor_name not in _COMMON_ADDMM_VENDORS,
-    reason="This case validates the common AddMM implementation",
+_addmm_beta_zero_only = pytest.mark.skipif(
+    flag_gems.vendor_name not in _ADDMM_BETA_ZERO_VENDORS,
+    reason="This backend does not yet preserve the AddMM beta-zero contract",
 )
 
 
@@ -96,7 +103,7 @@ def test_addmm(monkeypatch, M, N, K, scalar, dtype, b_column_major):
 
 
 @pytest.mark.addmm
-@_common_addmm_only
+@_addmm_beta_zero_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_addmm_beta_zero_ignores_bias(dtype):
     M, N, K = 17, 19, 23
@@ -227,7 +234,7 @@ def test_addmm_out(M, N, K, scalar, dtype):
 
 
 @pytest.mark.addmm_out
-@_common_addmm_only
+@_addmm_beta_zero_only
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_addmm_out_beta_zero_ignores_bias(dtype):
     M, N, K = 17, 19, 23
@@ -354,7 +361,7 @@ def test_addmm_dtype_fp32_accum(M, N, K):
 
 
 @pytest.mark.addmm_dtype
-@_common_addmm_only
+@_addmm_beta_zero_only
 @pytest.mark.skipif(
     version.parse(torch.__version__) < version.parse("2.8"),
     reason="The operator addmm.dtype was added starting from 2.8.0",
@@ -413,7 +420,7 @@ def test_addmm_dtype_out_fp32_accum(M, N, K):
 
 
 @pytest.mark.addmm_dtype_out
-@_common_addmm_only
+@_addmm_beta_zero_only
 @pytest.mark.skipif(
     version.parse(torch.__version__) < version.parse("2.8"),
     reason="The operator addmm.dtype_out was added starting from 2.8.0",

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -44,11 +44,17 @@ else:
 
 
 _ADDMM_LAYOUT_BIAS_VENDORS = ("ascend", "nvidia", "hygon", "thead", "mthreads")
+_COMMON_ADDMM_VENDORS = ("nvidia", "hygon", "thead")
 
 # Extend this set as vendor implementations gain equivalent layout and bias support.
 _addmm_layout_bias_only = pytest.mark.skipif(
     flag_gems.vendor_name not in _ADDMM_LAYOUT_BIAS_VENDORS,
     reason="Issue #5385: AddMM layout and bias coverage is pending on this backend",
+)
+
+_common_addmm_only = pytest.mark.skipif(
+    flag_gems.vendor_name not in _COMMON_ADDMM_VENDORS,
+    reason="This case validates the common AddMM implementation",
 )
 
 
@@ -87,6 +93,28 @@ def test_addmm(monkeypatch, M, N, K, scalar, dtype, b_column_major):
         res_out2 = torch.addmm(bias2, mat1, mat2, alpha=alpha, beta=beta)
 
     utils.gems_assert_close(res_out2, ref_out2, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm
+@_common_addmm_only
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_addmm_beta_zero_ignores_bias(dtype):
+    M, N, K = 17, 19, 23
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.full((N,), float("nan"), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+        beta=0,
+    )
+    with flag_gems.use_gems():
+        result = torch.addmm(bias, mat1, mat2, beta=0)
+
+    assert torch.isfinite(result).all()
+    utils.gems_assert_close(result, ref_out, dtype, reduce_dim=K)
 
 
 @pytest.mark.addmm
@@ -199,6 +227,29 @@ def test_addmm_out(M, N, K, scalar, dtype):
 
 
 @pytest.mark.addmm_out
+@_common_addmm_only
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_addmm_out_beta_zero_ignores_bias(dtype):
+    M, N, K = 17, 19, 23
+    mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
+    mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
+    bias = torch.full((N,), float("nan"), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((M, N), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.addmm(
+        utils.to_reference(bias, True),
+        utils.to_reference(mat1, True),
+        utils.to_reference(mat2, True),
+        beta=0,
+    )
+    with flag_gems.use_gems():
+        torch.addmm(bias, mat1, mat2, beta=0, out=out)
+
+    assert torch.isfinite(out).all()
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.addmm_out
 @_addmm_layout_bias_only
 @pytest.mark.parametrize("M, N, K", VECTOR_BIAS_MNK_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
@@ -302,6 +353,32 @@ def test_addmm_dtype_fp32_accum(M, N, K):
     utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=K)
 
 
+@pytest.mark.addmm_dtype
+@_common_addmm_only
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("2.8"),
+    reason="The operator addmm.dtype was added starting from 2.8.0",
+)
+def test_addmm_dtype_beta_zero_ignores_bias():
+    M, N, K = 17, 19, 23
+    mat1 = torch.randn((M, K), dtype=torch.float16, device=flag_gems.device)
+    mat2 = torch.randn((K, N), dtype=torch.float16, device=flag_gems.device)
+    bias = torch.full((N,), float("nan"), dtype=torch.float16, device=flag_gems.device)
+    ref_out = mat1.detach().cpu().float() @ mat2.detach().cpu().float()
+
+    with flag_gems.use_gems():
+        result = torch.ops.aten.addmm.dtype(
+            bias, mat1, mat2, torch.float32, beta=0.0, alpha=1.0
+        )
+
+    if utils.TO_CPU:
+        result = result.to("cpu")
+    else:
+        ref_out = ref_out.to(flag_gems.device)
+    assert torch.isfinite(result).all()
+    utils.gems_assert_close(result, ref_out, torch.float32, reduce_dim=K)
+
+
 @pytest.mark.addmm_dtype_out
 @pytest.mark.parametrize("M, N, K", MNK_SHAPES)
 @pytest.mark.skipif(
@@ -332,4 +409,37 @@ def test_addmm_dtype_out_fp32_accum(M, N, K):
         out = out.to("cpu")
     else:
         ref_out = ref_out.to(flag_gems.device)
+    utils.gems_assert_close(out, ref_out, torch.float32, reduce_dim=K)
+
+
+@pytest.mark.addmm_dtype_out
+@_common_addmm_only
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("2.8"),
+    reason="The operator addmm.dtype_out was added starting from 2.8.0",
+)
+def test_addmm_dtype_out_beta_zero_ignores_bias():
+    M, N, K = 17, 19, 23
+    mat1 = torch.randn((M, K), dtype=torch.float16, device=flag_gems.device)
+    mat2 = torch.randn((K, N), dtype=torch.float16, device=flag_gems.device)
+    bias = torch.full((N,), float("nan"), dtype=torch.float16, device=flag_gems.device)
+    out = torch.empty((M, N), dtype=torch.float32, device=flag_gems.device)
+    ref_out = mat1.detach().cpu().float() @ mat2.detach().cpu().float()
+
+    with flag_gems.use_gems():
+        torch.ops.aten.addmm.dtype_out(
+            bias,
+            mat1,
+            mat2,
+            torch.float32,
+            beta=0.0,
+            alpha=1.0,
+            out=out,
+        )
+
+    if utils.TO_CPU:
+        out = out.to("cpu")
+    else:
+        ref_out = ref_out.to(flag_gems.device)
+    assert torch.isfinite(out).all()
     utils.gems_assert_close(out, ref_out, torch.float32, reduce_dim=K)

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -61,7 +61,7 @@ _addmm_layout_bias_only = pytest.mark.skipif(
 
 _addmm_beta_zero_only = pytest.mark.skipif(
     flag_gems.vendor_name not in _ADDMM_BETA_ZERO_VENDORS,
-    reason="This backend does not yet preserve the AddMM beta-zero contract",
+    reason="Issue #5755: this backend does not yet preserve the AddMM beta-zero contract",
 )
 
 


### PR DESCRIPTION
### PR Category

Operator, OP Test

### Type of Change

Performance Optimization

### Description

This is the MetaX-only split of #5282.

This PR optimizes `addmm`, `addmm.out`, `addmm.dtype`, and
`addmm.dtype_out` while preserving the existing AddMM numerical contract. The
MetaX implementation:

- uses grouped M-tile ordering to improve B-tile reuse and includes matrix
  layout strides in the tuning key;
- keeps vector and scalar bias compact and uses broadcast strides for other
  valid bias shapes instead of materializing a full `[M, N]` tensor;
- supports row-major, column-major, and padded matrix views, materializing only
  layouts that the MetaX GEMM lowering cannot consume efficiently;
- shares one implementation across all four public APIs, including
  non-contiguous output tensors and FP16/BF16-to-FP32 dtype overloads;
- uses a scalar-reduction fallback for small output dimensions or MetaX
  async-pipeline lowering failures, avoiding recursive dispatcher fallback;
- skips every bias load and dtype conversion when `beta == 0`, matching PyTorch
  behavior for NaN and Inf bias values.

FP32 dot behavior remains strict (`allow_tf32=False`). The MetaX commit does not
change another vendor kernel, its tile/configuration pool, or the public AddMM
contract.

### Issue

#5385

### Merge Sequence

- #5383 (Ascend) and #5384 (MThreads) are merged.
- #5387 is the pending common `beta == 0` follow-up.
- This PR is stacked on #5387 and contains one additional MetaX commit,
  `46650c47f`.
- After #5387 merges, this PR becomes a MetaX-only diff against `master`.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Correctness

Final-head validation used an existing C550 container with
PyTorch `2.8.0+metax3.7.0.7`. The run loaded source commit `46650c47f` from an
isolated `python -S` path; the MetaX AddMM source SHA-256 was
`72c9ff52b82019dc7a29cd5a3bcfbb93b3dfce674dd3dfba59cc250954dca476`.

- `tests/test_addmm.py`: **209 passed** in 116.36 s.
- Coverage includes FP32, FP16, and BF16; `addmm`, `addmm.out`, `addmm.dtype`,
  and `addmm.dtype_out`; scalar/vector/broadcast bias; row-, column-, and padded
  layouts; non-contiguous output; small-shape fallback; and `beta == 0`.
- `pre-commit`, Python compilation, and `git diff --check` pass.

The prior source-isolated baseline run showed three existing Official failures
for scalar bias (FP32/FP16/BF16), caused by accessing `bias.stride(0)` on a
0-D tensor. The MetaX implementation adds an explicit scalar-bias path.

### Performance

The following source-isolated measurements compare Official Gems with the
MetaX scheduling implementation in this PR. They use the public FlagGems
benchmark path in kernel mode/core level; speedup is `Official Gems / This PR`.

| Case group (5 cases each) | FP32 | FP16 | BF16 |
|---|---:|---:|---:|
| Upstream AddMM shapes | 1.004x | 1.001x | 0.998x |
| Medium vector-bias, column-major `mat2` | 3.683x | 4.864x | 4.944x |

Selected rows:

| Dtype / shape | Torch (ms) | Official Gems (ms) | This PR (ms) | Speedup |
|---|---:|---:|---:|---:|
| FP32, `[4096,4096]@[4096,4096]` | 3.998464 | 7.557376 | 7.460864 | 1.013x |
| BF16, `[1024,1024]@[1024,1024]` | 0.066304 | 0.068096 | 0.068352 | 0.996x |
| FP32, `[64,184]@[184,256]`, vector bias | 0.018944 | 0.289024 | 0.046336 | 6.238x |
| BF16, `[512,1024]@[1024,1024]`, vector bias | 0.029440 | 0.316672 | 0.076544 | 4.137x |

These timings were collected before the final `beta == 0` follow-up. The final
restack changes only whether bias is read when beta is zero; all benchmark rows
use the normal beta-one path, and the grid, tile, tuning pool, layout handling,
and GEMM loop are unchanged. The vector-bias gains primarily remove full
`[M, N]` bias materialization and layout conversion; they are not presented as
GEMM-core speedups. Upstream square shapes remain within about 2.2% of
Official.
