### PR TITLE
Fix mean_dim keepdim inverted when dim is None on Ascend

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/mean.py
@@ -94,7 +94,7 @@ def mean_dim(x, dim, keepdim=False, *, dtype=None):
         dtype = x.dtype
     if dim is None:
         out = mean(x, dtype=dtype)
-        if not keepdim:
+        if keepdim:
             out = out.reshape([1] * x.ndim)
         return out
 

--- a/tests/test_mean.py
+++ b/tests/test_mean.py
@@ -62,6 +62,22 @@ def test_mean_dim(shape, dim, keepdim, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.mean_dim
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "ascend", reason="Ascend-specific regression test"
+)
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_mean_dim_none(keepdim):
+    inp = torch.randn((2, 3, 4), dtype=torch.float32, device=flag_gems.device)
+    ref_inp = inp.cpu().to(torch.float64)
+
+    ref_out = torch.mean(ref_inp, dim=None, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.mean(inp, dim=None, keepdim=keepdim)
+
+    utils.gems_assert_close(res_out.cpu(), ref_out, torch.float32)
+
+
 # Shapes where K (product of dims after the reduction axis) exceeds the CUDA
 # grid-Y limit of 65535, which used to trigger "Triton Error [CUDA]: invalid
 # argument" before the mean_heur_tile_k grid-overflow fix.


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

On the Ascend backend, `mean(inp, dim=None, keepdim=...)` had the `keepdim` branch
inverted. With `keepdim=False` the result was reshaped to `[1] * x.ndim`, and with
`keepdim=True` the 0-d result was returned as is. Both are the opposite of PyTorch.

The condition is now `if keepdim`. A parametrized regression test covers both values.

### Issue

None.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact. One reshape on the full-reduction path.
