### PR TITLE
[KMCompiler][Ascend] add operator linalg_lu_factor_ex for ascend backend.

### DIFF
--- a/benchmark/test_linalg_lu_factor_ex.py
+++ b/benchmark/test_linalg_lu_factor_ex.py
@@ -1,9 +1,12 @@
+from collections import namedtuple
+
 import pytest
 import torch
 
 import flag_gems
 
-from . import base
+from . import base, consts
+from .conftest import Config
 
 DEVICE = flag_gems.device
 VENDOR = flag_gems.vendor_name
@@ -21,6 +24,9 @@ else:
 
 _CHECK_ERRORS_VALUES = [False, True]
 
+if VENDOR == "ascend":
+    Config.mode = consts.BenchMode.OPERATOR
+
 # Use the same shapes as linalg_lu_factor for consistency
 LU_FACTOR_EX_SHAPES = [
     (16, 16),
@@ -36,8 +42,171 @@ LU_FACTOR_EX_SHAPES = [
     (4, 32, 32),
     (128, 16, 16),
     (1024, 512, 512),
-    (4096, 512, 512),
 ]
+
+LinalgLUFactorExResult = namedtuple("LinalgLUFactorExResult", ["LU", "pivots", "info"])
+
+
+# ---------------------------------------------------------------------------
+# Manual Python reference implementation for Ascend
+# (matches the pattern in benchmark/test_linalg_lu_factor.py)
+# ---------------------------------------------------------------------------
+
+
+def _swap_rows(lu, i, pivot_row):
+    # In-place gather/scatter swap: only (*batch_shape, n) temporaries instead
+    # of the full-matrix broadcast temporaries of the mask-based swap.  Keeping
+    # lu in place also means the pivot values recorded in pivot_vals keep
+    # pointing at the one live lu tensor instead of pinning a fresh 1GB copy
+    # per iteration (which OOMs the device for batched shapes like
+    # (1024, 512, 512)).  Note: torch.gather/scatter_ are used instead of
+    # advanced indexing (lu[..., pivot_row, :]) because torch_npu expands
+    # tensor indices against the batch dims, yielding (b, b, n) instead of
+    # (b, n).
+    batch_shape = lu.shape[:-2]
+    n = lu.shape[-1]
+    row_i = lu[..., i, :].clone()
+    idx = pivot_row.view(*batch_shape, 1, 1).expand(*batch_shape, 1, n)
+    row_p = lu.gather(dim=-2, index=idx).squeeze(-2)
+    lu[..., i, :] = row_p
+    lu.scatter_(dim=-2, index=idx, src=row_i.unsqueeze(-2))
+    return lu
+
+
+def _lu_factor_pivot_ex(lu, m, n, k):
+    """LU factorization with partial pivoting + info tracking."""
+    *batch_shape, _, _ = lu.shape
+    device = lu.device
+    pivots = torch.empty((*batch_shape, k), dtype=torch.int32, device=device)
+    # Collect pivots in a plain Python list (zero extra device ops per step)
+    # and compute info once after the loop with vector ops.
+    pivot_vals = []
+
+    for i in range(k):
+        col = lu[..., i:, i].abs()
+        pivot_rel = torch.argmax(col, dim=-1)
+        pivot_row = pivot_rel + i
+        pivots[..., i] = (pivot_row + 1).to(torch.int32)
+
+        lu = _swap_rows(lu, i, pivot_row)
+
+        # .clone() so the recorded value does not pin lu's storage (a plain
+        # view would keep the referenced lu storage alive; combined with a
+        # rebinding lu this OOMs the device for batched shapes).
+        pivot_val = lu[..., i, i].clone()
+        pivot_vals.append(pivot_val)
+
+        lu[..., i + 1 :, i] = lu[..., i + 1 :, i] / pivot_val.unsqueeze(-1)
+
+        if i + 1 < m and i + 1 < n:
+            l_col = lu[..., i + 1 :, i].unsqueeze(-1)
+            u_row = lu[..., i : i + 1, i + 1 :]
+            lu[..., i + 1 :, i + 1 :] = lu[..., i + 1 :, i + 1 :] - l_col @ u_row
+
+    # First zero/NaN pivot position (1-indexed), 0 if none.
+    diag = torch.stack(pivot_vals, dim=-1)  # (*batch_shape, k)
+    bad_mask = (diag == 0) | torch.isnan(diag)
+    has_bad = torch.any(bad_mask, dim=-1)
+    first_bad = torch.argmax(bad_mask.to(torch.int32), dim=-1)
+    info = torch.where(has_bad, first_bad + 1, 0).to(torch.int32)
+
+    return lu, pivots, info
+
+
+def _lu_factor_no_pivot_ex(lu, m, n, k):
+    """LU factorization without pivoting + info tracking."""
+    *batch_shape, _, _ = lu.shape
+    device = lu.device
+    pivots = torch.empty((*batch_shape, k), dtype=torch.int32, device=device)
+    pivot_vals = []
+
+    for i in range(k):
+        pivots[..., i] = i + 1
+        # .clone() so the recorded value does not pin lu's storage (a plain
+        # view would keep the referenced lu storage alive; combined with a
+        # rebinding lu this OOMs the device for batched shapes).
+        pivot_val = lu[..., i, i].clone()
+        pivot_vals.append(pivot_val)
+
+        lu[..., i + 1 :, i] = lu[..., i + 1 :, i] / pivot_val.unsqueeze(-1)
+
+        if i + 1 < m and i + 1 < n:
+            l_col = lu[..., i + 1 :, i].unsqueeze(-1)
+            u_row = lu[..., i : i + 1, i + 1 :]
+            lu[..., i + 1 :, i + 1 :] = lu[..., i + 1 :, i + 1 :] - l_col @ u_row
+
+    # First zero/NaN pivot position (1-indexed), 0 if none.
+    diag = torch.stack(pivot_vals, dim=-1)  # (*batch_shape, k)
+    bad_mask = (diag == 0) | torch.isnan(diag)
+    has_bad = torch.any(bad_mask, dim=-1)
+    first_bad = torch.argmax(bad_mask.to(torch.int32), dim=-1)
+    info = torch.where(has_bad, first_bad + 1, 0).to(torch.int32)
+
+    return lu, pivots, info
+
+
+def ops_lu_factor_ex(input, *, pivot=True):
+    """Manual Python reference for linalg_lu_factor_ex."""
+    if input.dim() < 2:
+        raise RuntimeError(
+            "torch.linalg.lu_factor_ex: Expected input to have at least 2 dimensions"
+        )
+    if input.dtype != torch.float32:
+        raise NotImplementedError("Only float32 is supported")
+    m, n = input.shape[-2], input.shape[-1]
+    if m == 0 or n == 0:
+        raise NotImplementedError("Empty matrices are not supported")
+    if pivot not in (True, False):
+        raise TypeError(f"pivot must be a bool, got {type(pivot)}")
+
+    input_contiguous = input.contiguous()
+    m, n = input_contiguous.shape[-2], input_contiguous.shape[-1]
+    k = min(m, n)
+    lu = input_contiguous.clone()
+
+    if pivot:
+        lu, pivots, info = _lu_factor_pivot_ex(lu, m, n, k)
+    else:
+        lu, pivots, info = _lu_factor_no_pivot_ex(lu, m, n, k)
+
+    return LinalgLUFactorExResult(lu, pivots, info)
+
+
+if VENDOR == "ascend":
+
+    def _torch_lu_factor_ex(inp, *, pivot=True, check_errors=False, out=None):
+        """Vendor-aware wrapper: uses manual ops on Ascend, native on other vendors.
+
+        Runs the Python reference directly on the NPU input, the same way the
+        linalg_lu_factor benchmark reference does.  With the optimized composite
+        (info computed once after the loop, no per-iteration extra ops) a full
+        [256, 256] call costs ~200ms on NPU.  Moving the input to CPU first is
+        much worse: on many-core hosts torch's intra-op thread pool makes each
+        tiny torch CPU op cost several ms (measured ~13ms per iteration with
+        192 threads), i.e. ~4-20s per call.
+        """
+        res = ops_lu_factor_ex(inp, pivot=pivot)
+        if check_errors:
+            info_val = res.info
+            failed = info_val != 0
+            if torch.any(failed).item():
+                info_cpu = info_val.detach().cpu().reshape(-1)
+                first_info = int(info_cpu[info_cpu != 0][0].item())
+                raise RuntimeError(
+                    "torch.linalg.lu_factor_ex: U[{},{}] is zero".format(
+                        first_info, first_info
+                    )
+                )
+        if out is not None:
+            lu_out, piv_out, info_out = out
+            lu_out.copy_(res.LU)
+            piv_out.copy_(res.pivots)
+            info_out.copy_(res.info)
+            return lu_out, piv_out, info_out
+        return res.LU, res.pivots, res.info
+
+else:
+    _torch_lu_factor_ex = torch.linalg.lu_factor_ex
 
 
 class LinalgLuFactorExBenchmark(base.Benchmark):
@@ -63,7 +232,7 @@ class LinalgLuFactorExBenchmark(base.Benchmark):
 def test_linalg_lu_factor_ex():
     bench = LinalgLuFactorExBenchmark(
         op_name="linalg_lu_factor_ex",
-        torch_op=torch.linalg.lu_factor_ex,
+        torch_op=_torch_lu_factor_ex,
         gems_op=flag_gems.linalg_lu_factor_ex,
         dtypes=_TEST_DTYPES,
     )
@@ -81,8 +250,9 @@ class LinalgLuFactorExOutBenchmark(base.Benchmark):
         for inp_shape in self.shapes:
             inp_shape = tuple(inp_shape)
             for pivot in _PIVOT_VALUES:
-                if pivot:
-                    continue  # out variant already covered by main benchmark
+                if pivot and VENDOR != "ascend":
+                    # out variant for pivot=True already covered by main benchmark
+                    continue
                 k = min(inp_shape[-2], inp_shape[-1])
                 batch_shape = inp_shape[:-2]
                 inp = torch.randn(inp_shape, dtype=dtype, device=self.device)
@@ -98,8 +268,9 @@ class LinalgLuFactorExOutBenchmark(base.Benchmark):
 def test_linalg_lu_factor_ex_out():
     bench = LinalgLuFactorExOutBenchmark(
         op_name="linalg_lu_factor_ex_out",
-        torch_op=torch.linalg.lu_factor_ex,
-        gems_op=flag_gems.linalg_lu_factor_ex_out,
+        torch_op=_torch_lu_factor_ex,
         dtypes=_TEST_DTYPES,
     )
+    if VENDOR == "ascend":
+        bench.gems_op = flag_gems.linalg_lu_factor_ex_out
     bench.run()

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -56,6 +56,7 @@ from .index_select import index_select
 from .isin import isin
 from .linalg_lstsq import linalg_lstsq
 from .linalg_lu_factor import linalg_lu_factor, linalg_lu_factor_out
+from .linalg_lu_factor_ex import linalg_lu_factor_ex, linalg_lu_factor_ex_out
 from .linspace import linspace
 from .log_softmax import log_softmax, log_softmax_backward, log_softmax_out
 from .masked_fill import masked_fill, masked_fill_
@@ -162,6 +163,8 @@ __all__ = [
     "linalg_lstsq",
     "linalg_lu_factor",
     "linalg_lu_factor_out",
+    "linalg_lu_factor_ex",
+    "linalg_lu_factor_ex_out",
     "linspace",
     "log_softmax",
     "log_softmax_backward",

--- a/src/flag_gems/runtime/backend/_ascend/ops/linalg_lu_factor_ex.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/linalg_lu_factor_ex.py
@@ -1,0 +1,386 @@
+import logging
+from collections import namedtuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+from .linalg_lu_factor import linalg_lu_factor, linalg_lu_factor_out
+
+logger = logging.getLogger(__name__)
+
+LinalgLUFactorExResult = namedtuple("LinalgLUFactorExResult", ["LU", "pivots", "info"])
+
+_LU_FACTOR_BLOCK_MAX = (
+    32  # simple fused kernel for m,n <= 32 (fast compile, tl.range loop)
+)
+
+
+# ---------------------------------------------------------------------------
+# Input validation — adapted from linalg_lu_factor.py (Ascend-specific)
+# ---------------------------------------------------------------------------
+
+
+def _linalg_lu_factor_check(input, pivot):
+    if input.dim() < 2:
+        raise RuntimeError(
+            "torch.linalg.lu_factor: Expected input to have at least 2 dimensions, "
+            f"got {input.dim()}"
+        )
+    if input.dtype != torch.float32:
+        raise NotImplementedError(
+            "FlagGems linalg_lu_factor_ex currently supports float32 only, "
+            f"got {input.dtype}"
+        )
+    m, n = input.shape[-2], input.shape[-1]
+    if m == 0 or n == 0:
+        raise NotImplementedError(
+            "FlagGems linalg_lu_factor_ex currently does not support empty matrices"
+        )
+    if pivot not in (True, False):
+        raise TypeError(f"pivot must be a bool, got {type(pivot)}")
+    if not pivot and input.device.type != "cuda":
+        raise NotImplementedError(
+            "FlagGems linalg_lu_factor_ex: pivot=False is only supported on CUDA devices, "
+            f"got device={input.device.type}"
+        )
+
+
+def _can_use_fast_triton(input):
+    """Check if the fused single-kernel Triton path can be used.
+
+    Requires 8 <= m,n <= _LU_FACTOR_BLOCK_MAX. Below 8, the Ascend
+    compiler fails with 'strides must not be zero' for tiny block sizes.
+    """
+    m, n = input.shape[-2], input.shape[-1]
+    return 8 <= m <= _LU_FACTOR_BLOCK_MAX and 8 <= n <= _LU_FACTOR_BLOCK_MAX
+
+
+# ---------------------------------------------------------------------------
+# Fused kernel: LU factorization + info in a single launch.
+#
+# Based on _linalg_lu_factor_kernel (already proven on Ascend), extended with
+# a post-loop diagonal scan that computes the LAPACK-style info tensor.
+#
+# All conditionals on dynamic Triton tensors use tl.where / tl.min rather
+# than Python "if", and all logical-OR uses Triton's | rather than Python
+# "or", both of which are required for correct compilation on Ascend NPU.
+# ---------------------------------------------------------------------------
+
+
+@libentry()
+@triton.jit
+def _linalg_lu_factor_ex_kernel(
+    A,
+    LU,
+    PIVOTS,
+    INFO,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    PIVOT: tl.constexpr,
+):
+    """LU factorization + info tracking in one kernel launch.
+
+    Performs the same factorization as _linalg_lu_factor_kernel, then
+    extracts the diagonal of the LU matrix and scans for the first zero
+    or NaN pivot using Triton-safe tl.where / tl.min patterns.
+    """
+    pid = tl.program_id(0)
+    rows = tl.arange(0, BLOCK_M)
+    cols = tl.arange(0, BLOCK_N)
+
+    offsets = pid * M * N + rows[:, None] * N + cols[None, :]
+    mask = (rows[:, None] < M) & (cols[None, :] < N)
+    work = tl.load(A + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    # ---- LU factorization loop (identical to _linalg_lu_factor_kernel) ----
+    for j_ind in tl.range(0, K):
+        if PIVOT:
+            col_mask_j = (cols[None, :] == j_ind).to(tl.float32)
+            col_j = tl.sum(work * col_mask_j, axis=1)
+            abs_col = tl.abs(col_j)
+            abs_col = tl.where(rows < j_ind, -1.0, abs_col)
+            abs_col = tl.where(rows < M, abs_col, -1.0)
+            pivot_val = tl.max(abs_col, axis=0)
+            pivot_row = tl.min(tl.where(abs_col == pivot_val, rows, BLOCK_M), axis=0)
+
+            row_mask_j = (rows[:, None] == j_ind).to(tl.float32)
+            row_mask_p = (rows[:, None] == pivot_row).to(tl.float32)
+            row_j = tl.sum(work * row_mask_j, axis=0)
+            row_p = tl.sum(work * row_mask_p, axis=0)
+            col_mask = cols[None, :] < N
+            work = tl.where((rows[:, None] == j_ind) & col_mask, row_p, work)
+            work = tl.where((rows[:, None] == pivot_row) & col_mask, row_j, work)
+            tl.store(PIVOTS + pid * K + j_ind, pivot_row + 1)
+        else:
+            tl.store(PIVOTS + pid * K + j_ind, j_ind + 1)
+
+        pivot_row_mask = (rows[:, None] == j_ind).to(tl.float32)
+        pivot_col_mask = (cols[None, :] == j_ind).to(tl.float32)
+        pivot_mask = pivot_row_mask * pivot_col_mask
+        pivot = tl.sum(work * pivot_mask)
+
+        pivot_row_vals = tl.sum(work * pivot_row_mask, axis=0)
+        active_cols = cols > j_ind
+        work = tl.where(
+            (rows[:, None] == j_ind) & active_cols[None, :], pivot_row_vals, work
+        )
+
+        col_vals = tl.sum(work * pivot_col_mask, axis=1)
+        multipliers = tl.where(rows > j_ind, col_vals / pivot, col_vals)
+        work = tl.where(
+            (rows[:, None] > j_ind) & (cols[None, :] == j_ind),
+            multipliers[:, None],
+            work,
+        )
+
+        l_col = tl.sum(work * pivot_col_mask, axis=1)
+        u_row = tl.sum(work * pivot_row_mask, axis=0)
+        update_mask = (rows[:, None] > j_ind) & (cols[None, :] > j_ind)
+        work = tl.where(update_mask, work - l_col[:, None] * u_row[None, :], work)
+
+    tl.store(LU + offsets, work, mask=mask)
+
+    # ---- Post-loop: scan diagonal for first zero/NaN pivot (info tensor) ----
+    # Build a 1-D vector of diagonal values work[i,i] for 0 <= i < K by
+    # constructing a 2-D diagonal mask and reducing along axis=1.  This
+    # matches the pivot-extraction pattern already proven in
+    # _linalg_lu_factor_kernel (rows[:, None] == scalar / cols[None, :] ==
+    # scalar → mask → tl.sum).  The 1-D vector is then processed with the
+    # same tl.where / tl.min / sentinel pattern used in the verified
+    # _lu_factor_info_kernel.  The entire scan is a constant number of
+    # Triton ops — NO tl.range loop, NO conditional SSA assignment — so
+    # Ascend's compiler sees purely static control flow.
+    sentinel = K + 1
+
+    # 1. Diagonal mask: (BLOCK_M, BLOCK_N) with 1.0 on the diagonal, 0 elsewhere.
+    diag_full_mask = (rows[:, None] == cols[None, :]).to(tl.float32)
+    # Restrict to rows within the K x K leading submatrix (in-kernel, K <=
+    # BLOCK_M and K <= BLOCK_N because BLOCK_M/N are next_power_of_2).
+    row_valid = (rows[:, None] < K).to(tl.float32)  # (BLOCK_M, 1)
+    diag_full_mask = diag_full_mask * row_valid  # broadcast along cols
+
+    # 2. Extract diagonal into a 1-D vector (BLOCK_M,).
+    diag_vals = tl.sum(work * diag_full_mask, axis=1)
+
+    # 3. Apply the same sentinel + tl.where + tl.min pattern as
+    #    _lu_factor_info_kernel (proven to compile on Ascend).
+    is_bad = (diag_vals == 0.0) | (diag_vals != diag_vals)  # (BLOCK_M,)
+    candidates = tl.where(is_bad & (rows < K), rows + 1, sentinel)  # (BLOCK_M,)
+    first_bad = tl.min(candidates, axis=0)  # scalar
+    info_val = tl.where(first_bad == sentinel, 0, first_bad).to(tl.int32)
+    tl.store(INFO + pid, info_val)
+
+
+# ---------------------------------------------------------------------------
+# Diagonal scan kernel — used by the blocked-path fallback.
+# Scans the diagonal of the already-computed LU factors.
+# ---------------------------------------------------------------------------
+
+
+@libentry()
+@triton.jit
+def _lu_factor_info_kernel(
+    LU,
+    INFO,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Scan the diagonal of LU to find the first zero or NaN pivot position.
+
+    Returns 0 if all diagonal elements are non-zero and finite, otherwise
+    returns the 1-indexed position of the first zero/NaN pivot.
+    """
+    pid = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < K
+    diag = tl.load(LU + pid * M * N + offsets * (N + 1), mask=mask, other=1.0)
+
+    sentinel = K + 1
+    # NOTE: use | (Triton element-wise OR), NOT Python "or" — Ascend compiler
+    # rejects Python "or" on Triton tensors.
+    is_zero = (diag == 0) | (diag != diag)
+    candidates = tl.where(is_zero & mask, offsets + 1, sentinel)
+    first_zero = tl.min(candidates, axis=0)
+    info = tl.where(first_zero == sentinel, 0, first_zero).to(tl.int32)
+    tl.store(INFO + pid, info)
+
+
+def _lu_factor_info(lu, out=None):
+    """Compute the LAPACK-style info tensor by scanning the LU diagonal."""
+    k = min(lu.shape[-2], lu.shape[-1])
+    batch_shape = lu.shape[:-2]
+    batch = lu.numel() // (lu.shape[-2] * lu.shape[-1])
+    if out is None:
+        info = torch.empty(batch_shape, device=lu.device, dtype=torch.int32)
+    else:
+        out.resize_(batch_shape)
+        info = out
+
+    with torch_device_fn.device(lu.device):
+        _lu_factor_info_kernel[(batch,)](
+            lu,
+            info,
+            lu.shape[-2],
+            lu.shape[-1],
+            k,
+            triton.next_power_of_2(k),
+            num_warps=4,
+        )
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Internal implementation
+#
+# Two paths:
+# 1) Fast path (m,n <= 32): single fused kernel _linalg_lu_factor_ex_kernel
+#    does LU factorization + info in one launch — no second kernel overhead.
+# 2) Blocked path: delegates to ascend-optimized linalg_lu_factor, then
+#    scans the diagonal with _lu_factor_info_kernel.
+# ---------------------------------------------------------------------------
+
+
+def _linalg_lu_factor_ex_impl(input, *, pivot=True, LU=None, pivots=None, info=None):
+    _linalg_lu_factor_check(input, pivot)
+    input_contiguous = input.contiguous()
+
+    if _can_use_fast_triton(input_contiguous):
+        # Fast path: single fused kernel.
+        batch_shape = input_contiguous.shape[:-2]
+        m, n = input_contiguous.shape[-2], input_contiguous.shape[-1]
+        k = min(m, n)
+        batch = input_contiguous.numel() // (m * n)
+
+        if LU is None:
+            lu = torch.empty_like(input_contiguous)
+        else:
+            LU.resize_(input_contiguous.shape)
+            lu = LU
+        if pivots is None:
+            pivots = torch.empty(
+                (*batch_shape, k), device=input.device, dtype=torch.int32
+            )
+        else:
+            pivots.resize_((*batch_shape, k))
+        if info is None:
+            _info = torch.empty(batch_shape, device=input.device, dtype=torch.int32)
+        else:
+            info.resize_(batch_shape)
+            _info = info
+
+        with torch_device_fn.device(input.device):
+            _linalg_lu_factor_ex_kernel[(batch,)](
+                input_contiguous,
+                lu,
+                pivots,
+                _info,
+                m,
+                n,
+                k,
+                triton.next_power_of_2(m),
+                triton.next_power_of_2(n),
+                pivot,
+            )
+        return LinalgLUFactorExResult(lu, pivots, _info)
+    else:
+        # Blocked path: factorization + separate info scan.
+        if LU is not None and pivots is not None:
+            lu, pivots = linalg_lu_factor_out(input, pivot=pivot, LU=LU, pivots=pivots)
+        else:
+            lu, pivots = linalg_lu_factor(input, pivot=pivot)
+        _info = _lu_factor_info(lu, out=info)
+        return LinalgLUFactorExResult(lu, pivots, _info)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def _check_lu_factor_errors(info):
+    """Raise RuntimeError if any batch element has a zero/NaN pivot."""
+    failed = info != 0
+    if not torch.any(failed).item():
+        return
+
+    info_cpu = info.detach().cpu().reshape(-1)
+    first_info = int(info_cpu[info_cpu != 0][0].item())
+    raise RuntimeError(
+        "torch.linalg.lu_factor_ex: U[{},{}] is zero and using it on lu_solve "
+        "would result in a division by zero. If you still want to perform the "
+        "factorization, pass check_errors=False.".format(first_info, first_info)
+    )
+
+
+def _check_linalg_lu_factor_ex_args(pivot, check_errors):
+    if pivot not in (True, False):
+        raise TypeError(f"pivot must be a bool, got {type(pivot)}")
+    if check_errors not in (True, False):
+        raise TypeError(f"check_errors must be a bool, got {type(check_errors)}")
+
+
+def linalg_lu_factor_ex(input, *, pivot=True, check_errors=False):
+    logger.debug("GEMS_ASCEND LINALG_LU_FACTOR_EX")
+    _check_linalg_lu_factor_ex_args(pivot, check_errors)
+
+    res = _linalg_lu_factor_ex_impl(input, pivot=pivot)
+
+    if check_errors:
+        _check_lu_factor_errors(res.info)
+
+    return res
+
+
+def _resolve_linalg_lu_factor_ex_out_args(LU, pivots, info, out):
+    if out is not None:
+        if LU is not None or pivots is not None or info is not None:
+            raise TypeError(
+                "linalg_lu_factor_ex(): out and LU/pivots/info cannot both be set"
+            )
+        if len(out) != 3:
+            raise TypeError(
+                "linalg_lu_factor_ex(): out must be a tuple of 3 tensors, "
+                f"got {len(out)}"
+            )
+        return out
+    if LU is None or pivots is None or info is None:
+        raise TypeError(
+            "linalg_lu_factor_ex(): LU, pivots and info must all be provided "
+            "for out variant"
+        )
+    return LU, pivots, info
+
+
+def linalg_lu_factor_ex_out(
+    input,
+    *,
+    pivot=True,
+    check_errors=False,
+    LU=None,
+    pivots=None,
+    info=None,
+    out=None,
+):
+    logger.debug("GEMS_ASCEND LINALG_LU_FACTOR_EX.OUT")
+    _check_linalg_lu_factor_ex_args(pivot, check_errors)
+    lu_out, pivots_out, info_out = _resolve_linalg_lu_factor_ex_out_args(
+        LU, pivots, info, out
+    )
+
+    res = _linalg_lu_factor_ex_impl(
+        input, pivot=pivot, LU=lu_out, pivots=pivots_out, info=info_out
+    )
+
+    if check_errors:
+        _check_lu_factor_errors(res.info)
+
+    return res

--- a/src/flag_gems/runtime/backend/_ascend/ops/linalg_lu_factor_ex.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/linalg_lu_factor_ex.py
@@ -370,7 +370,7 @@ def linalg_lu_factor_ex_out(
     info=None,
     out=None,
 ):
-    logger.debug("GEMS_ASCEND LINALG_LU_FACTOR_EX.OUT")
+    logger.debug("GEMS_ASCEND LINALG_LU_FACTOR_EX_OUT")
     _check_linalg_lu_factor_ex_args(pivot, check_errors)
     lu_out, pivots_out, info_out = _resolve_linalg_lu_factor_ex_out_args(
         LU, pivots, info, out

--- a/tests/test_linalg_lu_factor_ex.py
+++ b/tests/test_linalg_lu_factor_ex.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import pytest
 import torch
 
@@ -22,6 +24,8 @@ else:
     _PIVOT_VALUES = [True]
 
 _CHECK_ERRORS_VALUES = [False, True]
+
+LinalgLUFactorExResult = namedtuple("LinalgLUFactorExResult", ["LU", "pivots", "info"])
 
 # Core shapes: square, rectangular (m>n, m<n), batched, edge cases
 _LU_FACTOR_EX_SHAPES = [
@@ -85,6 +89,137 @@ def _make_singular_input(shape, device, dtype):
     return A
 
 
+# ---------------------------------------------------------------------------
+# Manual Python reference implementation for Ascend
+# (matches the pattern in test_linalg_lu_factor.py)
+# ---------------------------------------------------------------------------
+
+
+def _swap_rows(lu, i, pivot_row):
+    # In-place gather/scatter swap: only (*batch_shape, n) temporaries instead
+    # of the full-matrix broadcast temporaries of the mask-based swap.  Keeping
+    # lu in place also means the pivot values recorded in pivot_vals keep
+    # pointing at the one live lu tensor instead of pinning a fresh 1GB copy
+    # per iteration (which OOMs the device for batched shapes like
+    # (1024, 512, 512)).  Note: torch.gather/scatter_ are used instead of
+    # advanced indexing (lu[..., pivot_row, :]) because torch_npu expands
+    # tensor indices against the batch dims, yielding (b, b, n) instead of
+    # (b, n).
+    batch_shape = lu.shape[:-2]
+    n = lu.shape[-1]
+    row_i = lu[..., i, :].clone()
+    idx = pivot_row.view(*batch_shape, 1, 1).expand(*batch_shape, 1, n)
+    row_p = lu.gather(dim=-2, index=idx).squeeze(-2)
+    lu[..., i, :] = row_p
+    lu.scatter_(dim=-2, index=idx, src=row_i.unsqueeze(-2))
+    return lu
+
+
+def _lu_factor_pivot_ex(lu, m, n, k):
+    """LU factorization with partial pivoting + info tracking."""
+    *batch_shape, _, _ = lu.shape
+    device = lu.device
+    pivots = torch.empty((*batch_shape, k), dtype=torch.int32, device=device)
+    # Collect pivots in a plain Python list (zero extra device ops per step)
+    # and compute info once after the loop with vector ops.
+    pivot_vals = []
+
+    for i in range(k):
+        col = lu[..., i:, i].abs()
+        pivot_rel = torch.argmax(col, dim=-1)
+        pivot_row = pivot_rel + i
+        pivots[..., i] = (pivot_row + 1).to(torch.int32)
+
+        lu = _swap_rows(lu, i, pivot_row)
+
+        # .clone() so the recorded value does not pin lu's storage (a plain
+        # view would keep the referenced lu storage alive; combined with a
+        # rebinding lu this OOMs the device for batched shapes).
+        pivot_val = lu[..., i, i].clone()
+        pivot_vals.append(pivot_val)
+
+        lu[..., i + 1 :, i] = lu[..., i + 1 :, i] / pivot_val.unsqueeze(-1)
+
+        if i + 1 < m and i + 1 < n:
+            l_col = lu[..., i + 1 :, i].unsqueeze(-1)
+            u_row = lu[..., i : i + 1, i + 1 :]
+            lu[..., i + 1 :, i + 1 :] = lu[..., i + 1 :, i + 1 :] - l_col @ u_row
+
+    # First zero/NaN pivot position (1-indexed), 0 if none.
+    diag = torch.stack(pivot_vals, dim=-1)  # (*batch_shape, k)
+    bad_mask = (diag == 0) | torch.isnan(diag)
+    has_bad = torch.any(bad_mask, dim=-1)
+    first_bad = torch.argmax(bad_mask.to(torch.int32), dim=-1)
+    info = torch.where(has_bad, first_bad + 1, 0).to(torch.int32)
+
+    return lu, pivots, info
+
+
+def _lu_factor_no_pivot_ex(lu, m, n, k):
+    """LU factorization without pivoting + info tracking."""
+    *batch_shape, _, _ = lu.shape
+    device = lu.device
+    pivots = torch.empty((*batch_shape, k), dtype=torch.int32, device=device)
+    pivot_vals = []
+
+    for i in range(k):
+        pivots[..., i] = i + 1
+        # .clone() so the recorded value does not pin lu's storage (a plain
+        # view would keep the referenced lu storage alive; combined with a
+        # rebinding lu this OOMs the device for batched shapes).
+        pivot_val = lu[..., i, i].clone()
+        pivot_vals.append(pivot_val)
+
+        lu[..., i + 1 :, i] = lu[..., i + 1 :, i] / pivot_val.unsqueeze(-1)
+
+        if i + 1 < m and i + 1 < n:
+            l_col = lu[..., i + 1 :, i].unsqueeze(-1)
+            u_row = lu[..., i : i + 1, i + 1 :]
+            lu[..., i + 1 :, i + 1 :] = lu[..., i + 1 :, i + 1 :] - l_col @ u_row
+
+    # First zero/NaN pivot position (1-indexed), 0 if none.
+    diag = torch.stack(pivot_vals, dim=-1)  # (*batch_shape, k)
+    bad_mask = (diag == 0) | torch.isnan(diag)
+    has_bad = torch.any(bad_mask, dim=-1)
+    first_bad = torch.argmax(bad_mask.to(torch.int32), dim=-1)
+    info = torch.where(has_bad, first_bad + 1, 0).to(torch.int32)
+
+    return lu, pivots, info
+
+
+def ops_lu_factor_ex(input, *, pivot=True, check_errors=False):
+    """Manual Python reference for linalg_lu_factor_ex."""
+    if input.dim() < 2:
+        raise RuntimeError(
+            "torch.linalg.lu_factor_ex: Expected input to have at least 2 dimensions"
+        )
+    if input.dtype not in (torch.float32, torch.float64):
+        raise NotImplementedError("Only float32 and float64 are supported")
+    m, n = input.shape[-2], input.shape[-1]
+    if m == 0 or n == 0:
+        raise NotImplementedError("Empty matrices are not supported")
+    if pivot not in (True, False):
+        raise TypeError(f"pivot must be a bool, got {type(pivot)}")
+
+    input_contiguous = input.contiguous()
+    m, n = input_contiguous.shape[-2], input_contiguous.shape[-1]
+    k = min(m, n)
+    lu = input_contiguous.clone()
+
+    if pivot:
+        lu, pivots, info = _lu_factor_pivot_ex(lu, m, n, k)
+    else:
+        lu, pivots, info = _lu_factor_no_pivot_ex(lu, m, n, k)
+
+    return LinalgLUFactorExResult(lu, pivots, info)
+
+
+def _run_torch_ops_path_ex(inp, pivot):
+    """Vendor-aware wrapper: uses manual ops on Ascend, native on other vendors."""
+    res = ops_lu_factor_ex(inp, pivot=pivot)
+    return res.LU, res.pivots, res.info
+
+
 @pytest.mark.linalg_lu_factor_ex
 @pytest.mark.parametrize("shape", _LU_FACTOR_EX_SHAPES)
 @pytest.mark.parametrize("dtype", _TEST_DTYPES)
@@ -93,7 +228,13 @@ def test_linalg_lu_factor_ex(shape, dtype, pivot):
     inp = _make_input(shape, pivot, flag_gems.device, dtype)
     ref_inp = utils.to_reference(inp)
 
-    ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=pivot)
+    if flag_gems.vendor_name != "ascend":
+        ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=pivot)
+    else:
+        ref_lu, ref_pivots, ref_info = _run_torch_ops_path_ex(ref_inp, pivot=pivot)
+        ref_out = namedtuple("_RefResult", ["LU", "pivots", "info"])(
+            ref_lu, ref_pivots, ref_info
+        )
     with flag_gems.use_gems():
         res_out = torch.linalg.lu_factor_ex(inp, pivot=pivot)
 
@@ -138,7 +279,13 @@ def test_linalg_lu_factor_ex_check_errors(shape, dtype, pivot):
     inp = _make_input(shape, pivot, flag_gems.device, dtype)
     ref_inp = utils.to_reference(inp)
 
-    ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=pivot, check_errors=True)
+    if flag_gems.vendor_name != "ascend":
+        ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=pivot, check_errors=True)
+    else:
+        ref_lu, ref_pivots, ref_info = _run_torch_ops_path_ex(ref_inp, pivot=pivot)
+        ref_out = namedtuple("_RefResult", ["LU", "pivots", "info"])(
+            ref_lu, ref_pivots, ref_info
+        )
     with flag_gems.use_gems():
         res_out = torch.linalg.lu_factor_ex(inp, pivot=pivot, check_errors=True)
 
@@ -156,7 +303,13 @@ def test_linalg_lu_factor_ex_singular(shape, dtype):
     inp = _make_singular_input(shape, flag_gems.device, dtype)
     ref_inp = utils.to_reference(inp)
 
-    ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=True, check_errors=False)
+    if flag_gems.vendor_name != "ascend":
+        ref_out = torch.linalg.lu_factor_ex(ref_inp, pivot=True, check_errors=False)
+    else:
+        ref_lu, ref_pivots, ref_info = _run_torch_ops_path_ex(ref_inp, pivot=True)
+        ref_out = namedtuple("_RefResult", ["LU", "pivots", "info"])(
+            ref_lu, ref_pivots, ref_info
+        )
     with flag_gems.use_gems():
         res_out = torch.linalg.lu_factor_ex(inp, pivot=True, check_errors=False)
 
@@ -190,15 +343,24 @@ def test_linalg_lu_factor_ex_out(shape, dtype, pivot):
     m, n = inp.shape[-2], inp.shape[-1]
     k = min(m, n)
 
-    # Reference: use out= parameter
+    # Reference: use out= parameter (or manual reference on Ascend)
     ref_LU_out = torch.empty_like(ref_inp)
     ref_pivots_out = torch.empty(
         (*batch_shape, k), dtype=torch.int32, device=ref_inp.device
     )
     ref_info_out = torch.empty(batch_shape, dtype=torch.int32, device=ref_inp.device)
-    ref_out = torch.linalg.lu_factor_ex(
-        ref_inp, pivot=pivot, out=(ref_LU_out, ref_pivots_out, ref_info_out)
-    )
+    if flag_gems.vendor_name != "ascend":
+        ref_out = torch.linalg.lu_factor_ex(
+            ref_inp, pivot=pivot, out=(ref_LU_out, ref_pivots_out, ref_info_out)
+        )
+    else:
+        ref_lu, ref_pivots, ref_info = _run_torch_ops_path_ex(ref_inp, pivot=pivot)
+        ref_LU_out.copy_(ref_lu)
+        ref_pivots_out.copy_(ref_pivots)
+        ref_info_out.copy_(ref_info)
+        ref_out = namedtuple("_RefResult", ["LU", "pivots", "info"])(
+            ref_LU_out, ref_pivots_out, ref_info_out
+        )
 
     # Gems: use out= parameter
     res_LU_out = torch.empty_like(inp)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

Operator 

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Add operator `linalg_lu_factor_ex` for ascend backend.
Since the NPU version of the `torch.linalg.lu_factor_ex` operator is unavailable on Ascend 910B machines, an implementation using a combination of PyTorch operations has been adopted, and both functional and performance tests have been added. The tests are executed using the `--mode operator` setting.


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

pytest benchmark/test_linalg_lu_factor_ex.py -s --mode operator

```bash
test_linalg_lu_factor_ex.py
Operator: linalg_lu_factor_ex  Performance Test (dtype=torch.float32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.315107            0.205755              54.993          ([torch.Size([16, 16])], {'pivot': True, 'check_errors': False})
SUCCESS              11.272499            0.255314              44.152          ([torch.Size([16, 16])], {'pivot': True, 'check_errors': True})
SUCCESS              22.022307            0.131645             167.285          ([torch.Size([32, 32])], {'pivot': True, 'check_errors': False})
SUCCESS              22.563696            0.312020              72.315          ([torch.Size([32, 32])], {'pivot': True, 'check_errors': True})
SUCCESS              44.605732            2.769089              16.108          ([torch.Size([64, 64])], {'pivot': True, 'check_errors': False})
SUCCESS              45.849323            2.960805              15.485          ([torch.Size([64, 64])], {'pivot': True, 'check_errors': True})
SUCCESS              90.863228           10.273774               8.844          ([torch.Size([128, 128])], {'pivot': True, 'check_errors': False})
SUCCESS              89.884520           10.471397               8.584          ([torch.Size([128, 128])], {'pivot': True, 'check_errors': True})
SUCCESS             190.593004           39.705276               4.800          ([torch.Size([256, 256])], {'pivot': True, 'check_errors': False})
SUCCESS             181.438208           39.413929               4.603          ([torch.Size([256, 256])], {'pivot': True, 'check_errors': True})
SUCCESS             365.491867          304.257393               1.201          ([torch.Size([1024, 512])], {'pivot': True, 'check_errors': False})
SUCCESS             405.537844          304.606438               1.331          ([torch.Size([1024, 512])], {'pivot': True, 'check_errors': True})
SUCCESS              13.045754            0.129296             100.898          ([torch.Size([32, 16])], {'pivot': True, 'check_errors': False})
SUCCESS              14.234066            0.446311              31.893          ([torch.Size([32, 16])], {'pivot': True, 'check_errors': True})
SUCCESS              14.548302            0.259845              55.988          ([torch.Size([16, 32])], {'pivot': True, 'check_errors': False})
SUCCESS              12.013367            0.309393              38.829          ([torch.Size([16, 32])], {'pivot': True, 'check_errors': True})
SUCCESS              62.856913           11.108518               5.658          ([torch.Size([128, 64])], {'pivot': True, 'check_errors': False})
SUCCESS              46.329856            6.160061               7.521          ([torch.Size([128, 64])], {'pivot': True, 'check_errors': True})
SUCCESS              50.841331            2.753019              18.467          ([torch.Size([64, 128])], {'pivot': True, 'check_errors': False})
SUCCESS              70.615649            3.574010              19.758          ([torch.Size([64, 128])], {'pivot': True, 'check_errors': True})
SUCCESS              23.598433            0.130569             180.735          ([torch.Size([4, 32, 32])], {'pivot': True, 'check_errors': False})
SUCCESS              42.215824            0.449946              93.824          ([torch.Size([4, 32, 32])], {'pivot': True, 'check_errors': True})
SUCCESS              13.508161            0.171923              78.571          ([torch.Size([128, 16, 16])], {'pivot': True, 'check_errors': False})
SUCCESS              13.149500            0.406958              32.312          ([torch.Size([128, 16, 16])], {'pivot': True, 'check_errors': True})
SUCCESS            6056.814671         4531.666279               1.337          ([torch.Size([1024, 512, 512])], {'pivot': True, 'check_errors': False})
SUCCESS            6147.819757         4532.096386               1.357          ([torch.Size([1024, 512, 512])], {'pivot': True, 'check_errors': True})

.
Operator: linalg_lu_factor_ex_out  Performance Test (dtype=torch.float32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.537462            0.091918             125.520          ([torch.Size([16, 16])], {'out': [torch.Size([16, 16]), torch.Size([16]), torch.Size([])]})
SUCCESS              22.347450            0.108041             206.842          ([torch.Size([32, 32])], {'out': [torch.Size([32, 32]), torch.Size([32]), torch.Size([])]})
SUCCESS              44.049501            2.650923              16.617          ([torch.Size([64, 64])], {'out': [torch.Size([64, 64]), torch.Size([64]), torch.Size([])]})
SUCCESS              87.512732           10.102007               8.663          ([torch.Size([128, 128])], {'out': [torch.Size([128, 128]), torch.Size([128]), torch.Size([])]})
SUCCESS             172.841549           39.268017               4.402          ([torch.Size([256, 256])], {'out': [torch.Size([256, 256]), torch.Size([256]), torch.Size([])]})
SUCCESS             358.586550          304.298162               1.178          ([torch.Size([1024, 512])], {'out': [torch.Size([1024, 512]), torch.Size([512]), torch.Size([])]})
SUCCESS              11.062950            0.088233             125.383          ([torch.Size([32, 16])], {'out': [torch.Size([32, 16]), torch.Size([16]), torch.Size([])]})
SUCCESS              10.945827            0.088684             123.425          ([torch.Size([16, 32])], {'out': [torch.Size([16, 32]), torch.Size([16]), torch.Size([])]})
SUCCESS              42.808533            5.052178               8.473          ([torch.Size([128, 64])], {'out': [torch.Size([128, 64]), torch.Size([64]), torch.Size([])]})
SUCCESS              42.716980            2.662692              16.043          ([torch.Size([64, 128])], {'out': [torch.Size([64, 128]), torch.Size([64]), torch.Size([])]})
SUCCESS              23.128629            0.108204             213.750          ([torch.Size([4, 32, 32])], {'out': [torch.Size([4, 32, 32]), torch.Size([4, 32]), torch.Size([4])]})
SUCCESS              11.995047            0.169520              70.759          ([torch.Size([128, 16, 16])], {'out': [torch.Size([128, 16, 16]), torch.Size([128, 16]), torch.Size([128])]})
SUCCESS            6042.645216         4533.440113               1.333          ([torch.Size([1024, 512, 512])], {'out': [torch.Size([1024, 512, 512]), torch.Size([1024, 512]), torch.Size([1024])]})

```