### PR TITLE
Use space as parameter separator for command workflow

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -44,6 +44,7 @@ jobs:
           skip_reviews: "true"
           fork_review_bypass: "true"
           permissions: "write,admin"
+          param_separator: " "
 
       - id: parse-command
         if: ${{ steps.check.outputs.continue == 'true' }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The on-demand test command should be `/test | <op>:<backend>` while sometimes we simply forget to add the pipe symbol '`|`'. This PR tries to use space as the parameter separator for the `command` action.

Not sure if it works. A test is needed.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A