### PR TITLE
fix: skip kernel launch for zero-element tensors in empty()

### DIFF
--- a/src/flag_gems/ops/empty.py
+++ b/src/flag_gems/ops/empty.py
@@ -87,6 +87,11 @@ def empty(
     if dtype.is_complex:
         return out
     N = volume(shape)
+    # Skip kernel launch for zero-element tensors to avoid invalid grid size on
+    # backends that validate coreDim > 0 (e.g., Ascend NPU). With N=0 the kernel's
+    # store is fully masked out anyway, so skipping is semantically identical.
+    if N == 0:
+        return out
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
     with torch_device_fn.device(device):
         empty_kernel[grid_fn](out, N, BLOCK_SIZE=1024)


### PR DESCRIPTION
## Description

This PR fixes issue #5298 by adding an early return when `N=0` in the `empty()` function to avoid launching kernels with invalid grid size (`coreDim=0`) on Ascend NPU.

## Problem

On Ascend NPU, calling `torch.empty(0)` or any zero-element tensor creation fails with:
```
RuntimeError: coreDim must not equal 0
```

The root cause is that when `N=0`, the grid function computes `triton.cdiv(0, 1024) = 0`, resulting in a kernel launch with grid size 0. While CUDA tolerates this silently, CANN strictly validates that `coreDim > 0`.

## Solution

Add an early return when `N == 0` before launching the kernel:
- Semantically correct: with N=0, the kernel's store operation is fully masked anyway
- Matches existing patterns in the codebase (e.g., `bincount.py`, `_upsample_nearest_exact1d.py`)
- Verified on Ascend 910B to fix previously failing test suites

## Changes

- Added zero-element check in `src/flag_gems/ops/empty.py`
- Added explanatory comment about the backend validation difference

Fixes #5298