### PR TITLE
Fix device mismatch in rmsnorm accuracy test

### DIFF
--- a/experimental_tests/unit/rmsnorm_test.py
+++ b/experimental_tests/unit/rmsnorm_test.py
@@ -78,6 +78,6 @@ def test_nmsnorm_accuracy(shape, dtype, eps):
     with flag_gems.use_gems():
         res_out = flag_gems.experimental_ops.rmsnorm(inp, weight=weight, eps=eps)
 
-    # Move result to CPU for comparison
-    res_out_cpu = res_out.cpu()
-    gems_assert_close(res_out_cpu, ref_out, dtype, equal_nan=True)
+    # Let gems_assert_close handle the device transfer so that res and ref
+    # always end up on the same device (avoids a CPU/device mismatch).
+    gems_assert_close(res_out, ref_out, dtype, equal_nan=True)


### PR DESCRIPTION
Closes #1777

## Problem
`test_nmsnorm_accuracy` manually moves the FlagGems output to CPU with `res_out.cpu()`, but the reference tensor `ref_out` stays on the AI device when `TO_CPU=false` (the GPU default). `gems_assert_close` then compares a CPU tensor against a device tensor and raises a device-mismatch error.

## Fix
Pass `res_out` directly to `gems_assert_close`, which already handles the device transfer via `to_cpu` based on `TO_CPU`. This keeps `res` and `ref` on the same device in both GPU and `--ref=cpu` modes.