### PR TITLE
[KernelGen][Nvidia] Remap native_dropout_backward to canonical wrapper

### DIFF
--- a/benchmark/test_dropout.py
+++ b/benchmark/test_dropout.py
@@ -38,13 +38,13 @@ def test_dropout():
     bench.run()
 
 
-@pytest.mark.dropout_backward
+@pytest.mark.native_dropout_backward
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
-def test_dropout_backward():
+def test_native_dropout_backward():
     bench = base.GenericBenchmark(
-        op_name="dropout_backward",
+        op_name="native_dropout_backward",
         input_fn=_dropout_backward_input_fn,
         torch_op=torch.ops.aten.native_dropout_backward,
         dtypes=consts.FLOAT_DTYPES,

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2767,7 +2767,7 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '1.0'
-  - id: dropout_backward
+  - id: native_dropout_backward
     description: The backward case of `dropout()`.
     for:
       - native_dropout_backward

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -702,7 +702,7 @@ _FULL_CONFIG = (
     ("native_batch_norm", batch_norm),
     ("native_batch_norm_backward", batch_norm_backward),
     ("native_dropout", dropout),
-    ("native_dropout_backward", dropout_backward),
+    ("native_dropout_backward", native_dropout_backward),
     ("native_group_norm", group_norm),
     ("native_group_norm_backward", group_norm_backward),
     ("native_layer_norm", native_layer_norm),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -486,6 +486,7 @@ from flag_gems.ops.nanmedian import (
 from flag_gems.ops.nansum import nansum, nansum_out
 from flag_gems.ops.narrow import narrow
 from flag_gems.ops.narrow_copy import narrow_copy
+from flag_gems.ops.native_dropout_backward import native_dropout_backward
 from flag_gems.ops.native_layer_norm import native_layer_norm
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.ne_ import ne_, ne_scalar_
@@ -1335,6 +1336,7 @@ __all__ = [
     "nansum_out",
     "narrow",
     "narrow_copy",
+    "native_dropout_backward",
     "native_layer_norm",
     "ne",
     "ne_scalar",

--- a/src/flag_gems/ops/native_dropout_backward.py
+++ b/src/flag_gems/ops/native_dropout_backward.py
@@ -1,0 +1,25 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from flag_gems.ops.dropout import dropout_backward
+
+logger = logging.getLogger(__name__)
+
+
+def native_dropout_backward(grad_output, mask, scale):
+    """Canonical adapter for aten::native_dropout_backward."""
+    logger.debug("GEMS NATIVE_DROPOUT_BACKWARD")
+    return dropout_backward(grad_output, mask, scale)

--- a/tests/test_dropout.py
+++ b/tests/test_dropout.py
@@ -82,14 +82,14 @@ def test_dropout(shape, p, dtype):
         ), f"num_equal: {num_equal}, exp_equal: {exp_equal}, num_total: {res_inp.numel()}"
 
 
-@pytest.mark.dropout_backward
+@pytest.mark.native_dropout_backward
 @pytest.mark.parametrize("shape", utils.SPECIAL_SHAPES)
 @pytest.mark.parametrize("p", [0.3] if cfg.QUICK_MODE else [0.3, 0.6, 0.9])
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
-def test_dropout_backward(shape, p, dtype):
+def test_native_dropout_backward(shape, p, dtype):
     if flag_gems.vendor_name == "kunlunxin":
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0)


### PR DESCRIPTION
## Summary

This PR remaps `native_dropout_backward` to use an independent canonical wrapper following the pattern established in PR #5180 (`native_layer_norm`).

Previously, `native_dropout_backward` was directly registered to the existing `dropout_backward` implementation. This PR creates a dedicated thin wrapper in `ops/native_dropout_backward.py` that forwards to `dropout_backward`, allowing the operator to be selected by its canonical ATen name while maintaining the same underlying implementation.

**Changes:**
- Created `ops/native_dropout_backward.py` with canonical wrapper
- Remapped registration in `__init__.py` from `dropout_backward` to `native_dropout_backward`
- Updated `operators.yaml` id from `dropout_backward` to `native_dropout_backward`
- Renamed test mark and function from `dropout_backward` to `native_dropout_backward`
- Renamed benchmark mark and function to match canonical name

**Operators registered in conf/operators.yaml (alphabetical order):**
- `native_dropout_backward` (line 2770)

## Testing

**Backend:** NVIDIA H20

**Test Coverage:**
- 45 precision tests across 15 shapes × 3 dtypes (float16, float32, bfloat16)
- All tests PASSED with correct gradient computation

**Precision test command:**
```bash
CUDA_VISIBLE_DEVICES=4 pytest -xvs tests/test_dropout.py::test_native_dropout_backward
```

**Results:** ✅ 45/45 passed

**CI Parity Tests:**
- ✅ Target nodeid GPU: 45/45 passed
- ✅ Full test file GPU: 90/90 passed (dropout + native_dropout_backward)
- ✅ Target nodeid CPU quick: 1/1 passed, 0 skip
- ✅ Full test file CPU quick: 2/2 passed, 0 failure

## Performance

**Platform:** NVIDIA H20-3e  
**Benchmark Command:**
```bash
CUDA_VISIBLE_DEVICES=4 pytest -xvs benchmark/test_dropout.py::test_native_dropout_backward
```

**Results:** All 36 workloads SUCCESS

| dtype | Speedup Range | Status |
|-------|---------------|--------|
| float16 | 0.481x - 1.085x | ✅ All SUCCESS |
| float32 | 0.651x - 1.080x | ✅ All SUCCESS |
| bfloat16 | 0.510x - 1.100x | ✅ All SUCCESS |

**Note:** `native_dropout_backward` is a memory-bound operation (simple element-wise multiply-by-scale on masked elements). Speedups below 1.0x for large tensors are expected due to memory bandwidth saturation on H20. Small tensors show speedups above 1.0x due to reduced kernel launch overhead.

## Multi-backend Testing

- ✅ **NVIDIA**: All tests passed (H20-3e)
- Other backends: Not tested in this PR (remap does not change computation logic)

## Files Changed

- `src/flag_gems/ops/native_dropout_backward.py` (new file)
- `src/flag_gems/ops/__init__.py` (import and export)
- `src/flag_gems/__init__.py` (registration remap)
- `conf/operators.yaml` (id update)
- `tests/test_dropout.py` (mark and function rename)
- `benchmark/test_dropout.py` (mark and function rename)

**Total:** 6 files changed, 34 insertions(+), 7 deletions(-)