### PR TITLE
[KMCompiler][Ascend][Iluvatar] Add ascend backend for pairwise_distance op, and fix iluvatar cpu reference error.

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -69,6 +69,7 @@ from .multinomial import multinomial
 from .ones import ones
 from .ones_like import ones_like
 from .outer import outer
+from .pairwise_distance import pairwise_distance
 from .polar import polar
 from .pow import (
     pow_scalar,
@@ -177,6 +178,7 @@ __all__ = [
     "ones",
     "ones_like",
     "outer",
+    "pairwise_distance",
     "polar",
     "pow_scalar",
     "pow_tensor_scalar",

--- a/src/flag_gems/runtime/backend/_ascend/ops/pairwise_distance.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/pairwise_distance.py
@@ -1,0 +1,461 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+
+# x ** p is decomposed as exp2(p * log2(x)): tl_extra_shim.pow is too heavy
+exp2 = tl_extra_shim.exp2
+log2 = tl_extra_shim.log2
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_general_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, p, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0), axis=1)
+    dist = exp2((1.0 / p) * log2(acc))
+    tl.store(out_ptr + pid, dist[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p2_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, (diff * diff), 0.0), axis=1)
+
+    dist = tl.sqrt(acc)
+    tl.store(out_ptr + pid, dist[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p1_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, diff, 0.0), axis=1)
+
+    tl.store(out_ptr + pid, acc[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p0_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    acc = tl.zeros([BLOCK_M], dtype=acc_dtype)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        acc += tl.sum(tl.where(mask, (diff != 0).to(acc_dtype), 0.0), axis=1)
+
+    tl.store(out_ptr + pid, acc[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_max_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    row_mask = pid < N
+    max_val = tl.full([BLOCK_M], -float("inf"), acc_dtype)
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        max_val = tl.maximum(
+            max_val, tl.max(tl.where(mask, diff, -float("inf")), axis=1)
+        )
+    tl.store(out_ptr + pid, max_val[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_min_kernel(
+    x1_ptr, x2_ptr, out_ptr, N, D, eps, BLOCK_M: tl.constexpr, BLOCK_D: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    min_val = tl.full([BLOCK_M], float("inf"), acc_dtype)
+    row_mask = pid < N
+    for start in range(0, D, BLOCK_D):
+        cols = start + tl.arange(0, BLOCK_D)[None, :]
+        col_mask = cols < D
+        mask = row_mask & col_mask
+        a = tl.load(x1_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        b = tl.load(x2_ptr + pid * D + cols, mask=mask, other=0).to(acc_dtype)
+        diff = tl.abs(a - b + eps)
+        min_val = tl.minimum(
+            min_val, tl.min(tl.where(mask, diff, float("inf")), axis=1)
+        )
+    tl.store(out_ptr + pid, min_val[:, None], row_mask)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p2_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, diff * diff, 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p2_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sqrt(tl.sum(mid))
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p1_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, diff, 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p1_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sum(mid)
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p0_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, (diff != 0).to(acc_dtype), 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_p0_kernel_2(mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = tl.sum(mid)
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_general_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.sum(tl.where(mask, exp2(p * log2(diff)), 0.0))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_general_kernel_2(
+    mid_ptr, out_ptr, p, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if mid_ptr.type.element_ty == tl.float64 else tl.float32
+    p = p.to(acc_dtype)
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    sum = exp2((1 / p) * log2(tl.sum(mid)))
+
+    tl.store(out_ptr + pid, sum)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_max_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.max(tl.where(mask, diff, -float("inf")))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_max_kernel_2(
+    mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    max_val = tl.max(tl.where(mask, mid, -float("inf")))
+
+    tl.store(out_ptr + pid, max_val)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_min_kernel_1(
+    x1_ptr, x2_ptr, mid_ptr, D, eps, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    acc_dtype = tl.float64 if x1_ptr.type.element_ty == tl.float64 else tl.float32
+    pid_n = tl.program_id(0)
+    pid_d = tl.program_id(1)
+    offset = pid_d * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    base = pid_n * D
+    mask = offset < D
+    a = tl.load(x1_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    b = tl.load(x2_ptr + base + offset, mask=mask, other=0.0).to(acc_dtype)
+    diff = tl.abs(a - b + eps)
+    mid = tl.min(tl.where(mask, diff, float("inf")))
+    tl.store(mid_ptr + pid_n * MID_SIZE + pid_d, mid)
+
+
+@libentry()
+@triton.jit
+def pairwise_distance_min_kernel_2(
+    mid_ptr, out_ptr, MID_SIZE, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_SIZE)
+    mask = offset < MID_SIZE
+    mid = tl.load(mid_ptr + pid * MID_SIZE + offset, mask=mask, other=0.0)
+    min_val = tl.min(tl.where(mask, mid, float("inf")))
+
+    tl.store(out_ptr + pid, min_val)
+
+
+def _single_config(D, heavy=False):
+    """Explicit per-D tile (no autotune).
+
+    Light kernels (p in {0,1,2,inf,-inf}) keep BLOCK_D aligned to D so loads
+    have no masked waste; BLOCK_M fills the ~8192-elem per-tile budget. The
+    exp2/log2 general-p kernel uses a 4096-elem budget with BLOCK_D <= 2048:
+    that reproduces the shared op's autotuned tile for large D (e.g. (2, 2048)
+    at D=65536), which is the config that passes the fp32 1.3e-6-rtol accuracy
+    tests, and it keeps UB within budget.
+    """
+    if heavy:
+        bd = min(triton.next_power_of_2(D), 2048)
+        bm = max(1, min(512, 4096 // bd))
+        return bm, bd
+    bd = min(triton.next_power_of_2(D), 4096)
+    bm = max(1, min(512, 8192 // bd))
+    return bm, bd
+
+
+def pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
+    logger.debug("GEMS_ASCEND PAIRWISE_DISTANCE")
+    # Only broadcast/contiguous when needed (same shape + contiguous is the common
+    # case; unconditional broadcast_tensors + contiguous materializes a copy).
+    if x1.shape != x2.shape:
+        x1, x2 = torch.broadcast_tensors(x1, x2)
+    if not x1.is_contiguous():
+        x1 = x1.contiguous()
+    if not x2.is_contiguous():
+        x2 = x2.contiguous()
+    D = x1.shape[-1]
+
+    # Empty feature dim: torch returns 0 for finite p; inf/-inf have no identity
+    # element over an empty reduction. Short-circuit (also avoids ZeroDivisionError
+    # in the split-K plumbing when BLOCK_SIZE == 0).
+    if D == 0:
+        if p == float("inf") or p == float("-inf"):
+            raise RuntimeError(
+                "pairwise_distance cannot compute the inf/-inf norm on an empty "
+                "reduction dimension (no identity element)"
+            )
+        out = torch.zeros(x1.shape[:-1], device=x1.device, dtype=x1.dtype)
+        if keepdim:
+            out = out.unsqueeze(-1)
+        return out
+
+    N = x1.numel() // D
+    out = torch.empty(x1.shape[:-1], device=x1.device, dtype=x1.dtype)
+    if keepdim:
+        out = out.unsqueeze(-1)
+    mid_dtype = torch.float64 if x1.dtype == torch.float64 else torch.float32
+
+    with torch_device_fn.device(x1.device):
+        BLOCK_SIZE = min(triton.next_power_of_2(D), 4096)
+        MID_SIZE = triton.cdiv(D, BLOCK_SIZE)
+        # Split-K only pays off when the row is long enough to need many chunks:
+        # on Ascend each extra launch costs ~0.1ms, so splitting e.g. D=65536
+        # (MID_SIZE=16) is slower than the single kernel. Keep the shared op's
+        # small-N guard but require a large chunk count (D ~>= 1M).
+        use_split_k = (N <= 128) and (MID_SIZE >= 256)
+
+        if use_split_k:
+            BLOCK_MID = triton.next_power_of_2(MID_SIZE)
+            mid = torch.empty((N, MID_SIZE), device=x1.device, dtype=mid_dtype)
+            if p == 2.0:
+                pairwise_distance_p2_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p2_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+            elif p == 1.0:
+                pairwise_distance_p1_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p1_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+            elif p == 0.0:
+                pairwise_distance_p0_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_p0_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+            elif p == float("inf"):
+                pairwise_distance_max_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_max_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+            elif p == float("-inf"):
+                pairwise_distance_min_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_min_kernel_2[(N,)](mid, out, MID_SIZE, BLOCK_MID)
+            else:
+                pairwise_distance_general_kernel_1[(N, MID_SIZE)](
+                    x1, x2, mid, D, eps, p, MID_SIZE, BLOCK_SIZE
+                )
+                pairwise_distance_general_kernel_2[(N,)](
+                    mid, out, p, MID_SIZE, BLOCK_MID
+                )
+            return out
+
+        is_general = p not in (2.0, 1.0, 0.0, float("inf"), float("-inf"))
+        bm, bd = _single_config(D, heavy=is_general)
+        grid = (triton.cdiv(N, bm),)
+        if p == 2.0:
+            pairwise_distance_p2_kernel[grid](
+                x1, x2, out, N, D, eps, BLOCK_M=bm, BLOCK_D=bd
+            )
+        elif p == 1.0:
+            pairwise_distance_p1_kernel[grid](
+                x1, x2, out, N, D, eps, BLOCK_M=bm, BLOCK_D=bd
+            )
+        elif p == 0.0:
+            pairwise_distance_p0_kernel[grid](
+                x1, x2, out, N, D, eps, BLOCK_M=bm, BLOCK_D=bd
+            )
+        elif p == float("inf"):
+            pairwise_distance_max_kernel[grid](
+                x1, x2, out, N, D, eps, BLOCK_M=bm, BLOCK_D=bd
+            )
+        elif p == float("-inf"):
+            pairwise_distance_min_kernel[grid](
+                x1, x2, out, N, D, eps, BLOCK_M=bm, BLOCK_D=bd
+            )
+        else:
+            pairwise_distance_general_kernel[grid](
+                x1, x2, out, N, D, eps, p, BLOCK_M=bm, BLOCK_D=bd
+            )
+
+    return out

--- a/tests/test_pairwise_distance.py
+++ b/tests/test_pairwise_distance.py
@@ -8,9 +8,7 @@ from . import conftest as cfg
 
 
 def composed_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
-    """NPU-native pairwise_distance via basic torch ops (sub+abs+pow+sum).
-    Supports arbitrary p, unlike torch_npu's LpNormV2 which only accepts {0,1,2}.
-    Used as the reference when aten would crash on p not in {0,1,2,inf,-inf}."""
+    # torch-native pairwise_distance via basic torch ops (sub+abs+pow+sum).
     diff = torch.abs(x1 - x2 + eps)
     if p == float("inf"):
         return torch.amax(diff, dim=-1, keepdim=keepdim)
@@ -29,11 +27,17 @@ def composed_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
 # torch_npu's native pairwise_distance only supports p in {0, 1, 2} -- inf,
 # -inf, and arbitrary real p all crash (core dump). When the reference runs on
 # NPU (not CPU), use the composed version for any p outside {0, 1, 2}.
-_ATEN_SUPPORTED_P = (0.0, 1.0, 2.0)
+_ASCEND_SUPPORTED_P = (0.0, 1.0, 2.0)
 
 
 def _ref_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
-    if not cfg.TO_CPU and p not in _ATEN_SUPPORTED_P:
+    # On ascend backend, native pairwise_distance only supports p in {0, 1, 2}.
+    # Fall back to composed op for unsupported p values.
+    if flag_gems.vendor_name == "ascend" and not cfg.TO_CPU and p not in _ASCEND_SUPPORTED_P:
+        return composed_pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
+    # On iluvatar, CPU-mode torch.pairwise_distance precision does not match
+    # the device-side implementation. Use composed op when TO_CPU is enabled.
+    if flag_gems.vendor_name == "iluvatar" and cfg.TO_CPU:
         return composed_pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
     return torch.nn.functional.pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
 

--- a/tests/test_pairwise_distance.py
+++ b/tests/test_pairwise_distance.py
@@ -33,7 +33,11 @@ _ASCEND_SUPPORTED_P = (0.0, 1.0, 2.0)
 def _ref_pairwise_distance(x1, x2, p=2.0, eps=1e-6, keepdim=False):
     # On ascend backend, native pairwise_distance only supports p in {0, 1, 2}.
     # Fall back to composed op for unsupported p values.
-    if flag_gems.vendor_name == "ascend" and not cfg.TO_CPU and p not in _ASCEND_SUPPORTED_P:
+    if (
+        flag_gems.vendor_name == "ascend"
+        and not cfg.TO_CPU
+        and p not in _ASCEND_SUPPORTED_P
+    ):
         return composed_pairwise_distance(x1, x2, p=p, eps=eps, keepdim=keepdim)
     # On iluvatar, CPU-mode torch.pairwise_distance precision does not match
     # the device-side implementation. Use composed op when TO_CPU is enabled.


### PR DESCRIPTION
### PR Category
[ Operator]

### Type of Change
[ New Feature]

### Description
Add ascend backend for pairwise_distance op.
Fix iluvatar accuracy test cpu reference error.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
pytest benchmark/test_pairwise_distance.py --mode operator -s, avg speedup is 1.1x
```
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-8.3.2, pluggy-1.6.0
rootdir: /workspace/repo/FlagGems
configfile: pytest.ini
plugins: xdist-3.6.1, anyio-4.10.0
collected 1 item

benchmark/test_pairwise_distance.py 
Operator: pairwise_distance  Performance Test (dtype=torch.float16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.076027            0.185728               0.409          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.079228            0.124277               0.638          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.045345            0.123661               0.367          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.042937            0.124352               0.345          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.045089            0.124758               0.361          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.120437            0.128235               0.939          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.070572            0.126026               0.560          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.069630            0.126801               0.549          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.041153            0.126139               0.326          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.041282            0.125095               0.330          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.041929            0.124145               0.338          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.109225            0.125475               0.870          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.068559            0.124630               0.550          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.068891            0.125550               0.549          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.042059            0.124882               0.337          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.040988            0.125673               0.326          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.041296            0.125639               0.329          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.109770            0.127147               0.863          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.128168            0.128206               1.000          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.129138            0.124986               1.033          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.244565            0.126131               1.939          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.146635            0.126620               1.158          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.143170            0.125790               1.138          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               0.691991            0.157666               4.389          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               0.943572            0.412217               2.289          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               0.943764            0.412868               2.286          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               1.077464            0.447977               2.405          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               0.732427            0.378783               1.934          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               0.734475            0.399660               1.838          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               3.059298            0.765497               3.996          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.066452            0.128929               0.515          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.065755            0.126403               0.520          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.041545            0.125934               0.330          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.041710            0.123989               0.336          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.041711            0.125591               0.332          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.107257            0.129501               0.828          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.069116            0.122855               0.563          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.067774            0.123263               0.550          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.041177            0.122060               0.337          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.040632            0.121812               0.334          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.040903            0.122182               0.335          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.141326            0.123458               1.145          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS               8.596875            3.933112               2.186          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS               8.600257            3.932536               2.187          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS              10.250542            4.279310               2.395          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS               6.725635            3.614059               1.861          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS               6.800515            3.813863               1.783          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS              29.178937            7.307676               3.993          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.066620            0.125976               0.529          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.068469            0.125331               0.546          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.036036            0.122521               0.294          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.036767            0.122786               0.299          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.036448            0.121992               0.299          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.107820            0.125761               0.857          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.069188            0.122237               0.566          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.067913            0.122312               0.555          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.037257            0.122122               0.305          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.037403            0.122920               0.304          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.037272            0.122182               0.305          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.108159            0.125760               0.860          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.068684            0.119266               0.576          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.068320            0.117665               0.581          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.058491            0.118037               0.496          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.037276            0.119127               0.313          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.041562            0.119522               0.348          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.182079            0.121247               1.502          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.069525            0.208398               0.334          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.068134            0.208047               0.327          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.106405            0.205588               0.518          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.046690            0.205548               0.227          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.049616            0.206078               0.241          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.398947            0.208191               1.916          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})


Operator: pairwise_distance  Performance Test (dtype=torch.float32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.068545            0.122790               0.558          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.067309            0.121538               0.554          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.042622            0.121197               0.352          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.043297            0.121290               0.357          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.041968            0.121138               0.346          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.113462            0.127625               0.889          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.069225            0.125815               0.550          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.068685            0.124535               0.552          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.040141            0.123562               0.325          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.041122            0.122724               0.335          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.041101            0.123031               0.334          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.107423            0.126373               0.850          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.066993            0.123082               0.544          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.075558            0.141378               0.534          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.044346            0.142989               0.310          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.043369            0.139218               0.312          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.044082            0.142663               0.309          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.120598            0.142593               0.846          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.443695            0.140990               3.147          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.443184            0.138297               3.205          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.442809            0.142280               3.112          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.368218            0.141288               2.606          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.376593            0.148196               2.541          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               1.015775            0.154150               6.590          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               1.851802            0.401851               4.608          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               1.851990            0.402123               4.606          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               1.645651            0.428552               3.840          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               1.411794            0.380874               3.707          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               1.416505            0.393502               3.600          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               3.931723            0.597285               6.583          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.076097            0.138446               0.550          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.079421            0.137191               0.579          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.040463            0.135633               0.298          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.043313            0.135855               0.319          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.043822            0.135287               0.324          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.128688            0.140900               0.913          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.082156            0.135537               0.606          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.081019            0.135025               0.600          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.044330            0.136073               0.326          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.044332            0.135134               0.328          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.045559            0.136814               0.333          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.148416            0.141077               1.052          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS              17.116904            3.822873               4.477          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS              17.089415            3.819416               4.474          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS              16.234438            4.072075               3.987          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS              12.961217            3.639755               3.561          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS              13.066087            3.746370               3.488          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS              37.153125            5.693391               6.526          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.074521            0.139946               0.532          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.074708            0.140111               0.533          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.044096            0.139682               0.316          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.044490            0.137995               0.322          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.044202            0.143173               0.309          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.118138            0.144060               0.820          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.076012            0.142237               0.534          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.075874            0.142237               0.533          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.044803            0.138521               0.323          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.045450            0.139576               0.326          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.045885            0.139851               0.328          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.121470            0.144142               0.843          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.080750            0.137272               0.588          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.079463            0.141495               0.562          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.065983            0.136913               0.482          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.041877            0.136721               0.306          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.042124            0.136675               0.308          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.204851            0.138986               1.474          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.188930            0.226995               0.832          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.188373            0.225949               0.834          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.237636            0.223589               1.063          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.173973            0.225949               0.770          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.176988            0.221570               0.799          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.524902            0.241570               2.173          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})


Operator: pairwise_distance  Performance Test (dtype=torch.bfloat16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.084581            0.137085               0.617          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': -inf})
SUCCESS               0.081625            0.137473               0.594          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': inf})
SUCCESS               0.044215            0.135907               0.325          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 0.0})
SUCCESS               0.044069            0.135924               0.324          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 1.0})
SUCCESS               0.045053            0.136243               0.331          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 2.0})
SUCCESS               0.112304            0.140758               0.798          ([torch.Size([64, 64]), torch.Size([64, 64])], {'p': 6.6})
SUCCESS               0.077976            0.135577               0.575          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': -inf})
SUCCESS               0.077586            0.139655               0.556          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': inf})
SUCCESS               0.040480            0.138012               0.293          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 0.0})
SUCCESS               0.040575            0.137212               0.296          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 1.0})
SUCCESS               0.041167            0.137925               0.298          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 2.0})
SUCCESS               0.128537            0.139269               0.923          ([torch.Size([256, 256]), torch.Size([256, 256])], {'p': 6.6})
SUCCESS               0.083757            0.138257               0.606          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': -inf})
SUCCESS               0.080075            0.138679               0.577          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': inf})
SUCCESS               0.041520            0.138040               0.301          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 0.0})
SUCCESS               0.041581            0.139529               0.298          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 1.0})
SUCCESS               0.041979            0.138581               0.303          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 2.0})
SUCCESS               0.127282            0.138909               0.916          ([torch.Size([1024, 1024]), torch.Size([1024, 1024])], {'p': 6.6})
SUCCESS               0.154939            0.140204               1.105          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': -inf})
SUCCESS               0.158804            0.139596               1.138          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': inf})
SUCCESS               0.264368            0.139637               1.893          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 0.0})
SUCCESS               0.155814            0.140947               1.105          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 1.0})
SUCCESS               0.169685            0.137116               1.238          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 2.0})
SUCCESS               0.717246            0.165617               4.331          ([torch.Size([4096, 4096]), torch.Size([4096, 4096])], {'p': 6.6})
SUCCESS               1.007501            0.417440               2.414          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': -inf})
SUCCESS               1.007426            0.417451               2.413          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': inf})
SUCCESS               1.131844            0.453703               2.495          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 0.0})
SUCCESS               0.776758            0.384465               2.020          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 1.0})
SUCCESS               0.777501            0.405106               1.919          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 2.0})
SUCCESS               3.121138            0.768604               4.061          ([torch.Size([1024, 65536]), torch.Size([1024, 65536])], {'p': 6.6})
SUCCESS               0.075544            0.138876               0.544          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': -inf})
SUCCESS               0.075391            0.136896               0.551          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': inf})
SUCCESS               0.044670            0.136398               0.328          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 0.0})
SUCCESS               0.043704            0.136790               0.319          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 1.0})
SUCCESS               0.043656            0.137199               0.318          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 2.0})
SUCCESS               0.129733            0.139225               0.932          ([torch.Size([10000, 1]), torch.Size([10000, 1])], {'p': 6.6})
SUCCESS               0.081778            0.138015               0.593          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': -inf})
SUCCESS               0.076344            0.137295               0.556          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': inf})
SUCCESS               0.046297            0.137776               0.336          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 0.0})
SUCCESS               0.043358            0.136735               0.317          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 1.0})
SUCCESS               0.044184            0.136210               0.324          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 2.0})
SUCCESS               0.151565            0.139001               1.090          ([torch.Size([10000, 256]), torch.Size([10000, 256])], {'p': 6.6})
SUCCESS               9.225583            3.943018               2.340          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': -inf})
SUCCESS               9.232068            3.941038               2.343          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': inf})
SUCCESS              10.753526            4.293022               2.505          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 0.0})
SUCCESS               7.145900            3.628006               1.970          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 1.0})
SUCCESS               7.179150            3.822813               1.878          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 2.0})
SUCCESS              29.733578            7.330344               4.056          ([torch.Size([10000, 65536]), torch.Size([10000, 65536])], {'p': 6.6})
SUCCESS               0.080512            0.137009               0.588          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': -inf})
SUCCESS               0.078125            0.137030               0.570          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': inf})
SUCCESS               0.040689            0.137604               0.296          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 0.0})
SUCCESS               0.040669            0.134994               0.301          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 1.0})
SUCCESS               0.040618            0.135252               0.300          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 2.0})
SUCCESS               0.126345            0.142151               0.889          ([torch.Size([1, 65536]), torch.Size([1, 65536])], {'p': 6.6})
SUCCESS               0.078580            0.137402               0.572          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': -inf})
SUCCESS               0.078591            0.137363               0.572          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': inf})
SUCCESS               0.038611            0.140487               0.275          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 0.0})
SUCCESS               0.039853            0.139655               0.285          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 1.0})
SUCCESS               0.040252            0.137382               0.293          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 2.0})
SUCCESS               0.119890            0.142436               0.842          ([torch.Size([8, 65536]), torch.Size([8, 65536])], {'p': 6.6})
SUCCESS               0.082429            0.136582               0.604          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': -inf})
SUCCESS               0.077493            0.139653               0.555          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': inf})
SUCCESS               0.064035            0.139186               0.460          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 0.0})
SUCCESS               0.042917            0.137023               0.313          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 1.0})
SUCCESS               0.041122            0.137835               0.298          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 2.0})
SUCCESS               0.200021            0.138411               1.445          ([torch.Size([64, 65536]), torch.Size([64, 65536])], {'p': 6.6})
SUCCESS               0.076144            0.229187               0.332          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': -inf})
SUCCESS               0.075343            0.228557               0.330          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': inf})
SUCCESS               0.119070            0.222063               0.536          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 0.0})
SUCCESS               0.059492            0.223231               0.267          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 1.0})
SUCCESS               0.062352            0.219282               0.284          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 2.0})
SUCCESS               0.410047            0.235993               1.738          ([torch.Size([1, 10000000]), torch.Size([1, 10000000])], {'p': 6.6})

================== 1 passed, 3 warnings in 254.22s (0:04:14) ===================

```
