### PR TITLE
[Operator] Fix and optimize Hopper FP8 einsum TLE pipeline

### DIFF
--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
@@ -27,7 +27,9 @@ if has_triton_tle(3, 6, 0):
     try:
         import triton.experimental.tle.language as tle
 
-        HAS_TLE_W8A8_BLOCK_FP8_BMM = hasattr(tle.gpu, "alloc_barriers")
+        HAS_TLE_W8A8_BLOCK_FP8_BMM = hasattr(tle, "pipe") and hasattr(
+            tle.gpu, "warp_specialize"
+        )
     except ImportError:
         tle = None
         HAS_TLE_W8A8_BLOCK_FP8_BMM = False
@@ -46,19 +48,18 @@ def _set_triton_descriptor_allocator(device: torch.device) -> None:
 
 
 def _get_tle_w8a8_block_fp8_bmm_configs():
-    # TLE shared-memory tensors require power-of-two shapes, so stage counts
-    # like 6 cannot compile.  Stage 8 compiles, but hits launch failures on
-    # large DeepSeek-V4 Pro shapes (for example BMM K=7168), so keep the stable
-    # Hopper TLE path on 4 stages for now.
+    # The current TLE memory-descriptor type still rejects non-power-of-two
+    # stage dimensions, so keep stage 6 disabled.  Stages 4 and 8 are both
+    # correct once the persistent pipe generation continues across output tiles.
     return [
         config
         for config in runtime.get_tuned_config("w8a8_block_fp8_bmm")
-        if config.num_stages == 4
+        if config.num_stages in (4, 8)
     ]
 
 
 def _filter_tle_w8a8_block_fp8_bmm_configs(configs):
-    return [config for config in configs if config.num_stages == 4]
+    return [config for config in configs if config.num_stages in (4, 8)]
 
 
 class _TLEW8A8BlockFP8BMMTuner(LibTuner.get("default")):
