### PR TITLE
Fix environment variable setting for Enflame CI

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -136,6 +136,7 @@ backends:
       LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
       TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
       ENABLE_I64_CHECK: "0"
+      ENFLAME_PT_OP_DEBUG_CONFIG: "fallback_cpu=all_ops"
     deps:
       - pyefml==1.9.10
       - torch==2.10.0+cpu
@@ -158,6 +159,7 @@ backends:
       TORCH_GCU_ENABLE_INT64_AND_UINT64: "1"
       ENABLE_I64_CHECK: "0"
       TORCHGCU_INDUCTOR_ENABLE: "1"
+      ENFLAME_PT_OP_DEBUG_CONFIG: "fallback_cpu=all_ops"
     deps:
       - enflame-modelopt==3.6.20260615+torch.2.11.0
       - numpy==2.3.5


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The Enflame backend doesn't support int64 data type. The workaround is to export a special environment variable so that all non-supported ops will fall back to CPU.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A
