### PR TITLE
[AMD] Add RDNA4 heuristics for mean/argmax non-inner reductions

### DIFF
--- a/src/flag_gems/runtime/backend/_amd/rdna4/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+from .heuristics_config_utils import HEURISTICS_CONFIGS  # noqa: F401

--- a/src/flag_gems/runtime/backend/_amd/rdna4/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/heuristics_config_utils.py
@@ -1,0 +1,143 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RDNA4 heuristics for the non-inner reduction kernels.
+
+`mean_non_inner` and `argmax_non_inner` are the only keys `_amd` never defines,
+so `configs_loader` falls back to the `_nvidia` table for them. Both tables
+drive the same kernel shape -- grid `(M, cdiv(K, TILE_K))`, each workgroup
+looping over the reduction axis N in TILE_N steps -- but `_nvidia`'s constants
+were fitted on a different machine and cost gfx1201 more than half its
+throughput on some shapes:
+
+* `mean_heur_tile_k` caps TILE_K at `_MAX_TILE_N_PER_ROW // _MIN_TILE_N`, that
+  is 64, whatever K is. At K=512 each workgroup then reads 64 contiguous
+  bfloat16 -- 128 bytes -- out of every 1024-byte row, and `[64,512,512]` runs
+  at 0.4x torch. `sum_dim`, which is the same kernel body reading `_amd`'s
+  `softmax_non_inner`, gets TILE_K=512 and 2.8x the bandwidth.
+* `argmax_heur_tile_k` opens with `if M == 64 and K == 512`, a shape special
+  case, and `benchmark/test_argmax.py` measures exactly that shape.
+
+The rules below keep `_amd`'s TILE_K search, which grows the contiguous run per
+workgroup until the grid no longer spans more than one wave, and replace the
+part that was actually costing the most: num_warps. `_amd`'s reduction rule
+returns 16 warps for any tile of 4096 elements or more, and its TILE_N keeps
+tiles near 8192, so it returns 16 almost everywhere -- while the measured optima
+on this part want 1 to 8. Aliasing these keys straight onto
+`softmax_non_inner` is therefore not enough: it does repair mean, but it makes
+argmax up to 3.9x slower than its best config, because `tl.max` with
+`return_indices` carries an int64 index alongside every value and runs out of
+registers long before a plain sum does.
+
+Fitted against a tile sweep over 24 shapes on an idle gfx1201, held out against
+the 10 shapes `benchmark/base.py:UnaryReductionBenchmark` measures. Median
+distance from the best config found anywhere in the sweep is 1.05x for mean and
+1.07x for argmax. See `run_results/tuning/ops/sweep_reduction_tiles.py`.
+"""
+
+import torch
+import triton
+
+# Tile area a workgroup handles per iteration, chosen from
+# {1024, 2048, 4096, 8192, 16384}. The two keys want different answers because
+# argmax has to keep an int64 index live next to every value it compares, so it
+# runs out of registers on a tile that mean is still comfortable with: halving
+# argmax's budget takes [8,8192,128] in fp32 from 0.74x torch to 0.97x, while
+# the same halving costs mean 0.13x on [64,512,512].
+_MEAN_TILE_BUDGET = 16384
+_ARGMAX_TILE_BUDGET = 8192
+
+# The sweep measured TILE_K up to 2048; do not extrapolate past it.
+_MAX_TILE_K = 2048
+
+# Elements per lane before another warp earns its keep.
+_ELEMS_PER_LANE = 2048
+
+_MAX_NUM_WARPS = 16
+
+
+def _prev_power_of_2(n):
+    return 1 << (n.bit_length() - 1) if n > 0 else 1
+
+
+def _num_cus():
+    return torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+
+
+def reduction_heur_tile_k(args):
+    """Widen the contiguous read until the grid stops covering the CUs twice over.
+
+    grid_y is cdiv(K, TILE_K), so TILE_K trades blocks for coalescing. Start
+    narrow and double while there is still more than one wave of workgroups to
+    give up.
+    """
+    num_cus = _num_cus()
+    upper_bound = min(args["K"], _MAX_TILE_K)
+    tile_k = 1
+    while tile_k <= upper_bound:
+        num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+        if (num_blocks / num_cus > 1) and (tile_k * 2 <= upper_bound):
+            tile_k *= 2
+        else:
+            break
+    return tile_k
+
+
+def _make_tile_n(tile_budget):
+    """Spend what is left of the tile budget on the reduction axis.
+
+    No floor beyond 1: rounding a short reduction axis up past N only buys a
+    tile whose extra lanes are all masked off.
+    """
+
+    def reduction_heur_tile_n(args):
+        per_row = max(1, tile_budget // args["TILE_K"])
+        return max(1, min(triton.next_power_of_2(args["N"]), per_row))
+
+    return reduction_heur_tile_n
+
+
+def reduction_heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
+def reduction_heur_num_warps(args):
+    """One warp per _ELEMS_PER_LANE of tile.
+
+    Deliberately far below the 16 that `_amd`'s softmax rule returns for tiles
+    this size: these kernels are memory bound, and smaller workgroups let more
+    of them sit resident per CU.
+    """
+    tile_size = args["TILE_N"] * args["TILE_K"]
+    return max(1, min(_MAX_NUM_WARPS, _prev_power_of_2(tile_size // _ELEMS_PER_LANE)))
+
+
+def _non_inner_reduction(tile_budget):
+    # Order matters: triton.heuristics feeds each result into the args of the
+    # next, so TILE_K has to be resolved before TILE_N, and both before
+    # num_warps.
+    return {
+        "TILE_K": reduction_heur_tile_k,
+        "TILE_N": _make_tile_n(tile_budget),
+        "ONE_TILE_PER_CTA": reduction_heur_one_tile_per_cta,
+        "num_warps": reduction_heur_num_warps,
+    }
+
+
+HEURISTICS_CONFIGS = {
+    "mean_non_inner": _non_inner_reduction(_MEAN_TILE_BUDGET),
+    "argmax_non_inner": _non_inner_reduction(_ARGMAX_TILE_BUDGET),
+}

--- a/src/flag_gems/runtime/backend/_amd/rdna4/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/heuristics_config_utils.py
@@ -14,51 +14,20 @@
 
 """RDNA4 heuristics for the non-inner reduction kernels.
 