@@ -105,12 +106,7 @@ def _get_tile(
 
 @triton.jit
 def _tle_w8a8_block_fp8_bmm_compute_partition(
-    x_smem,
-    y_smem,
-    empty_x,
-    empty_y,
-    full_x,
-    full_y,
+    xy_reader,
     xs_ptr,
     z_ptr,
     ys_ptr,
@@ -159,13 +155,15 @@ def _tle_w8a8_block_fp8_bmm_compute_partition(
         else:
             acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
+        # A persistent CTA keeps the same pipe barriers while advancing by
+        # num_sms output tiles.  Carry the ring generation across those tiles;
+        # restarting it from k_block_idx=0 can wait on the wrong parity.
+        tile_sequence = tile_id // num_sms
         for k_block_idx in range(0, num_k_blocks):
-            index = k_block_idx % num_stages
-            phase = k_block_idx // num_stages
-            x_slot = x_smem.slot(index).slot(0)  # [BLOCK_M, BLOCK_K]
-            y_slot = y_smem.slot(index)  # [BLOCK_N, BLOCK_K]
-            tle.gpu.barrier_wait(full_x[index], phaseIdx=phase)
-            tle.gpu.barrier_wait(full_y[index], phaseIdx=phase)
+            ring_iter = tile_sequence * num_k_blocks + k_block_idx
+            xy_slot = xy_reader.wait(ring_iter).slot
+            x_slot = xy_slot.x.slot(0)  # [BLOCK_M, BLOCK_K]
+            y_slot = xy_slot.y  # [BLOCK_N, BLOCK_K]
 
             x_s = tl.load(
                 xs_ptr + xs_row_base + k_block_idx * xs_sKb,
@@ -194,8 +192,7 @@ def _tle_w8a8_block_fp8_bmm_compute_partition(
                 partial = tle.gpu.wgmma_wait(0, partial)
                 acc = acc + partial * xy_s[:, None]
 
-            tle.gpu.barrier_arrive(empty_x[index], phaseIdx=phase)
-            tle.gpu.barrier_arrive(empty_y[index], phaseIdx=phase)
+            xy_reader.release(ring_iter)
 
         if SWAP_AB:
             acc_out = tl.trans(acc)
@@ -214,12 +211,7 @@ def _tle_w8a8_block_fp8_bmm_compute_partition(
 def _tle_w8a8_block_fp8_bmm_load_partition(
     x_desc,
     y_desc,
-    x_smem,
-    y_smem,
-    empty_x,
-    empty_y,
-    full_x,
-    full_y,
+    xy_writer,
     B: tl.constexpr,
     M: tl.constexpr,
     M_aligned: tl.constexpr,
@@ -246,26 +238,24 @@ def _tle_w8a8_block_fp8_bmm_load_partition(
         n_start = n_tile_id * BLOCK_N
         y_row = batch_id * N + n_start
 
+        tile_sequence = tile_id // num_sms
         for k_block_idx in range(0, K // BLOCK_K):
-            index = k_block_idx % num_stages
-            phase = k_block_idx // num_stages
+            ring_iter = tile_sequence * (K // BLOCK_K) + k_block_idx
             k_start = k_block_idx * BLOCK_K
-            tle.gpu.barrier_wait(empty_x[index], phaseIdx=phase)
+            xy_slot = xy_writer.acquire(ring_iter)
             tle.gpu.copy(
                 x_desc,
-                x_smem.slot(index),
+                xy_slot.x,
                 [1, BLOCK_M, BLOCK_K],
                 [batch_id, m_start, k_start],
-                barrier=full_x[index],
             )
-            tle.gpu.barrier_wait(empty_y[index], phaseIdx=phase)
             tle.gpu.copy(
                 y_desc,
-                y_smem.slot(index),
+                xy_slot.y,
                 [BLOCK_N, BLOCK_K],
                 [y_row, k_start],
-                barrier=full_y[index],
             )
+            xy_writer.commit(ring_iter)
 
 
 if HAS_TLE_W8A8_BLOCK_FP8_BMM:
@@ -308,7 +298,7 @@ if HAS_TLE_W8A8_BLOCK_FP8_BMM:
         num_stages: tl.constexpr,
         num_sms: tl.constexpr,
     ):
-        _ = num_warps
+        _ = (num_warps, X_ELEM_BYTES, Y_ELEM_BYTES)
         x_smem = tle.gpu.alloc(
             [num_stages, 1, BLOCK_M, BLOCK_K],
             dtype=x_desc.dtype,
@@ -321,21 +311,12 @@ if HAS_TLE_W8A8_BLOCK_FP8_BMM:
             layout=None,
             scope=tle.gpu.smem,
         )
-        empty_x = tle.gpu.alloc_barriers(
-            num_barriers=num_stages, arrive_count=1, init=tle.gpu.READY
-        )
-        empty_y = tle.gpu.alloc_barriers(
-            num_barriers=num_stages, arrive_count=1, init=tle.gpu.READY
-        )
-        full_x = tle.gpu.alloc_barriers(
-            num_barriers=num_stages,
-            arrive_count=1,
-            expect_bytes=BLOCK_M * BLOCK_K * X_ELEM_BYTES,
-        )
-        full_y = tle.gpu.alloc_barriers(
-            num_barriers=num_stages,
-            arrive_count=1,
-            expect_bytes=BLOCK_N * BLOCK_K * Y_ELEM_BYTES,
+        xy_pipe = tle.pipe(
+            capacity=num_stages,
+            scope="cta",
+            name="w8a8_xy",
+            x=x_smem,
+            y=y_smem,
         )
 
         tle.gpu.warp_specialize(
@@ -343,12 +324,7 @@ if HAS_TLE_W8A8_BLOCK_FP8_BMM:
                 (
                     _tle_w8a8_block_fp8_bmm_compute_partition,
                     (
-                        x_smem,
-                        y_smem,
-                        empty_x,
-                        empty_y,
-                        full_x,
-                        full_y,
+                        xy_pipe.reader(),
                         xs_ptr,
                         z_ptr,
                         ys_ptr,
@@ -377,12 +353,7 @@ if HAS_TLE_W8A8_BLOCK_FP8_BMM:
                     (
                         x_desc,
                         y_desc,
-                        x_smem,
-                        y_smem,
-                        empty_x,
-                        empty_y,
-                        full_x,
-                        full_y,
+                        xy_pipe.writer(),
                         B,
                         M,
                         M_aligned,

--- a/tests/test_fp8_einsum.py
+++ b/tests/test_fp8_einsum.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import math
+from contextlib import contextmanager
 
 import pytest
 import torch
@@ -24,9 +26,14 @@ from .conftest import QUICK_MODE
 
 # The Gluon fp8_einsum kernel requires Triton >= 3.6.0 and specific TLE features.
 fp8_einsum = None
+w8a8_block_fp8_bmm_module = None
 if triton.__version__ >= "3.6.0":
     try:
         from flag_gems.runtime.backend._nvidia.hopper.ops.fp8_einsum import fp8_einsum
+
+        w8a8_block_fp8_bmm_module = importlib.import_module(
+            "flag_gems.runtime.backend._nvidia.hopper.ops.w8a8_block_fp8_bmm"
+        )
     except (AttributeError, ImportError):
         pass
 
@@ -160,6 +167,52 @@ def torch_fp8_block_einsum_reference(x_data, x_scale, y_data, y_scale, block_sha
     return torch.einsum("bhr,hdr->bhd", x_deq, y_deq)
 
 
+@contextmanager
+def _force_tle_pipeline_config(num_stages):
+    """Temporarily force one registered TLE config for a regression call."""
+    kernel = w8a8_block_fp8_bmm_module.w8a8_block_fp8_bmm_kernel
+    current = kernel
+    seen = set()
+    tuner = None
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        configs = getattr(current, "configs", None)
+        if configs is not None:
+            tuner = current
+            break
+        current = getattr(current, "fn", None)
+    if tuner is None:
+        raise RuntimeError("TLE w8a8_block_fp8_bmm tuner not found")
+
+    matches = [
+        config
+        for config in tuner.configs
+        if config.num_warps == 4
+        and config.num_stages == num_stages
+        and config.kwargs.get("TILE_ORDER") == 0
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one 4-warp stage-{num_stages} horizontal config, got {matches}"
+        )
+
+    original_configs = tuner.configs
+    original_defaults = tuner._flagtune_default_configs
+    tuner.configs = matches
+    tuner._flagtune_default_configs = matches
+    for cache in kernel.kernel_cache:
+        cache.clear()
+    kernel._cpu_cache.clear()
+    try:
+        yield
+    finally:
+        tuner.configs = original_configs
+        tuner._flagtune_default_configs = original_defaults
+        for cache in kernel.kernel_cache:
+            cache.clear()
+        kernel._cpu_cache.clear()
+
+
 @pytest.mark.fp8_einsum
 @pytest.mark.parametrize("config", FP8_EINSUM_CONFIGS)
 @pytest.mark.parametrize("block_shape", [[128, 128]])
@@ -196,3 +249,39 @@ def test_accuracy_fp8_einsum(config, block_shape):
     rtol = 2e-1
     atol = max(5e-2, ref.abs().max().item() * 5e-2)
     torch.testing.assert_close(result, ref.to(result.dtype), rtol=rtol, atol=atol)
+
+
+@pytest.mark.fp8_einsum
+@pytest.mark.skipif(
+    not (
+        CUDA_AVAILABLE
+        and TRITON_VERSION_OK
+        and fp8_einsum is not None
+        and w8a8_block_fp8_bmm_module is not None
+        and w8a8_block_fp8_bmm_module.HAS_TLE_W8A8_BLOCK_FP8_BMM
+    ),
+    reason="requires NVIDIA Hopper GPU and typed TLE pipe support",
+)
+def test_tle_fp8_einsum_persistent_pipe_stage8():
+    """Keep pipe generation valid when a persistent CTA advances to another tile."""
+    block_shape = [128, 128]
+    inputs = _make_fp8_einsum_inputs(
+        b=1,
+        h=16,
+        r=7168,
+        d=1024,
+        block_shape=block_shape,
+        device=flag_gems.device,
+    )
+
+    outputs = {}
+    for num_stages in (4, 8):
+        with _force_tle_pipeline_config(num_stages):
+            outputs[num_stages] = fp8_einsum(
+                "bhr,hdr->bhd",
+                *inputs,
+                block_size=block_shape,
+            )
+            torch.cuda.synchronize()
+
+    assert torch.equal(outputs[8], outputs[4])


### PR DESCRIPTION
### PR Category

Operator; OP Test; Benchmark

### Type of Change

Bug Fix; Performance Optimization

## Summary

Fixes the persistent TLE pipeline behind Hopper FP8 einsum and makes stage 8
available again. On the representative H20 workload, the repaired stage-8 path
has `11.22%` lower CUDA Graph kernel latency than the exact PR parent's
best-valid stage-4 path and remains within `0.40%` of Gluon stage 8.

### Description

This change fixes the Hopper TLE path used by
`fp8_einsum("bhr,hdr->bhd")` and makes the stage-8 pipeline available again.
On the representative DeepSeek-V4-Pro shape, one matched four-way H20 run
changes the usable TLE endpoint from pre-fix stage 4 at `0.0429271 ms` to this
PR's stage 8 at `0.0381119 ms` (`11.22%` lower latency). The current stage-8
result is within the pre-registered `3%` noise band of Gluon stage 8.

The retained mechanism has two parts:

1. Replace the four manually managed X/Y full/empty barrier arrays with one
   typed multi-field `tle.pipe`. X and Y now share one slot lifecycle and one
   generation contract.
2. Keep the pipe generation continuous when a persistent CTA advances to a
   later output tile. The old code restarted the generation from
   `k_block_idx == 0` for every tile even though the same barriers remained
   live, which could wait on the wrong parity for deeper pipelines.

### Typed-pipe iteration contract

For logical iteration `i` in an `N`-stage pipe, `stage` selects the physical
payload slot and `phase` distinguishes successive uses of that slot:

```text
stage = i % N              -> slot[i % N]
phase = (i // N) % 2       -> barrier generation parity

Producer                                      Consumer
writer.acquire(i)
        |
        v
TMA copy X/Y into slot[stage]
        |
writer.commit(i) ---------------------------> reader.wait(i)
                                                  |
                                                  v
                                             WGMMA reads slot
                                                  |
writer.acquire(i + N) <--------------------- reader.release(i)
same physical slot, opposite phase
```

Producer and consumer must use the same logical iteration. Releasing iteration
`i` permits the next use of the same physical slot at `i + N`, whose phase has
flipped.

### Why stage 8 exposes the reset

For the representative DeepSeek-V4-Pro case, `K=7168` and `BLOCK_K=128` give
56 K blocks per output tile. The same persistent CTA keeps the pipe slots and
barriers alive when it advances to the next output tile.

For an eight-stage pipe, the slot-0 generations around that boundary are:

```text
ring_iter     0   8  16  24  32  40  48 | 56
slot          0   0   0   0   0   0   0 |  0
phase         0   1   0   1   0   1   0 |  1  <- next required generation
tile          <--------- tile A --------> | tile B

pre-fix tile B: reset i to 0   -> slot 0, phase 0  -> mismatch
fixed tile B:   continue at 56 -> slot 0, phase 1  -> matched

stage 4: 56 / 4 = 14 traversals (even) -> next phase 0 -> reset happens to work
stage 8: 56 / 8 =  7 traversals (odd)  -> next phase 1 -> reset mismatches
```

The fix therefore uses
`ring_iter = tile_sequence * num_k_blocks + k_block_idx` in both partitions.

Stage 6 remains filtered out because current upstream TLE rejects its
non-power-of-two memory-descriptor stage dimension. This PR enables only stages
4 and 8; it does not depend on a separate compiler fix.

## Related PRs

| PR | Relationship to this change |
|---|---|
| #3297 | Introduced `fp8_einsum`, its original Gluon-backed FP8 BMM, correctness tests, and benchmark harness. It is historical operator context, not a change fixed by this PR. |
| #4794 | Replaced the BMM path with TLE and introduced the persistent pipeline changed here. This PR is a direct follow-up to #4794. |
| #5438 | Disabled the problematic `empty.memory_format` registration. It is already an ancestor of this PR's base and is recorded here to bind the benchmark environment, not as a kernel dependency. |

## Review map

1. Review `_tle_w8a8_block_fp8_bmm_compute_partition` and
   `_tle_w8a8_block_fp8_bmm_load_partition` for the shared `ring_iter`
   invariant. Producer and consumer derive the same monotonic iteration from
   `tile_sequence * num_k_blocks + k_block_idx`.
2. Review `w8a8_block_fp8_bmm_kernel` for the typed pipe ownership and field
   mapping: the pipe owns the stage lifecycle; the two partitions retain the
   existing TMA load, WGMMA math, scaling, and output store paths.
3. Review `_get_tle_w8a8_block_fp8_bmm_configs` and the tuner filter for the
   bounded stage set `(4, 8)`.
4. Review `test_tle_fp8_einsum_persistent_pipe_stage8` for the persistent-CTA
   regression that forces matched stage-4 and stage-8 configurations.
5. Treat `fp8_einsum.py` and `benchmark/test_fp8_einsum.py` as unchanged caller
   and benchmark surfaces. `w8a8_block_fp8_matmul.py` is a separate non-batched
   operator and is intentionally outside this PR.

## Supported contract

| Surface | This PR |
|---|---|
| Optimized path | Existing NVIDIA Hopper TLE `w8a8_block_fp8_bmm` path |
| Pipeline depths | Stages 4 and 8 |
| Exactness | Stage 8 is bitwise equal to stage 4 on all four tested Flash/Pro shapes |
| Fallback | Existing general kernel remains selected when the required typed TLE pipe / warp-specialization APIs are unavailable |
| Unchanged | FP8 math, WGMMA tile geometry, scaling, split-K path, general path, output layout, and public `fp8_einsum` API |
| Not enabled | Stage 6, pending an independent FlagTree memory-descriptor/lowering fix |

### Issue

Direct follow-up to #4794; operator context originates from #3297.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is covered by a focused UT.

## Validation

### H20 correctness and activation

Current PR head is `ba9cffa261a4f41842da1c8acbcdc0307db2a9ca`.
The branch was rebased onto `b831bc1e6e5cdafc890e032e991b6326149fcac3`
without changing the feature diff or either modified file. H20 gates therefore
remain component-exact to the current kernel and test bytes; local repository
checks were rerun on the current head.

| Gate | Result | What it proves |
|---|---|---|
| Focused `test_tle_fp8_einsum_persistent_pipe_stage8` | `1 passed` | The stage-8 persistent pipe executes and is bitwise equal to forced stage 4 on `pro_b1` |
| Cross-shape stage 8 vs. stage 4 | `4/4` bitwise equal, max abs `0.0` | Covers Flash/Pro with token batch `b=1/4` |
| Four-way compile/call oracle | Pre-fix stage 4, this PR stage 4, and this PR stage 8 are each bitwise equal to matched Gluon stage 8, max abs `0.0` | Uses an independent implementation oracle rather than relying only on stage-4/stage-8 self-consistency |
| Four-way timed-output audit | `16/16` outputs bitwise equal to Gluon stage 8, max abs `0.0` | Admits every pre-fix TLE, current TLE, and Gluon timing process to the performance comparison |
| Timing integrity | `16/16` unique caches; each implementation occupied each Latin-square position once; GPU UUID unchanged | Rules out shared mutable compile caches, fixed ordering, fallback, and GPU-identity drift in the matched run |
| Injected pre-fix stage 8 | First call reaches CUDA launch, then synchronization reports `CUDA unspecified launch failure` | Reproduces that stage 8 is not a valid pre-fix performance baseline; no latency from this case is reported |
| Pre-commit hooks | PASS | flake8, isort, black, whitespace, and file checks passed |

Correctness is therefore checked in three layers: the focused regression forces
the persistent stage-8 path; the four-shape sweep checks stage 8 against the
known-good stage-4 path; and the H20 ablation checks both depths against the
independent Gluon full-output oracle. Every output admitted to the matched
timing table is bitwise equal to that oracle.

Cross-shape dimensions:

| Case | `b` | `h` | `r` | `d` |
|---|---:|---:|---:|---:|
| Flash b1 | 1 | 8 | 4096 | 1024 |
| Flash b4 | 4 | 8 | 4096 | 1024 |
| Pro b1 | 1 | 16 | 7168 | 1024 |
| Pro b4 | 4 | 16 | 7168 | 1024 |

## Performance

Two baselines answer different reviewer questions. The exact PR parent at
`b831bc1e6e5cdafc890e032e991b6326149fcac3` supplies the best-valid pre-fix TLE
path at stage 4. The Gluon stage-8 kernel from merged PR #3297 tests whether the
repaired endpoint is competitive with the previous operator implementation.

**Evidence boundary:** operator-level current-commit evidence for one H20 shape
and the fixed `w4/tile0` configurations below; this is not a complete product
benchmark.

### H20 matched best-valid stage qualification

Setup: NVIDIA H20, `pro_b1=(b=1,h=16,r=7168,d=1024)`,
four fresh processes per implementation, 30 warmup iterations and 200 CUDA
Graph samples per process. A four-way Latin square makes each implementation
occupy each execution position once. Every process used a unique compile cache,
the same FlagTree `11e9e3415c5d2f0f986b8acf500ebeb51f810ce4` build, and the
same `libtriton.so` SHA-256. The table reports the median of the four
per-process average latencies.

The candidate base contains #5438, so it does not register the problematic
`empty.memory_format` implementation. The older #3297 Gluon snapshot predates
that registration entirely. The timing runner also preallocates the output,
passes it directly to `w8a8_block_fp8_bmm`, and does not call
`flag_gems.enable()` or `only_enable()`. The paired result is therefore not
asymmetrically affected by the `torch.empty` registration bug.

| Implementation | Role | CUDA Graph latency | Relative to pre-fix TLE stage 4 |
|---|---|---:|---:|
| Pre-fix TLE stage 4 | Best valid before this PR | `0.0429271 ms` | `1.00000x` |
| This PR, TLE stage 4 | Same-stage negative control | `0.0425855 ms` | `0.99204x` (`0.80%` lower) |
| This PR, TLE stage 8 | Repaired endpoint | `0.0381119 ms` | `0.88783x` (`11.22%` lower) |
| Gluon stage 8 | External competitive baseline | `0.0379599 ms` | `0.88429x` |

| Transition | Ratio | Result | Attribution |
|---|---:|---:|---|
| Pre-fix TLE stage 4 -> this PR stage 4 | `0.99204x` | `0.80%` lower | Inside the `3%` noise band: same-stage no-regression evidence |
| This PR stage 4 -> this PR stage 8 | `0.89495x` | `10.50%` lower | Attributable to the deeper pipeline on byte-identical current source |
| Pre-fix best-valid stage 4 -> this PR stage 8 | `0.88783x` | `11.22%` lower | Primary representative-row stage win enabled by this PR |
| Gluon stage 8 -> this PR stage 8 | `1.00400x` | `0.40%` higher | Inside the `3%` noise band: competitive parity, not a stable win or regression |

The primary `11.22%` result is outside the pre-registered `3%` noise band, so
the four balanced base processes complete this representative-row stage gate
without escalation. The pre-fix stage-8 diagnostic is invalid at runtime and
is not timed; stage 4 is therefore the honest best-valid pre-fix endpoint.

An earlier independent five-process stage-8-only run sampled this PR `1.78%`
below Gluon, while this balanced four-way run samples it `0.40%` above Gluon.
Both deltas are inside the same `3%` band, so the retained conclusion is
TLE/Gluon parity for this shape rather than a stable compiler-backend win.

<details>
<summary><strong>Four-process matched CUDA Graph averages</strong> — absolute values used for the medians</summary>

| Replica | Pre-fix TLE s4 (ms) | This PR TLE s4 (ms) | This PR TLE s8 (ms) | Gluon s8 (ms) |
|---:|---:|---:|---:|---:|
| 0 | 0.04302176 | 0.04224960 | 0.03785488 | 0.03809840 |
| 1 | 0.04283248 | 0.04245200 | 0.03836896 | 0.03782144 |
| 2 | 0.04275648 | 0.04271904 | 0.03762448 | 0.03823888 |
| 3 | 0.04329616 | 0.04272832 | 0.03868432 | 0.03779984 |

</details>

## Files changed

- `src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py`
  — typed pipe lifecycle, persistent generation, and bounded stage selection.
- `tests/test_fp8_einsum.py`
  — forced-config stage-8 persistent-pipe regression.

Related but unchanged:

- `src/flag_gems/runtime/backend/_nvidia/hopper/ops/fp8_einsum.py`
  — public operator wrapper that maps `bhr,hdr->bhd` to the BMM path.
- `benchmark/test_fp8_einsum.py`
  — existing FlagGems-vs-DeepGEMM benchmark harness; used as operator context,
  not modified by this PR.
- `src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_matmul.py`
  — separate non-batched matmul implementation; not on the `fp8_einsum` call
  path and not part of this change.

## Known limits

- Performance is closed only for the representative `pro_b1/w4/s8/tile0`
  configuration. The cross-shape gate proves correctness, not performance.
- The `11.22%` primary result compares the best-valid pre-fix stage 4 with the
  repaired current stage 8. The same-stage control remains within the noise
  band, and pre-fix stage 8 cannot provide a valid timing baseline.
- Current TLE stage 8 and Gluon stage 8 are within the `3%` noise band; this PR
  does not claim a stable backend win over Gluon.
- Stage 6 is intentionally still excluded. Enabling it requires a separate
  FlagTree fix and independent tuning evidence.
- This PR does not change the split-K or general fallback kernels.
