### PR TITLE
Restore flagtree backend for metax CI

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -238,9 +238,7 @@ backends:
   metax-maca3810:
     python: "3.12"
     triton: triton==3.6.0+metax3.8.1.0
-    # FlagTree not usable on the CI node because it has requirements
-    # that cannot be met on the runner node.
-    # flagtree: flagtree==0.6.1a2+metax3.6
+    flagtree: flagtree==0.6.1+metax3.6
     env:
       MACA_PATH: /opt/maca
       PATH: /opt/maca/mxgpu_llvm/bin:/opt/maca/bin:${PATH}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The FlagTree package failed to run on Ubuntu 22.04. We had to mask it out early today to unblock MetaX test cases. After recompilation and hacking, we have made FlagTree to run on 22.04. This PR restores the backend configuration.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A