### PR TITLE
Fix argmax flattened reduction on Ascend (keepdim, block size)

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/argmax.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/argmax.py
@@ -112,13 +112,14 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
         M = inp.numel()
         if dtype is None:
             dtype = inp.dtype
-        block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
+        block_size = min(1024, triton.next_power_of_2(math.ceil(math.sqrt(M))))
         mid_size = triton.cdiv(M, block_size)
         block_mid = triton.next_power_of_2(mid_size)
 
         mid_value = torch.empty((mid_size,), dtype=dtype, device=inp.device)
         mid_index = torch.empty((mid_size,), dtype=torch.int64, device=inp.device)
-        out = torch.empty([], dtype=torch.int64, device=inp.device)
+        out_shape = [1] * inp.dim() if keepdim else []
+        out = torch.empty(out_shape, dtype=torch.int64, device=inp.device)
 
         with torch_device_fn.device(inp.device):
             argmax_kernel_1[(mid_size, 1, 1)](

--- a/tests/test_argmax.py
+++ b/tests/test_argmax.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 import flag_gems
+from flag_gems.runtime import torch_device_fn
 
 from . import accuracy_utils as utils
 from . import conftest as cfg
@@ -60,10 +61,32 @@ def test_argmax(shape, dim, keepdim, dtype):
     else:
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 
-    ref_inp = utils.to_reference(inp)
+    use_cpu_ref = flag_gems.vendor_name == "ascend" and dim is None and keepdim
+    ref_inp = inp.cpu() if use_cpu_ref else utils.to_reference(inp)
 
     ref_out = torch.argmax(ref_inp, dim=dim, keepdim=keepdim)
+    if use_cpu_ref and not cfg.TO_CPU:
+        ref_out = ref_out.to(inp.device)
     with flag_gems.use_gems():
         res_out = torch.argmax(inp, dim=dim, keepdim=keepdim)
 
     utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.argmax
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "ascend", reason="Ascend-specific regression test"
+)
+def test_argmax_large_flattened_block_size():
+    # block_size was derived from sqrt(numel) with no upper bound. For an input
+    # this large it went past what the device handles on the flattened path, and
+    # the returned index pointed at an element that was not the maximum.
+    for seed in (0, 2, 3, 9):
+        torch_device_fn.manual_seed_all(seed)
+        inp = torch.randn((200, 2560, 3), dtype=torch.bfloat16, device=flag_gems.device)
+        ref_out = torch.argmax(inp.cpu())
+
+        with flag_gems.use_gems():
+            res_out = torch.argmax(inp)
+
+        torch.testing.assert_close(res_out.cpu(), ref_out, atol=0, rtol=0)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

Two issues on the `dim=None` path of `argmax` on the Ascend backend.

1. keepdim. The output was allocated with `torch.empty([])` unconditionally, so
   `keepdim` was silently dropped. PyTorch returns shape `[1] * inp.dim()` in
   this case. The output shape is now chosen from `keepdim` before allocation.
   The kernel writes a single element either way, so no kernel change is needed.
2. Block size. `block_size` was derived only from `sqrt(numel)` with no upper
   bound. For a large input it went past what the device handles on this path,
   and the index that came back pointed at an element that was not the maximum.
   For a `(200, 2560, 3)` bfloat16 input the returned position held `4.5625`
   while the actual maximum was `4.8125`. It is now capped at 1024, the same
   bound `argmin` uses.

### Issue

None.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact from the keepdim change, which only affects the shape of
the output allocation. The block size cap keeps the reduction within a launch
configuration the device supports.

Verified on Ascend 910B. The block size regression test fails on every one of
three runs without the cap and passes on every run with it, and the full
`tests/test_argmax.py` suite passes three runs in a row.
