### PR TITLE
Try fix Iluvatar CI job

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -189,6 +189,7 @@ backends:
       COREX_ROOT: /usr/local/corex
       PATH: $COREX_ROOT/bin:$PATH
       LD_LIBRARY_PATH: $COREX_ROOT/lib:$LD_LIBRARY_PATH
+      CPATH: /usr/local/cuda-10.2/include
     deps:
       - torch==2.7.1+corex.4.4.0
       - torchaudio==2.7.1+corex.4.4.0


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The Triton compiler (maybe also including FlagTree) cannot find the 'cuda.h' header file when running CI jobs. This PR is an attempt to fix it.

Related error messages:

```
Running unit tests for tests/test_linalg_matrix_norm.py
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/tengqm/actions-runner/_work/FlagGems/FlagGems
configfile: pytest.ini
plugins: md-report-0.8.0
collected 1425 items

/tmp/tmphipe1j55/main.c:1:10: fatal error: 'cuda.h' file not found
    1 | #include "cuda.h"
      |          ^~~~~~~~
1 error generated.
tests/test_linalg_matrix_norm.py ssssssF

```