### PR TITLE
fix iluvatar

### DIFF
--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -24,8 +24,10 @@ from .linear import linear
 from .matmul_bf16 import matmul_bf16
 from .matmul_int8 import matmul_int8
 from .mm import mm, mm_out
+from .randperm import randperm
 from .repeat import repeat
 from .scatter_add import scatter_add_
+from .sort import sort, sort_stable
 from .special_modified_bessel_k1 import (
     special_modified_bessel_k1,
     special_modified_bessel_k1_out,
@@ -53,8 +55,11 @@ __all__ = [
     "matmul_int8",
     "mm",
     "mm_out",
+    "randperm",
     "repeat",
     "scatter_add_",
+    "sort",
+    "sort_stable",
     "special_modified_bessel_k1",
     "special_modified_bessel_k1_out",
     "special_shifted_chebyshev_polynomial_w",

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/addmm.py
@@ -194,12 +194,42 @@ def addmm_kernel(
 
 def _launch_addmm(mat1, mat2, bias, out, M, N, K, alpha, beta):
     """Launch Triton addmm kernel; out must be pre-allocated."""
+    from .mm import _MAX_BLOCK_K, _MIN_TRITON_DIM
+
+    # Pad when any dim is below the minimum tile or K is not a multiple of
+    # _MAX_BLOCK_K (EVEN_K=False is broken on the Iluvatar compiler).
+    need_pad = (
+        M < _MIN_TRITON_DIM
+        or N < _MIN_TRITON_DIM
+        or K < _MIN_TRITON_DIM
+        or K % _MAX_BLOCK_K != 0
+    )
+    if need_pad:
+        pad_M = max(_MIN_TRITON_DIM - M, 0)
+        pad_N = max(_MIN_TRITON_DIM - N, 0)
+        new_K = K + max(_MIN_TRITON_DIM - K, 0)
+        remainder = new_K % _MAX_BLOCK_K
+        if remainder:
+            new_K += _MAX_BLOCK_K - remainder
+        pad_K = new_K - K
+        if pad_M or pad_K:
+            mat1 = torch.nn.functional.pad(mat1, (0, pad_K, 0, pad_M))
+        if pad_K or pad_N:
+            mat2 = torch.nn.functional.pad(mat2, (0, pad_N, 0, pad_K))
+        if pad_M or pad_N:
+            bias = torch.nn.functional.pad(bias, (0, pad_N, 0, pad_M))
+        pM, pN, pK = M + pad_M, N + pad_N, new_K
+        out_padded = torch.zeros((pM, pN), device=out.device, dtype=out.dtype)
+    else:
+        pM, pN, pK = M, N, K
+        out_padded = out
+
     ab_dtype = get_higher_dtype(mat1.dtype, mat2.dtype)
     acc_dtype_tl = tl.float32
     ab_dtype_tl = _to_tl_type(ab_dtype)
 
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        triton.cdiv(pM, META["BLOCK_M"]) * triton.cdiv(pN, META["BLOCK_N"]),
         META["SPLIT_K"],
     )
 
@@ -208,31 +238,34 @@ def _launch_addmm(mat1, mat2, bias, out, M, N, K, alpha, beta):
             mat1,
             mat2,
             bias,
-            out,
+            out_padded,
             alpha,
             beta,
-            M,
-            N,
-            K,
+            pM,
+            pN,
+            pK,
             mat1.stride(0),
             mat1.stride(1),
             mat2.stride(0),
             mat2.stride(1),
             bias.stride(0),
             bias.stride(1),
-            out.stride(0),
-            out.stride(1),
+            out_padded.stride(0),
+            out_padded.stride(1),
             acc_dtype=acc_dtype_tl,
             input_precision=None,
             fp8_fast_accum=True,
             GROUP_M=8,
             AB_DTYPE=ab_dtype_tl,
         )
+
+    if need_pad:
+        out.copy_(out_padded[:M, :N])
+
     return out
 
 
 def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("GEMS_ILUVATAR ADDMM")
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -247,13 +280,14 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
 
     out_dtype = get_higher_dtype(mat1.dtype, mat2.dtype)
     out = torch.empty((M, N), device=mat1.device, dtype=out_dtype)
+    # Zero the output since kernel may use atomic_add when SPLIT_K > 1
+    out.zero_()
     bias = bias.broadcast_to(out.shape).contiguous()
 
     return _launch_addmm(mat1, mat2, bias, out, M, N, K, alpha, beta)
 
 
 def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
-    logger.debug("GEMS_ILUVATAR ADDMM_OUT")
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
@@ -264,8 +298,12 @@ def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
         out = torch.empty(
             (M, N), device=mat1.device, dtype=get_higher_dtype(mat1.dtype, mat2.dtype)
         )
+        # Zero the output since kernel may use atomic_add when SPLIT_K > 1
+        out.zero_()
     else:
         assert out.shape == (M, N), "Incompatible output shape"
+        # Zero the output since kernel may use atomic_add when SPLIT_K > 1
+        out.zero_()
 
     if mat1.stride(0) > 1 and mat1.stride(1) > 1:
         mat1 = mat1.contiguous()

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
@@ -203,14 +203,64 @@ def mm_kernel(
         tl.atomic_add(C, acc, mask=mask)
 
 
+# Minimum tile size from tuning configs.  When any matrix dimension is smaller
+# than this, the Triton kernel's tl.multiple_of / tl.max_contiguous hints become
+# invalid (they assume the range spans at least BLOCK elements) and the Iluvatar
+# compiler may crash or produce wrong results.  We pad the matrices to the
+# minimum size and then slice the result.
+_MIN_TRITON_DIM = 32
+
+# The Iluvatar Triton compiler produces incorrect results in the EVEN_K=False
+# (K remainder) code path.  To avoid this, K is always padded to a multiple of
+# the largest BLOCK_K used in the tuning configs so that EVEN_K is guaranteed
+# True regardless of which config the autotuner picks.
+_MAX_BLOCK_K = 128
+
+
+def _pad_dims(a, b, M, N, K):
+    """Pad a (M×K) and b (K×N) so all dims >= _MIN_TRITON_DIM and K is a
+    multiple of _MAX_BLOCK_K (ensures EVEN_K=True).
+
+    Returns (a_padded, b_padded, padded_M, padded_N, padded_K).
+    """
+    pad_M = max(_MIN_TRITON_DIM - M, 0)
+    pad_N = max(_MIN_TRITON_DIM - N, 0)
+    # Pad K to the next multiple of _MAX_BLOCK_K to guarantee EVEN_K=True.
+    new_K = K + max(_MIN_TRITON_DIM - K, 0)
+    remainder = new_K % _MAX_BLOCK_K
+    if remainder:
+        new_K += _MAX_BLOCK_K - remainder
+    pad_K = new_K - K
+    if pad_M or pad_K:
+        a = torch.nn.functional.pad(a, (0, pad_K, 0, pad_M))
+    if pad_K or pad_N:
+        b = torch.nn.functional.pad(b, (0, pad_N, 0, pad_K))
+    return a, b, M + pad_M, N + pad_N, new_K
+
+
 def _launch_mm(a, b, c, M, N, K):
     """Launch Triton matmul _kernel; c must be pre-allocated."""
+    # Pad when any dim is below the minimum tile or K is not a multiple of
+    # _MAX_BLOCK_K (EVEN_K=False is broken on the Iluvatar compiler).
+    need_pad = (
+        M < _MIN_TRITON_DIM
+        or N < _MIN_TRITON_DIM
+        or K < _MIN_TRITON_DIM
+        or K % _MAX_BLOCK_K != 0
+    )
+    if need_pad:
+        a, b, pM, pN, pK = _pad_dims(a, b, M, N, K)
+        c_padded = torch.empty((pM, pN), device=c.device, dtype=c.dtype)
+    else:
+        pM, pN, pK = M, N, K
+        c_padded = c
+
     ab_dtype = get_higher_dtype(a.dtype, b.dtype)
     acc_dtype_tl = tl.float32
     ab_dtype_tl = _to_tl_type(ab_dtype)
 
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        triton.cdiv(pM, META["BLOCK_M"]) * triton.cdiv(pN, META["BLOCK_N"]),
         META["SPLIT_K"],
     )
 
@@ -218,32 +268,54 @@ def _launch_mm(a, b, c, M, N, K):
         mm_kernel[grid](
             a,
             b,
-            c,
-            M,
-            N,
-            K,
+            c_padded,
+            pM,
+            pN,
+            pK,
             a.stride(0),
             a.stride(1),
             b.stride(0),
             b.stride(1),
-            c.stride(0),
-            c.stride(1),
+            c_padded.stride(0),
+            c_padded.stride(1),
             acc_dtype=acc_dtype_tl,
             input_precision=None,
             fp8_fast_accum=True,
             GROUP_M=8,
             AB_DTYPE=ab_dtype_tl,
         )
+
+    if need_pad:
+        c.copy_(c_padded[:M, :N])
+
     return c
+
+
+def _ensure_mm_layout(a, b):
+    """Ensure inputs have a valid layout for the Triton mm kernel.
+
+    The kernel requires that at least one stride equals 1 (row- or column-major).
+    Additionally, on the Iluvatar backend the compiler crashes when both matrices
+    reference the same storage with transposed strides (self-transpose pattern) and
+    dtype is float32.  Making at least one input contiguous avoids this.
+    """
+    # If both strides > 1, the tensor is neither row- nor column-major.
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # Guard against the self-transpose compiler bug: when a and b share storage
+    # and both are transposed (stride != 1 in leading dim), make b contiguous to
+    # give the compiler a clean layout.
+    if a.data_ptr() == b.data_ptr():
+        b = b.contiguous()
+    return a, b
 
 
 def mm(a, b):
     logger.debug("GEMS_ILUVATAR MM")
     device = a.device
-    if a.stride(0) > 1 and a.stride(1) > 1:
-        a = a.contiguous()
-    if b.stride(0) > 1 and b.stride(1) > 1:
-        b = b.contiguous()
+    a, b = _ensure_mm_layout(a, b)
     assert a.shape[1] == b.shape[0], "incompatible dimensions"
     M, K = a.shape
     _, N = b.shape
@@ -254,10 +326,7 @@ def mm(a, b):
 
 def mm_out(a, b, *, out):
     logger.debug("GEMS_ILUVATAR MM_OUT")
-    if a.stride(0) > 1 and a.stride(1) > 1:
-        a = a.contiguous()
-    if b.stride(0) > 1 and b.stride(1) > 1:
-        b = b.contiguous()
+    a, b = _ensure_mm_layout(a, b)
     assert a.shape[1] == b.shape[0], "incompatible dimensions"
     M, K = a.shape
     _, N = b.shape


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Fix compiler crashes and silent incorrect results in the Iluvatar backend's mm / mm_out operators under specific input conditions. Key changes:
1. Small-dimension padding (_MIN_TRITON_DIM = 32)
When any matrix dimension (M, N, or K) is smaller than 32, Triton's tl.multiple_of / tl.max_contiguous hints become invalid, causing the Iluvatar compiler to crash or produce wrong results. We automatically pad inputs to the minimum tile size and slice the result back to the original shape.
2. Force EVEN_K=True (_MAX_BLOCK_K = 128)
The Iluvatar Triton compiler generates incorrect results in the EVEN_K=False code path (when K is not divisible by the block size). We pad K to a multiple of 128, ensuring EVEN_K=True regardless of which autotuner config is selected.
3. Input layout guarding (_ensure_mm_layout)
Fixes two layout-related compiler issues:
Invalid strides: the kernel requires at least one stride to be 1 (row- or column-major). If both strides are greater than 1, we force contiguous().
Self-transpose crash: when a and b share the same underlying storage and both are transposed (e.g., a = x.T; b = x) with float32 dtype, the compiler crashes. We detect shared storage and force b.contiguous() to avoid this.
4. Code structure refactoring
Added _pad_dims() for dimension padding logic.
Added _launch_mm() to unify padding checks, temporary tensor allocation, and result copy-back.
mm() and mm_out() now both call _ensure_mm_layout() and _launch_mm().
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
