### PR TITLE
Fix /test command parsing for space-separated params

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -44,6 +44,7 @@ jobs:
           skip_reviews: "true"
           fork_review_bypass: "true"
           permissions: "write,admin"
+          param_separator: " "
 
       - id: parse-command
         if: ${{ steps.check.outputs.continue == 'true' }}

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -44,17 +44,18 @@ jobs:
           skip_reviews: "true"
           fork_review_bypass: "true"
           permissions: "write,admin"
-          param_separator: " "
 
       - id: parse-command
         if: ${{ steps.check.outputs.continue == 'true' }}
         env:
           PULL_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ steps.check.outputs.comment_body }}
         run: |
           # Parse command arguments
-          params=${{ steps.check.outputs.params }}
-          op=$(echo $params | cut -d ':' -f 1)
-          runner=$(echo $params | cut -d ':' -f 2)
+          # Comment format: "/test <op>:<runner>", e.g. "/test constant_pad_nd:mthreads"
+          params="${COMMENT_BODY#/test }"
+          op="${params%%:*}"
+          runner="${params##*:}"
           echo "OP_ID=${op}" >> $GITHUB_OUTPUT
           echo "RUNNER=${runner}" >> $GITHUB_OUTPUT
           echo "PR_NUMBER=${PULL_NUMBER}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes the `/test <op>:<runner>` on-demand test command, which broke after #5417 switched `param_separator` to a space.

## Root cause

Two stacked issues:

1. **`param_separator: " "` never reaches the action.** GitHub Actions trims leading/trailing whitespace from action input values, so `param_separator: " "` arrives as an empty string. `github/command` then splits the comment body into *characters*, drops the first one (`/`), and re-joins — emitting `test <op>:<runner>` as `params` instead of `<op>:<runner>` (see `🧮 detected parameters` in the failed run log).

2. **The parse step broke under `set -e`.** `params=${{ steps.check.outputs.params }}` is substituted unquoted into the `run` script, producing `params=test constant_pad_nd:mthreads`, where bash treats `constant_pad_nd:mthreads` as a command to execute → `command not found`, exit 127.

## Fix

- Drop the ineffective `param_separator` input.
- Parse the action's `comment_body` output (the raw comment) directly, passed via `env` to avoid unquoted `${{ }}` substitution in the `run` script.
- Use bash parameter expansion: strip the `/test ` prefix, split `<op>:<runner>` on `:`.

```bash
params="${COMMENT_BODY#/test }"
op="${params%%:*}"
runner="${params##*:}"
```

Verified by simulating the step: `/test constant_pad_nd:mthreads` → `OP_ID=constant_pad_nd`, `RUNNER=mthreads`.

Changes made with AI assistance.
