### PR TITLE
Fix index_select crash on 0-d index on Ascend

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/index_select.py
@@ -58,10 +58,9 @@ def index_select(inp, dim, index):
     logger.debug("GEMS_ASCEND INDEX_SELECT")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert index.ndim <= 1, "Index should have dimension 1 or 0"
-    assert ((i >= 0 and i < inp.size(dim)) for i in index), "Index out of range"
-
     if index.ndim == 0:
         index = index.unsqueeze(0)
+    assert ((i >= 0 and i < inp.size(dim)) for i in index), "Index out of range"
     dim = dim % inp.ndim
     inp_shape = list(inp.shape)
     index_len = index.numel()

--- a/tests/test_index_select.py
+++ b/tests/test_index_select.py
@@ -53,3 +53,18 @@ def test_index_select(shape, dim, dtype):
         res_out = torch.index_select(inp, dim, index)
 
     utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "ascend", reason="Ascend-specific regression test"
+)
+@pytest.mark.index_select
+def test_index_select_scalar_index():
+    inp = torch.arange(6, device=flag_gems.device).reshape(2, 3)
+    index = torch.tensor(1, dtype=torch.int64, device=flag_gems.device)
+
+    ref_out = torch.index_select(inp.cpu(), 1, index.cpu())
+    with flag_gems.use_gems():
+        res_out = torch.index_select(inp, 1, index)
+
+    utils.gems_assert_equal(res_out.cpu(), ref_out)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

On the Ascend backend, `index_select` with a 0-d index tensor raised
`TypeError: iteration over a 0-d tensor` before reaching the kernel. The range assertion
builds a generator over `index`, and it ran before the `unsqueeze(0)` that normalizes a
scalar index to length 1.

Moving the normalization above the assertion fixes it. Both the native CPU and the native
NPU implementations accept a 0-d index and return a result of length 1 along the selected
dimension.

The assertion itself is left as is. It wraps a generator expression, so it is always
truthy and never actually validates the range. Replacing it with a real check requires a
host side synchronization, which was already tried in #2447 and reverted the next day in
#2466. Fixing that belongs in a separate change with its own performance discussion.

The same ordering issue exists in a few other backends. This PR is limited to Ascend
because that is the hardware available for verification here.

### Issue

None.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact. The change only moves an existing normalization one line earlier.
