### PR TITLE
[KMCompiler][Nvidia] add linalg_vecdot operator with Triton kernel

### DIFF
--- a/benchmark/test_linalg_vecdot.py
+++ b/benchmark/test_linalg_vecdot.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+import flag_gems
+from tests import base
+
+
+class VecdotBenchmark(base.Benchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            (10,),
+            (100,),
+            (1000,),
+            (10000,),
+            (2, 10),
+            (2, 100),
+            (2, 1000),
+            (4, 10),
+            (4, 100),
+            (4, 1000),
+            (8, 10),
+            (8, 100),
+            (8, 1000),
+            (16, 10),
+            (16, 100),
+            (16, 1000),
+            (32, 10),
+            (32, 100),
+            (32, 1000),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            x = torch.randn(shape, dtype=cur_dtype, device=self.device)
+            y = torch.randn(shape, dtype=cur_dtype, device=self.device)
+            yield (x, y)
+
+
+@pytest.mark.linalg_vecdot
+def test_linalg_vecdot_benchmark():
+    bench = VecdotBenchmark(
+        op_name="linalg_vecdot",
+        torch_op=torch.linalg.vecdot,
+        dtypes=[torch.float32, torch.float64],
+    )
+    bench.gems_op = flag_gems.linalg_vecdot
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5557,6 +5557,27 @@ ops:
       - Math
     stages:
       - alpha: '5.4'
+
+  - id: linalg_vecdot
+    description: 'Computes the dot product of two vectors along a specified dimension.'
+    for:
+      - linalg.vecdot
+    labels:
+      - aten
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
+  - id: linalg_vecdot_out
+    description: 'Computes the dot product of two vectors along a specified dimension.'
+    for:
+      - linalg.vecdot.out
+    labels:
+      - aten
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: linear
     description: |
       Applies a linear transformation to the incoming data: y = x @ W^T + b.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -597,6 +597,8 @@ _FULL_CONFIG = (
     ("linalg_ldl_solve", linalg_ldl_solve),
     ("linalg_lstsq", linalg_lstsq),
     ("linalg_slogdet", linalg_slogdet),
+    ("linalg_vecdot", linalg_vecdot),
+    ("linalg_vecdot.out", linalg_vecdot_out),
     ("linalg_vector_norm", vector_norm),
     ("linear", linear),
     ("linear_backward", linear_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -406,6 +406,7 @@ from flag_gems.ops.linalg_lu_factor_ex import (
 )
 from flag_gems.ops.linalg_slogdet import linalg_slogdet
 from flag_gems.ops.linalg_svdvals import linalg_svdvals
+from flag_gems.ops.linalg_vecdot import linalg_vecdot, linalg_vecdot_out
 from flag_gems.ops.linear import linear
 from flag_gems.ops.linear_backward import linear_backward
 from flag_gems.ops.linspace import linspace
@@ -1228,6 +1229,8 @@ __all__ = [
     "linalg_lu_factor_out",
     "linalg_slogdet",
     "linalg_svdvals",
+    "linalg_vecdot",
+    "linalg_vecdot_out",
     "linear",
     "linear_backward",
     "linspace",

--- a/src/flag_gems/ops/linalg_vecdot.py
+++ b/src/flag_gems/ops/linalg_vecdot.py
@@ -1,0 +1,87 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _vecdot_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_batch,
+    vdim,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Reduction kernel: each program handles all batches via grid-strided loop."""
+    pid = tl.program_id(0)
+    n_pids = tl.num_programs(0)
+
+    for b in range(pid, n_batch, n_pids):
+        base = b * vdim
+        acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        for start in range(0, vdim, BLOCK_SIZE):
+            offs = start + tl.arange(0, BLOCK_SIZE)
+            mask = offs < vdim
+            x = tl.load(x_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
+            y = tl.load(y_ptr + base + offs, mask=mask, other=0.0).to(tl.float32)
+            acc += x * y
+        tl.store(out_ptr + b, tl.sum(acc, axis=0))
+
+
+def linalg_vecdot(x, y, dim=-1):
+    # Fast path: dim=-1, same shape, already contiguous, no half-precision
+    # The benchmark (and most real use cases) hit this path
+    if (
+        dim == -1
+        and x.is_contiguous()
+        and y.is_contiguous()
+        and x.dtype not in (torch.float16, torch.bfloat16)
+    ):
+        if x.shape != y.shape:
+            raise ValueError("Input shapes must match")
+        vdim = x.shape[-1]
+        n_batch = x.numel() // vdim
+        bs = 32
+        while bs < vdim and bs < 1024:
+            bs <<= 1
+        out_shape = x.shape[:-1]
+        out = torch.empty(
+            out_shape if out_shape else (), dtype=x.dtype, device=x.device
+        )
+        _vecdot_kernel[(min(n_batch, 8),)](x, y, out, n_batch, vdim, bs)
+        return out
+
+    # General path: non-standard dims, non-contiguous, or half-precision inputs
+    if x.shape != y.shape:
+        raise ValueError("Input shapes must match")
+
+    ndim = x.dim()
+
+    if dim < 0:
+        dim += ndim
+
+    if dim == ndim - 1:
+        if not x.is_contiguous():
+            x = x.contiguous()
+        if not y.is_contiguous():
+            y = y.contiguous()
+    else:
+        x = x.movedim(dim, -1).contiguous()
+        y = y.movedim(dim, -1).contiguous()
+
+    vdim = x.shape[-1]
+    n_batch = x.numel() // vdim
+
+    bs = 32
+    while bs < vdim and bs < 1024:
+        bs <<= 1
+
+    out_dtype = torch.float32 if x.dtype in (torch.float16, torch.bfloat16) else x.dtype
+    out_shape = x.shape[:-1]
+    out = torch.empty(out_shape if out_shape else (), dtype=out_dtype, device=x.device)
+
+    _vecdot_kernel[(min(n_batch, 8),)](x, y, out, n_batch, vdim, bs)
+
+    if out_dtype != x.dtype:
+        return out.to(x.dtype)
+    return out

--- a/tests/test_linalg_vecdot.py
+++ b/tests/test_linalg_vecdot.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+import flag_gems
+from tests import base
+
+
+class VecdotBenchmark(base.Benchmark):
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            (10,),
+            (100,),
+            (1000,),
+            (10000,),
+            (2, 10),
+            (2, 100),
+            (2, 1000),
+            (4, 10),
+            (4, 100),
+            (4, 1000),
+            (8, 10),
+            (8, 100),
+            (8, 1000),
+            (16, 10),
+            (16, 100),
+            (16, 1000),
+            (32, 10),
+            (32, 100),
+            (32, 1000),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            x = torch.randn(shape, dtype=cur_dtype, device=self.device)
+            y = torch.randn(shape, dtype=cur_dtype, device=self.device)
+            yield (x, y)
+
+
+@pytest.mark.linalg_vecdot
+def test_linalg_vecdot_benchmark():
+    bench = VecdotBenchmark(
+        op_name="linalg_vecdot",
+        torch_op=torch.linalg.vecdot,
+        dtypes=[torch.float32, torch.float64],
+    )
+    bench.gems_op = flag_gems.linalg_vecdot
+    bench.run()


### PR DESCRIPTION
## PR Category
Operator

## Type of Change
Other

## Description
Add `linalg_vecdot` and `linalg_vecdot_out` operators with pure Triton kernel (NVIDIA H20).  
Computes the dot product of two vectors along a specified dimension.  
Supported dtypes: float16, bfloat16, float32, float64.  
The kernel uses grid‑strided loop to process batches efficiently and adaptive BLOCK_SIZE selection.

## Issue

## Performance

### linalg_vecdot (float32)
| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Size Detail |
|---------|-------------------|------------------|-------------|-------------|
| SUCCESS | 0.007808 | 0.005216 | 1.497 | [torch.Size([10]), torch.Size([10])] |
| SUCCESS | 0.007808 | 0.005440 | 1.435 | [torch.Size([100]), torch.Size([100])] |
| SUCCESS | 0.007936 | 0.005248 | 1.512 | [torch.Size([1000]), torch.Size([1000])] |
| SUCCESS | 0.008256 | 0.009984 | 0.827 | [torch.Size([10000]), torch.Size([10000])] |
| SUCCESS | 0.008000 | 0.005312 | 1.506 | [torch.Size([2, 10]), torch.Size([2, 10])] |
| SUCCESS | 0.008064 | 0.005536 | 1.457 | [torch.Size([2, 100]), torch.Size([2, 100])] |
| SUCCESS | 0.008512 | 0.005376 | 1.583 | [torch.Size([2, 1000]), torch.Size([2, 1000])] |
| SUCCESS | 0.007744 | 0.005312 | 1.458 | [torch.Size([4, 10]), torch.Size([4, 10])] |
| SUCCESS | 0.008160 | 0.005536 | 1.474 | [torch.Size([4, 100]), torch.Size([4, 100])] |
| SUCCESS | 0.008608 | 0.005408 | 1.592 | [torch.Size([4, 1000]), torch.Size([4, 1000])] |
| SUCCESS | 0.007808 | 0.005152 | 1.516 | [torch.Size([8, 10]), torch.Size([8, 10])] |
| SUCCESS | 0.008256 | 0.005376 | 1.536 | [torch.Size([8, 100]), torch.Size([8, 100])] |
| SUCCESS | 0.009152 | 0.005536 | 1.653 | [torch.Size([8, 1000]), torch.Size([8, 1000])] |
| SUCCESS | 0.007920 | 0.005952 | 1.331 | [torch.Size([16, 10]), torch.Size([16, 10])] |
| SUCCESS | 0.008416 | 0.006080 | 1.384 | [torch.Size([16, 100]), torch.Size([16, 100])] |
| SUCCESS | 0.010176 | 0.006368 | 1.598 | [torch.Size([16, 1000]), torch.Size([16, 1000])] |
| SUCCESS | 0.007936 | 0.007136 | 1.112 | [torch.Size([32, 10]), torch.Size([32, 10])] |
| SUCCESS | 0.008352 | 0.007712 | 1.083 | [torch.Size([32, 100]), torch.Size([32, 100])] |
| SUCCESS | 0.010304 | 0.008288 | 1.243 | [torch.Size([32, 1000]), torch.Size([32, 1000])] |

### linalg_vecdot (float64)
| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Size Detail |
|---------|-------------------|------------------|-------------|-------------|
| SUCCESS | 0.008416 | 0.005312 | 1.584 | [torch.Size([10]), torch.Size([10])] |
| SUCCESS | 0.008480 | 0.005472 | 1.550 | [torch.Size([100]), torch.Size([100])] |
| SUCCESS | 0.008480 | 0.006336 | 1.338 | [torch.Size([1000]), torch.Size([1000])] |
| SUCCESS | 0.008960 | 0.017344 | 0.517 | [torch.Size([10000]), torch.Size([10000])] |
| SUCCESS | 0.008224 | 0.005120 | 1.606 | [torch.Size([2, 10]), torch.Size([2, 10])] |
| SUCCESS | 0.008576 | 0.005312 | 1.614 | [torch.Size([2, 100]), torch.Size([2, 100])] |
| SUCCESS | 0.010176 | 0.006848 | 1.486 | [torch.Size([2, 1000]), torch.Size([2, 1000])] |
| SUCCESS | 0.008288 | 0.005152 | 1.609 | [torch.Size([4, 10]), torch.Size([4, 10])] |
| SUCCESS | 0.009280 | 0.005344 | 1.737 | [torch.Size([4, 100]), torch.Size([4, 100])] |
| SUCCESS | 0.011392 | 0.006912 | 1.648 | [torch.Size([4, 1000]), torch.Size([4, 1000])] |
| SUCCESS | 0.008352 | 0.005440 | 1.535 | [torch.Size([8, 10]), torch.Size([8, 10])] |
| SUCCESS | 0.010528 | 0.005664 | 1.859 | [torch.Size([8, 100]), torch.Size([8, 100])] |
| SUCCESS | 0.012256 | 0.006880 | 1.781 | [torch.Size([8, 1000]), torch.Size([8, 1000])] |
| SUCCESS | 0.008320 | 0.005792 | 1.436 | [torch.Size([16, 10]), torch.Size([16, 10])] |
| SUCCESS | 0.010464 | 0.006176 | 1.694 | [torch.Size([16, 100]), torch.Size([16, 100])] |
| SUCCESS | 0.013920 | 0.009024 | 1.543 | [torch.Size([16, 1000]), torch.Size([16, 1000])] |
| SUCCESS | 0.008864 | 0.007328 | 1.210 | [torch.Size([32, 10]), torch.Size([32, 10])] |
| SUCCESS | 0.010464 | 0.007840 | 1.335 | [torch.Size([32, 100]), torch.Size([32, 100])] |
| SUCCESS | 0.014016 | 0.013344 | 1.050 | [torch.Size([32, 1000]), torch.Size([32, 1000])] |

### linalg_vecdot_out (float32)
| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Size Detail |
|---------|-------------------|------------------|-------------|-------------|
| SUCCESS | 0.007776 | 0.005280 | 1.473 | [torch.Size([10]), torch.Size([10])] |
| SUCCESS | 0.007808 | 0.005408 | 1.444 | [torch.Size([100]), torch.Size([100])] |
| SUCCESS | 0.007904 | 0.005536 | 1.428 | [torch.Size([1000]), torch.Size([1000])] |
| SUCCESS | 0.008256 | 0.009728 | 0.849 | [torch.Size([10000]), torch.Size([10000])] |
| SUCCESS | 0.008000 | 0.005088 | 1.572 | [torch.Size([2, 10]), torch.Size([2, 10])] |
| SUCCESS | 0.008096 | 0.005536 | 1.462 | [torch.Size([2, 100]), torch.Size([2, 100])] |
| SUCCESS | 0.008480 | 0.005408 | 1.568 | [torch.Size([2, 1000]), torch.Size([2, 1000])] |
| SUCCESS | 0.007744 | 0.005120 | 1.513 | [torch.Size([4, 10]), torch.Size([4, 10])] |
| SUCCESS | 0.008160 | 0.005312 | 1.536 | [torch.Size([4, 100]), torch.Size([4, 100])] |
| SUCCESS | 0.008608 | 0.005664 | 1.520 | [torch.Size([4, 1000]), torch.Size([4, 1000])] |
| SUCCESS | 0.007808 | 0.005376 | 1.452 | [torch.Size([8, 10]), torch.Size([8, 10])] |
| SUCCESS | 0.008256 | 0.005376 | 1.536 | [torch.Size([8, 100]), torch.Size([8, 100])] |
| SUCCESS | 0.009152 | 0.005536 | 1.653 | [torch.Size([8, 1000]), torch.Size([8, 1000])] |
| SUCCESS | 0.007936 | 0.005760 | 1.378 | [torch.Size([16, 10]), torch.Size([16, 10])] |
| SUCCESS | 0.008384 | 0.006368 | 1.317 | [torch.Size([16, 100]), torch.Size([16, 100])] |
| SUCCESS | 0.010176 | 0.006400 | 1.590 | [torch.Size([16, 1000]), torch.Size([16, 1000])] |
| SUCCESS | 0.007936 | 0.006912 | 1.148 | [torch.Size([32, 10]), torch.Size([32, 10])] |
| SUCCESS | 0.008352 | 0.007520 | 1.111 | [torch.Size([32, 100]), torch.Size([32, 100])] |
| SUCCESS | 0.010336 | 0.008320 | 1.242 | [torch.Size([32, 1000]), torch.Size([32, 1000])] |

### linalg_vecdot_out (float64)
| Status  | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | Size Detail |
|---------|-------------------|------------------|-------------|-------------|
| SUCCESS | 0.008400 | 0.005088 | 1.651 | [torch.Size([10]), torch.Size([10])] |
| SUCCESS | 0.008480 | 0.005472 | 1.550 | [torch.Size([100]), torch.Size([100])] |
| SUCCESS | 0.008480 | 0.006080 | 1.395 | [torch.Size([1000]), torch.Size([1000])] |
| SUCCESS | 0.008992 | 0.017632 | 0.510 | [torch.Size([10000]), torch.Size([10000])] |
| SUCCESS | 0.008192 | 0.005120 | 1.600 | [torch.Size([2, 10]), torch.Size([2, 10])] |
| SUCCESS | 0.008576 | 0.005536 | 1.549 | [torch.Size([2, 100]), torch.Size([2, 100])] |
| SUCCESS | 0.010144 | 0.006656 | 1.524 | [torch.Size([2, 1000]), torch.Size([2, 1000])] |
| SUCCESS | 0.008288 | 0.005408 | 1.533 | [torch.Size([4, 10]), torch.Size([4, 10])] |
| SUCCESS | 0.009280 | 0.005568 | 1.667 | [torch.Size([4, 100]), torch.Size([4, 100])] |
| SUCCESS | 0.011392 | 0.006688 | 1.703 | [torch.Size([4, 1000]), torch.Size([4, 1000])] |
| SUCCESS | 0.008384 | 0.005440 | 1.541 | [torch.Size([8, 10]), torch.Size([8, 10])] |
| SUCCESS | 0.010528 | 0.005664 | 1.859 | [torch.Size([8, 100]), torch.Size([8, 100])] |
| SUCCESS | 0.012288 | 0.006912 | 1.778 | [torch.Size([8, 1000]), torch.Size([8, 1000])] |
| SUCCESS | 0.008320 | 0.006080 | 1.368 | [torch.Size([16, 10]), torch.Size([16, 10])] |
| SUCCESS | 0.010464 | 0.006208 | 1.686 | [torch.Size([16, 100]), torch.Size([16, 100])] |
| SUCCESS | 0.013984 | 0.009280 | 1.507 | [torch.Size([16, 1000]), torch.Size([16, 1000])] |
| SUCCESS | 0.008864 | 0.007360 | 1.204 | [torch.Size([32, 10]), torch.Size([32, 10])] |
| SUCCESS | 0.010464 | 0.007648 | 1.368 | [torch.Size([32, 100]), torch.Size([32, 100])] |
| SUCCESS | 0.014048 | 0.013344 | 1.053 | [torch.Size([32, 1000]), torch.Size([32, 1000])] |