### PR TITLE
[Ascend] Fix input param of do_bench_npu

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -310,8 +310,9 @@ class Benchmark:
                 do_bench = triton.backends.ascend.testing.do_bench_npu
                 latency = do_bench(
                     fn,
-                    warmup=Config.warm_up,
-                    active=Config.repetition,
+                    # do_bench_npu requires iterations, rather than duration
+                    # warmup=Config.warm_up,
+                    # active=Config.repetition,
                 )
             else:
                 do_bench = triton.testing.do_bench


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
`do_bench_npu` requires the number of iterations as input, rather than a duration.
Use default value instead.

### Issue


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

