### PR TITLE
Match CI backend to runner node for metax and ascend

### DIFF
--- a/.github/backends.json
+++ b/.github/backends.json
@@ -49,8 +49,15 @@
     "enabled": true
   },
   {
+    "backend": "metax-maca3720",
+    "runner_label": "maca372",
+    "label": "vendor/MetaX",
+    "gpu_check": "tools/gpu_check_metax.sh",
+    "enabled": true
+  },
+  {
     "backend": "metax-maca3810",
-    "runner_label": "metax",
+    "runner_label": "maca381",
     "label": "vendor/MetaX",
     "gpu_check": "tools/gpu_check_metax.sh",
     "enabled": true

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -96,6 +96,26 @@ jobs:
               BACKEND="nvidia-cuda128"
               echo "COMPILER=triton" >> $GITHUB_ENV
               ;;
+            ascend)
+              VENDOR="ascend"
+              # The ascend runner pool contains nodes with two different CANN
+              # toolkits (8.5.x and 9.0.x). The job may land on either node, so
+              # detect the CANN version on the node and pick the matching
+              # backend: 8.5.x -> ascend-cann850, 9.0.x -> ascend-cann900
+              CANN_VERSION=$(ls -d /usr/local/Ascend/cann-* 2>/dev/null | sed 's|.*/cann-||' | sort -V | tail -1)
+              case "${CANN_VERSION}" in
+                8.5*)
+                  BACKEND="ascend-cann850"
+                  ;;
+                9.0*)
+                  BACKEND="ascend-cann900"
+                  ;;
+                *)
+                  echo "::error::Cannot detect CANN version on ascend runner (got '${CANN_VERSION}')" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
             cann850)
               VENDOR="ascend"
               BACKEND="ascend-cann850"
@@ -109,6 +129,30 @@ jobs:
               BACKEND="mthreads-musa520"
               ;;
             metax)
+              VENDOR="metax"
+              # The metax runner pool contains nodes with two different MACA
+              # drivers (3.7.x and 3.8.x). The job may land on either node, so
+              # detect the driver on the node and pick the matching backend:
+              #   3.7.x -> metax-maca3720, 3.8.x -> metax-maca3810
+              MACA_VERSION=$(mx-smi 2>/dev/null | awk -F': ' '/MACA Version/{split($2,a," "); print a[1]}')
+              case "${MACA_VERSION}" in
+                3.7.*)
+                  BACKEND="metax-maca3720"
+                  ;;
+                3.8.*)
+                  BACKEND="metax-maca3810"
+                  ;;
+                *)
+                  echo "::error::Cannot detect MACA version on metax runner (got '${MACA_VERSION}')" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+            maca372)
+              VENDOR="metax"
+              BACKEND="metax-maca3720"
+              ;;
+            maca381)
               VENDOR="metax"
               BACKEND="metax-maca3810"
               ;;

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -77,6 +77,26 @@ jobs:
               VENDOR="nvidia"
               BACKEND="nvidia-cuda133"
               ;;
+            ascend)
+              VENDOR="ascend"
+              # The ascend runner pool contains nodes with two different CANN
+              # toolkits (8.5.x and 9.0.x). The job may land on either node, so
+              # detect the CANN version on the node and pick the matching
+              # backend: 8.5.x -> ascend-cann850, 9.0.x -> ascend-cann900
+              CANN_VERSION=$(ls -d /usr/local/Ascend/cann-* 2>/dev/null | sed 's|.*/cann-||' | sort -V | tail -1)
+              case "${CANN_VERSION}" in
+                8.5*)
+                  BACKEND="ascend-cann850"
+                  ;;
+                9.0*)
+                  BACKEND="ascend-cann900"
+                  ;;
+                *)
+                  echo "::error::Cannot detect CANN version on ascend runner (got '${CANN_VERSION}')" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
             cann850)
               VENDOR="ascend"
               BACKEND="ascend-cann850"
@@ -86,6 +106,30 @@ jobs:
               BACKEND="ascend-cann900"
               ;;
             metax)
+              VENDOR="metax"
+              # The metax runner pool contains nodes with two different MACA
+              # drivers (3.7.x and 3.8.x). The job may land on either node, so
+              # detect the driver on the node and pick the matching backend:
+              #   3.7.x -> metax-maca3720, 3.8.x -> metax-maca3810
+              MACA_VERSION=$(mx-smi 2>/dev/null | awk -F': ' '/MACA Version/{split($2,a," "); print a[1]}')
+              case "${MACA_VERSION}" in
+                3.7.*)
+                  BACKEND="metax-maca3720"
+                  ;;
+                3.8.*)
+                  BACKEND="metax-maca3810"
+                  ;;
+                *)
+                  echo "::error::Cannot detect MACA version on metax runner (got '${MACA_VERSION}')" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+            maca372)
+              VENDOR="metax"
+              BACKEND="metax-maca3720"
+              ;;
+            maca381)
               VENDOR="metax"
               BACKEND="metax-maca3810"
               ;;


### PR DESCRIPTION
## Summary

Align on-demand and matrix CI jobs so each backend runs on a node whose driver/toolkit matches it. Both the metax and ascend runner pools contain nodes with two different driver generations, and jobs could previously land on the wrong node.

## Changes

### metax
- Split `backends.json` metax entry into `metax-maca3720` / `metax-maca3810` with precise runner labels `maca372` / `maca381` (shared `metax` label kept).
- `command.yaml` / `random-test.yaml`: on the shared `metax` label, detect the MACA driver version via `mx-smi` and pick the matching backend (3.7.x → maca3720, 3.8.x → maca3810); fail loudly if undetectable. Precise `maca372`/`maca381` labels map directly.

### ascend
- Add shared `ascend` label that detects the node's CANN toolkit version (`/usr/local/Ascend/cann-*`) and picks `ascend-cann850` (8.5.x) or `ascend-cann900` (9.0.x), mirroring the metax pattern — reviewers can now trigger on-demand tests with `/test | op:<op>:ascend` without knowing which label maps to which CANN version.
- Precise `cann850` / `cann9` labels kept for matrix backend-tests.

## Runner labels (synced on runners 2026-08-12)

| node | labels |
|---|---|
| metax123 (MACA 3.7) | `metax`, `maca372` |
| metax124 (MACA 3.8) | `metax`, `maca381` |
| hw25 (CANN 9.0.0) | `ascend`, `cann9` |
| hw26 (CANN 8.5.0) | `ascend`, `cann850` |

## Verification
- MACA detection validated on both metax nodes (123 → 3.7.1.5, 124 → 3.8.1.3).
- CANN detection validated on both ascend nodes (hw25 → 9.0.0, hw26 → 8.5.0).
- YAML/JSON validated locally; pre-commit hooks pass.

This PR was written in part with the assistance of generative AI.