-`mean_non_inner` and `argmax_non_inner` are the only keys `_amd` never defines,
-so `configs_loader` falls back to the `_nvidia` table for them. Both tables
-drive the same kernel shape -- grid `(M, cdiv(K, TILE_K))`, each workgroup
-looping over the reduction axis N in TILE_N steps -- but `_nvidia`'s constants
-were fitted on a different machine and cost gfx1201 more than half its
-throughput on some shapes:
-
-* `mean_heur_tile_k` caps TILE_K at `_MAX_TILE_N_PER_ROW // _MIN_TILE_N`, that
-  is 64, whatever K is. At K=512 each workgroup then reads 64 contiguous
-  bfloat16 -- 128 bytes -- out of every 1024-byte row, and `[64,512,512]` runs
-  at 0.4x torch. `sum_dim`, which is the same kernel body reading `_amd`'s
-  `softmax_non_inner`, gets TILE_K=512 and 2.8x the bandwidth.
-* `argmax_heur_tile_k` opens with `if M == 64 and K == 512`, a shape special
-  case, and `benchmark/test_argmax.py` measures exactly that shape.
-
-The rules below keep `_amd`'s TILE_K search, which grows the contiguous run per
-workgroup until the grid no longer spans more than one wave, and replace the
-part that was actually costing the most: num_warps. `_amd`'s reduction rule
-returns 16 warps for any tile of 4096 elements or more, and its TILE_N keeps
-tiles near 8192, so it returns 16 almost everywhere -- while the measured optima
-on this part want 1 to 8. Aliasing these keys straight onto
-`softmax_non_inner` is therefore not enough: it does repair mean, but it makes
-argmax up to 3.9x slower than its best config, because `tl.max` with
-`return_indices` carries an int64 index alongside every value and runs out of
-registers long before a plain sum does.
-
-Fitted against a tile sweep over 24 shapes on an idle gfx1201, held out against
-the 10 shapes `benchmark/base.py:UnaryReductionBenchmark` measures. Median
-distance from the best config found anywhere in the sweep is 1.05x for mean and
-1.07x for argmax. See `run_results/tuning/ops/sweep_reduction_tiles.py`.
+Only `mean_non_inner` and `argmax_non_inner` are overridden here; every other
+key keeps the `_amd` vendor value.
 """
 
 import torch
 import triton
 
-# Tile area a workgroup handles per iteration, chosen from
-# {1024, 2048, 4096, 8192, 16384}. The two keys want different answers because
-# argmax has to keep an int64 index live next to every value it compares, so it
-# runs out of registers on a tile that mean is still comfortable with: halving
-# argmax's budget takes [8,8192,128] in fp32 from 0.74x torch to 0.97x, while
-# the same halving costs mean 0.13x on [64,512,512].
+# Tile area (TILE_N * TILE_K) a workgroup handles per iteration. argmax keeps an
+# int64 index live next to every value it compares, so it needs a smaller tile
+# than mean to stay within the register budget.
 _MEAN_TILE_BUDGET = 16384
 _ARGMAX_TILE_BUDGET = 8192
 
-# The sweep measured TILE_K up to 2048; do not extrapolate past it.
+# A wider TILE_K would leave the tile budget too little room on the reduction axis.
 _MAX_TILE_K = 2048
 
 # Elements per lane before another warp earns its keep.
@@ -78,12 +47,8 @@ def _num_cus():
 
 
 def reduction_heur_tile_k(args):
-    """Widen the contiguous read until the grid stops covering the CUs twice over.
-
-    grid_y is cdiv(K, TILE_K), so TILE_K trades blocks for coalescing. Start
-    narrow and double while there is still more than one wave of workgroups to
-    give up.
-    """
+    # grid_y is cdiv(K, TILE_K), so widening TILE_K trades workgroups for
+    # coalescing. Double while there is more than one wave left to give up.
     num_cus = _num_cus()
     upper_bound = min(args["K"], _MAX_TILE_K)
     tile_k = 1
@@ -97,12 +62,8 @@ def reduction_heur_tile_k(args):
 
 
 def _make_tile_n(tile_budget):
-    """Spend what is left of the tile budget on the reduction axis.
-
-    No floor beyond 1: rounding a short reduction axis up past N only buys a
-    tile whose extra lanes are all masked off.
-    """
-
+    # Spend what TILE_K leaves of the tile budget on the reduction axis. No floor
+    # beyond 1: rounding N up only buys lanes that are masked off anyway.
     def reduction_heur_tile_n(args):
         per_row = max(1, tile_budget // args["TILE_K"])
         return max(1, min(triton.next_power_of_2(args["N"]), per_row))
@@ -115,12 +76,8 @@ def reduction_heur_one_tile_per_cta(args):
 
 
 def reduction_heur_num_warps(args):
-    """One warp per _ELEMS_PER_LANE of tile.
-
-    Deliberately far below the 16 that `_amd`'s softmax rule returns for tiles
-    this size: these kernels are memory bound, and smaller workgroups let more
-    of them sit resident per CU.
-    """
+    # These kernels are memory bound, so smaller workgroups than the vendor
+    # reduction rule picks keep more of them resident per CU.
     tile_size = args["TILE_N"] * args["TILE_K"]
     return max(1, min(_MAX_NUM_WARPS, _prev_power_of_2(tile_size // _ELEMS_PER_LANE)))
 


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Performance Optimization

### Description

`mean_non_inner` and `argmax_non_inner` are the only two heuristics keys `_amd` never defines, so `configs_loader` falls back to the `_nvidia` table for them.
Neither fallback suits gfx1201: `mean_heur_tile_k` clamps `TILE_K` to `_MAX_TILE_N_PER_ROW // _MIN_TILE_N`, i.e. 64, whatever `K` is, so at `K=512` each workgroup reads 128 bytes out of every 1024-byte row; `argmax_heur_tile_k` opens with an `if M == 64 and K == 512` shape special case, and elsewhere both tables pick far more warps than this part wants.

This adds `_amd/rdna4/heuristics_config_utils.py` defining both keys for RDNA4.
Both drive the same kernel shape — grid `(M, cdiv(K, TILE_K))`, each workgroup looping over the reduction axis `N` in `TILE_N` steps:

- **`TILE_K`** — keep `_amd`'s search: double the contiguous run per workgroup while the grid still spans more than one wave of CUs (capped at 2048).
- **`TILE_N`** — spend what is left of a fixed tile budget on the reduction axis. The budget differs per key (16384 for mean, 8192 for argmax) because `tl.max` with `return_indices` keeps an int64 index live next to every value and runs out of registers on a tile mean is still comfortable with.
- **`num_warps`** — one warp per 2048 elements of tile, well below the 16 tha   `_amd`'s reduction rule returns for tiles this size. These kernels are memory  bound, so smaller workgroups let more of them stay resident per CU. This is  what most of the gain comes from on shapes outside the special case above.

Config only — no kernel or dispatch changes. `_amd/__init__.py:ARCH_MAP` already maps `gfx1200`/`gfx1201` to `rdna4`, and arch-level heuristics already take priority over the vendor and NVIDIA tables.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

Environment: AMD gfx1201 (Radeon AI PRO R9700, 32 CU), ROCm 7.2.3, torch
2.10.0, triton 3.6.0.

**Correctness** — `pytest tests/test_mean.py tests/test_argmax.py`: 195 passed.
`tests/test_backend_heuristics.py`, `test_amax.py`, `test_sum.py`,
`test_argmin.py`: 230 passed.

**Benchmark** — `benchmark/test_mean.py::test_mean` and `benchmark/test_argmax.py`, run 4 times per arm alternating between this branch and its parent commit (which reverts to the `_nvidia` fallback). Numbers below are median Gems kernel latency, this branch vs. the fallback; `>1` is faster. 
Run-to-run spread within one arm was 0.9% median / 3.6% max, and the two arms' ranges do not overlap on 27 of the 33 combinations.

Only shapes these two keys govern are listed — `mean_dim` switches to a vectorised kernel at `K >= 1024`, `argmax` never does. All 69 other shapes in the same benchmark are unchanged.

| op | shape (`dim=1`) | fp16 | bf16 | fp32 |
| --- | --- | --- | --- | --- |
| mean | (64, 512, 512) | 2.46x | 2.47x | 1.55x |
| mean | (64, 4096, 64) | 1.19x | 1.19x | 0.97x |
| mean | (64, 1, 64) | 1.14x | 1.13x | 1.12x |
| mean | (64, 16, 64) | 1.09x | 1.09x | 1.04x |
| mean | (64, 256, 64) | 1.01x | 1.01x | 1.01x |
| argmax | (64, 512, 512) | 2.13x | 2.17x | 1.38x |
| argmax | (64, 4096, 64) | 1.26x | 1.27x | 1.35x |
| argmax | (1024, 1024, 1024) | 1.01x | 1.04x | 1.15x |
| argmax | (64, 256, 64) | 1.02x | 1.02x | 1.07x |
| argmax | (64, 16, 64) | 1.01x | 1.01x | 0.99x |
| argmax | (64, 1, 64) | 0.99x | 1.00x | 1.00x |

On the headline shape `(64, 512, 512)`, mean goes from 0.46x to 1.12x of torch (0.379ms to 0.154ms) and argmax from 0.61x to 1.31x.

One reproducible regression: mean fp32 `(64, 4096, 64)` at 0.97x, which still runs at 1.40x torch — the cost of replacing per-shape special cases with one general rule. The same shape gains 1.19x in fp16 and bf16.
