### PR TITLE
Gate CI jobs on CLA signature

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,82 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: cla-check
+
+on:
+  workflow_call:
+
+permissions:
+  statuses: read
+
+jobs:
+  check:
+    name: Check CLA status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the CLA has been signed
+        id: verify
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            // Only gate pull requests. Pushes to master and manual runs are trusted.
+            if (context.eventName !== 'pull_request') {
+              core.info('Not a pull request; skipping the CLA gate.');
+              return;
+            }
+
+            const sha = context.payload.pull_request && context.payload.pull_request.head.sha;
+            if (!sha) {
+              core.setFailed('Could not determine the pull request head commit.');
+              return;
+            }
+
+            // cla-assistant reports the signature state as a commit status named
+            // `license/cla` on the pull request head commit.
+            const CLA_STATUS_CONTEXT = 'license/cla';
+
+            // cla-assistant sets the status asynchronously after the PR is opened,
+            // so poll briefly to avoid a false "status not found" on the first run.
+            const deadline = Date.now() + 90_000;
+            let claStatus;
+            while (Date.now() < deadline) {
+              const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+              claStatus = statuses.find((s) => s.context === CLA_STATUS_CONTEXT);
+              if (claStatus) {
+                break;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 5_000));
+            }
+
+            if (!claStatus) {
+              core.setFailed(
+                `No '${CLA_STATUS_CONTEXT}' status found for ${sha}. ` +
+                  'Please sign the CLA so that cla-assistant can set the status.'
+              );
+              return;
+            }
+
+            if (claStatus.state !== 'success') {
+              core.setFailed(
+                `The CLA is not signed (status '${claStatus.state}'). ` +
+                  'Please sign the CLA to run CI.'
+              );
+              return;
+            }
+
+            core.info('The CLA has been signed.');

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,10 @@
 
 name: linter
 
+permissions:
+  contents: read
+  statuses: read
+
 on:
   push:
     branches:
@@ -28,7 +32,11 @@ on:
       - synchronize
 
 jobs:
+  cla:
+    uses: ./.github/workflows/cla-check.yaml
+
   code-style:
+    needs: cla
     permissions:
       contents: read
     concurrency:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -15,6 +15,7 @@
 name: unit-test
 permissions:
   contents: read
+  statuses: read
 
 on:
   workflow_dispatch:
@@ -28,7 +29,11 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
+  cla:
+    uses: ./.github/workflows/cla-check.yaml
+
   preprocess:
+    needs: cla
     runs-on: ubuntu-latest
     outputs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Block the linter and unit-test workflows until cla-assistant reports the `license/cla` status as success on the PR head commit. This avoids running (expensive) CI jobs for contributors who have not signed the CLA.

Closes #1505

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

- Resolves #1505

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
