### PR TITLE
Bump flagtree version for NVIDIA

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -51,7 +51,7 @@ backends:
     python: "3.12"
     cmake_backend: CUDA
     triton: triton==3.6.0
-    flagtree: flagtree==0.6.0
+    flagtree: flagtree==0.6.1
     env:
       PATH: /usr/local/cuda/bin:$PATH
       LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
@@ -64,7 +64,7 @@ backends:
     python: "3.12"
     cmake_backend: CUDA
     triton: triton==3.6.0
-    flagtree: flagtree==0.6.0
+    flagtree: flagtree==0.6.1
     env:
       PATH: /usr/local/cuda/bin:$PATH
       LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

Some operators needs flagtree release 0.6.1 for better performance on NVIDIA. This PR bumps the flagtree version.