### PR TITLE
Use Triton for metax CI

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -238,7 +238,9 @@ backends:
   metax-maca3810:
     python: "3.12"
     triton: triton==3.6.0+metax3.8.1.0
-    flagtree: flagtree==0.6.1a2+metax3.6
+    # FlagTree not usable on the CI node because it has requirements
+    # that cannot be met on the runner node.
+    # flagtree: flagtree==0.6.1a2+metax3.6
     env:
       MACA_PATH: /opt/maca
       PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

This PR disable FlagTree on the MetaX CI node, use Triton instead.

### Issue

FlagTree for MetaX has to run on a Ubuntu 24.04+ node, while our CI node has Ubuntu 22.04.

```
mportError while loading conftest '/home/tengqm/actions-runner/_work/FlagGems/FlagGems/tests/conftest.py'.
tests/conftest.py:27: in <module>
    import flag_gems
src/flag_gems/__init__.py:21: in <module>
    from flag_gems import testing  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/flag_gems/testing/__init__.py:17: in <module>
    from flag_gems import runtime
src/flag_gems/runtime/__init__.py:19: in <module>
    from .configs_loader import TunedConfigLoader
src/flag_gems/runtime/configs_loader.py:20: in <module>
    import triton
.venv/lib/python3.12/site-packages/triton/__init__.py:8: in <module>
    from .runtime import (
.venv/lib/python3.12/site-packages/triton/runtime/__init__.py:1: in <module>
    from .autotuner import (Autotuner, Config, Heuristics, autotune, heuristics)
.venv/lib/python3.12/site-packages/triton/runtime/autotuner.py:11: in <module>
    from .. import knobs
.venv/lib/python3.12/site-packages/triton/knobs.py:15: in <module>
    from triton._C.libtriton import getenv, getenv_bool  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /home/tengqm/actions-runner/_work/FlagGems/FlagGems/.venv/lib/python3.12/site-packages/triton/_C/libtriton.so)

```


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A
