### PR TITLE
fix gelu accuracy failure on mthreads backends

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/gelu.py
@@ -40,10 +40,9 @@ def gelu_none(x):
 @pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
 @triton.jit
 def gelu_tanh(x):
+    x_fp32 = x.to(tl.float32)
     output = (
-        0.5
-        * x
-        * (1 + fast_tanh(x * 0.79788456 * (1 + 0.044715 * pow(x.to(tl.float32), 2))))
+        0.5 * x * (1 + fast_tanh(x_fp32 * 0.79788456 * (1 + 0.044715 * pow(x_fp32, 2))))
     )
     return output
 
@@ -68,8 +67,8 @@ def gelu_backward_none(x, dy):
 def gelu_backward_tanh(x, dy):
     x_fp32 = x.to(tl.float32)
     # 0.79788456 = math.sqrt(2 / math.pi)
-    tanh_out = fast_tanh(0.79788456 * x * (1 + 0.044715 * pow(x_fp32, 2)))
-    dydx = 0.5 * x * (
+    tanh_out = fast_tanh(0.79788456 * x_fp32 * (1 + 0.044715 * pow(x_fp32, 2)))
+    dydx = 0.5 * x_fp32 * (
         (1 - pow(tanh_out, 2)) * (0.79788456 + 0.1070322243 * pow(x_fp32, 2))
     ) + 0.5 * (1 + tanh_out)
     dx = dydx * dy


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fixed precision loss in the mthreads backend `gelu` operator when input dtype is `bfloat16`.

cause:
In `gelu_tanh` and `gelu_backward_tanh`, intermediate calculations were performed in `bfloat16` instead of `float32`, leading to accumulated precision errors:
- `gelu_tanh`: Only `pow(x.to(tl.float32), 2)` was upcasted; the outer `x * 0.79788456` multiplication remained in `bfloat16`
- `gelu_backward_tanh`: `x_fp32` was defined but `0.79788456 * x` and `0.5 * x` still used the original low-precision `x`

fix:
- `gelu_tanh`: Added `x_fp32 = x.to(tl.float32)` at the start and replaced all intermediate uses of `x` with `x_fp32`
- `gelu_backward_tanh`: Replace remaining `x` with `x_fp32` in `tanh_out` and `dydx` calculations


### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [√] Change is fully covered by a UT (existing test_gelu).

### Performance
<img width="847" height="224" alt="image" src="https://github.com/user-attachments/assets/a16af3f1-ea60-4a17-a442-ef000e550328" />

### Accuracy
<img width="845" height="727" alt="image" src="https://github.com/user-attachments/assets/b5c5fd82-729b-439c-bb86-c56517a41194" />