### PR TITLE
fix(nvidia): reduce add launch overhead for small tensors

### DIFF
--- a/benchmark/test_add.py
+++ b/benchmark/test_add.py
@@ -20,12 +20,18 @@ import flag_gems
 from . import base, consts
 
 
+class AddBenchmark(base.BinaryPointwiseBenchmark):
+    def set_more_shapes(self):
+        # Add decode-sized cases without replacing configured benchmark shapes.
+        return super().set_more_shapes() + [(1, 4096), (16, 4096)]
+
+
 @pytest.mark.add
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
 def test_add():
-    bench = base.BinaryPointwiseBenchmark(
+    bench = AddBenchmark(
         op_name="add",
         torch_op=torch.add,
         dtypes=consts.FLOAT_DTYPES + consts.COMPLEX_DTYPES,

--- a/src/flag_gems/runtime/backend/_nvidia/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/ops/__init__.py
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Example for multi-backend ops.
-
-
 from .add import add
-from .gelu import gelu
 
 __all__ = [
     "add",
-    "gelu",
 ]
-"""

--- a/src/flag_gems/runtime/backend/_nvidia/ops/add.py
+++ b/src/flag_gems/runtime/backend/_nvidia/ops/add.py
@@ -39,6 +39,8 @@ def _can_use_fast_path(x, y, alpha):
     return (
         isinstance(x, torch.Tensor)
         and isinstance(y, torch.Tensor)
+        and isinstance(alpha, (int, float))
+        and not isinstance(alpha, bool)
         and alpha == 1
         and x.device == y.device
         and x.dtype == y.dtype

--- a/src/flag_gems/runtime/backend/_nvidia/ops/add.py
+++ b/src/flag_gems/runtime/backend/_nvidia/ops/add.py
@@ -12,55 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import torch
 import triton
 import triton.language as tl
 
+from flag_gems.ops.add import add as generic_add
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+_FAST_DTYPES = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+
 
 @triton.jit
-def add_kernel(
-    x_ptr,  # *Pointer* to first input vector.
-    y_ptr,  # *Pointer* to second input vector.
-    output_ptr,  # *Pointer* to output vector.
-    n_elements,  # Size of the vector.
-    BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
-    # NOTE: `constexpr` so it can be used as a shape value.
-):
-    # There are multiple 'programs' processing different data. We identify which program
-    # we are here:
-    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
-    # This program will process inputs that are offset from the initial data.
-    # For instance, if you had a vector of length 256 and block_size of 64, the programs
-    # would each access the elements [0:64, 64:128, 128:192, 192:256].
-    # Note that offsets is a list of pointers:
-    block_start = pid * BLOCK_SIZE
-    offsets = block_start + tl.arange(0, BLOCK_SIZE)
-    # Create a mask to guard memory operations against out-of-bounds accesses.
+def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
-    # Load x and y from DRAM, masking out any extra elements in case the input is not a
-    # multiple of the block size.
     x = tl.load(x_ptr + offsets, mask=mask)
     y = tl.load(y_ptr + offsets, mask=mask)
-    output = x + y
-    # Write x + y back to DRAM.
-    tl.store(output_ptr + offsets, output, mask=mask)
+    tl.store(output_ptr + offsets, x + y, mask=mask)
 
 
-def add(x: torch.Tensor, y: torch.Tensor):
-    # We need to preallocate the output.
-    print("\n.......test for mutibackend specific add........\n")
+def _can_use_fast_path(x, y, alpha):
+    return (
+        isinstance(x, torch.Tensor)
+        and isinstance(y, torch.Tensor)
+        and alpha == 1
+        and x.device == y.device
+        and x.dtype == y.dtype
+        and x.dtype in _FAST_DTYPES
+        and x.shape == y.shape
+        and x.is_contiguous()
+        and y.is_contiguous()
+    )
+
+
+def add(x, y, *, alpha=1):
+    if not _can_use_fast_path(x, y, alpha):
+        return generic_add(x, y, alpha=alpha)
+
+    logger.debug("GEMS ADD NVIDIA FAST PATH")
     output = torch.empty_like(x)
-    n_elements = output.numel()
-    # The SPMD launch grid denotes the number of kernel instances that run in parallel.
-    # It is analogous to CUDA launch grids. It can be either Tuple[int], or Callable(metaparameters) -> Tuple[int].
-    # In this case, we use a 1D grid where the size is the number of blocks:
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    n_elements = x.numel()
+    if n_elements == 0:
+        return output
 
-    # NOTE:
-    #  - Each torch.tensor object is implicitly converted into a pointer to its first element.
-    #  - `triton.jit`'ed functions can be indexed with a launch grid to obtain a callable GPU kernel.
-    #  - Don't forget to pass meta-parameters as keywords arguments.
-    add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
-    # We return a handle to z but, since `torch_device_fn.synchronize()` hasn't been called, the kernel is still
-    # running asynchronously at this point.
+    grid = (triton.cdiv(n_elements, 1024),)
+    with torch_device_fn.device(x.device):
+        add_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=1024)
     return output

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -28,22 +28,42 @@ from . import accuracy_utils as utils
 @pytest.mark.skipif(
     flag_gems.vendor_name != "nvidia", reason="NVIDIA-specific contiguous fast path"
 )
-@pytest.mark.parametrize("shape", [(0,), (1, 4096), (16, 4096)])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("shape", [(0,), (17,), (1, 4096), (16, 4096)])
+@pytest.mark.parametrize("dtype", utils.ALL_FLOAT_DTYPES)
 def test_add_nvidia_contiguous_fast_path(shape, dtype, monkeypatch):
     inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     expected = utils.to_reference(inp1, True) + utils.to_reference(inp2, True)
 
-    nvidia_add = importlib.import_module("flag_gems.runtime.backend._nvidia.ops.add")
+    nvidia_add = importlib.import_module(flag_gems.add.__module__)
 
     def fail_generic_add(*args, **kwargs):
         raise AssertionError("contiguous default-alpha add did not use the fast path")
 
     monkeypatch.setattr(nvidia_add, "generic_add", fail_generic_add)
-    with flag_gems.use_gems():
-        actual = torch.add(inp1, inp2)
+    actual = flag_gems.add(inp1, inp2)
     utils.gems_assert_close(actual, expected, dtype)
+
+
+@pytest.mark.add
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "nvidia", reason="NVIDIA-specific contiguous fast path"
+)
+@pytest.mark.parametrize("alpha", [True, 1 + 0j])
+def test_add_nvidia_invalid_alpha_uses_generic_path(alpha, monkeypatch):
+    inp1 = torch.ones((1, 4096), device=flag_gems.device)
+    inp2 = torch.ones_like(inp1)
+    nvidia_add = importlib.import_module(flag_gems.add.__module__)
+
+    class GenericPathCalled(Exception):
+        pass
+
+    def fail_generic_add(*args, **kwargs):
+        raise GenericPathCalled
+
+    monkeypatch.setattr(nvidia_add, "generic_add", fail_generic_add)
+    with pytest.raises(GenericPathCalled):
+        flag_gems.add(inp1, inp2, alpha=alpha)
 
 
 @pytest.mark.add

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import random
 
 import numpy as np
@@ -21,6 +22,28 @@ import torch
 import flag_gems
 
 from . import accuracy_utils as utils
+
+
+@pytest.mark.add
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "nvidia", reason="NVIDIA-specific contiguous fast path"
+)
+@pytest.mark.parametrize("shape", [(0,), (1, 4096), (16, 4096)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_add_nvidia_contiguous_fast_path(shape, dtype, monkeypatch):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    expected = utils.to_reference(inp1, True) + utils.to_reference(inp2, True)
+
+    nvidia_add = importlib.import_module("flag_gems.runtime.backend._nvidia.ops.add")
+
+    def fail_generic_add(*args, **kwargs):
+        raise AssertionError("contiguous default-alpha add did not use the fast path")
+
+    monkeypatch.setattr(nvidia_add, "generic_add", fail_generic_add)
+    with flag_gems.use_gems():
+        actual = torch.add(inp1, inp2)
+    utils.gems_assert_close(actual, expected, dtype)
 
 
 @pytest.mark.add


### PR DESCRIPTION
### PR Category

Operator, OP Test, Benchmark

### Type of Change

Bug Fix, Performance Optimization

### Description

- Activate the NVIDIA-specific `add` override and use a low-overhead raw Triton kernel for contiguous, same-shape floating tensors with the default numeric `alpha=1`.
- Preserve the generic pointwise path for broadcasting, non-contiguous layouts, mixed dtypes, scalars, non-default alpha, bool alpha, and complex alpha.
- Add public-API fast-path/fallback tests covering empty tensors, a 17-element tail, fp64, and decode-oriented shapes.
- Extend the comprehensive add benchmark through `set_more_shapes()` without replacing the repository's configured/core shapes.

The generated `pointwise_dynamic` path has a roughly constant Python and launch overhead. On H20, this dominates the small adds used by decode workloads, while large tensors are already memory-bound.

Validation on NVIDIA H20:

- complete `tests/test_add.py` on the original fix: 1067 passed;
- focused fast-path and invalid-alpha matrix after the follow-up: 18 passed;
- benchmark smoke test: 1 passed;
- `git diff --check`, Black, isort, Flake8, and pre-commit checks passed.

### Issue

- Resolves #4558

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

NVIDIA H20, PyTorch 2.10.0+cu128, Triton 3.6.0:

| Shape | PyTorch baseline | FlagGems master | This PR |
|---|---:|---:|---:|
| `(1, 4096)` | 6.5 us | 84.9 us | 20.9 us |
| `(16, 4096)` | 6.7 us | 67.9 us | 20.9 us |
| `(4096, 4096)` | 70-80 us | 81.7 us | 67.0 us |
| `(32768, 4096)` | 496-497 us | 533.0 us | 482.1 us |

The fast path removes about 80% of the excess latency for the small calls while preserving large-tensor throughput.
