### PR TITLE
fix: increase op test job timeout

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -475,7 +475,7 @@ def get_env(gpu_ids):
     return env
 
 
-def run_cmd(op, cmd, cwd=None, env=None, timeout=600, flavor=None):
+def run_cmd(op, cmd, cwd=None, env=None, timeout=1800, flavor=None):
     stdout = subprocess.DEVNULL
     stderr = subprocess.DEVNULL
     if CFG.dump_output:


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
there is a PR and try to update op test timeout value from 600 to 1800:  https://github.com/flagos-ai/FlagGems/pull/4645

but this value rollback 1800 to 600 by another PR: 
https://github.com/flagos-ai/FlagGems/pull/4829
this PR also include the kunlunxin fgmode fix rollback(fixed via another PR).

so we still need to fix this timeout value again with current PR.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
