### PR TITLE
fix(grouped_topk): compute selection scores in float32

### DIFF
--- a/src/flag_gems/fused/grouped_topk.py
+++ b/src/flag_gems/fused/grouped_topk.py
@@ -30,8 +30,8 @@ def topk_with_k2_triton(
     n_group,
     stride_scores_token,
     stride_group_scores_token,
+    scoring_func: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
-    INPUT_DTYPE: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -48,34 +48,32 @@ def topk_with_k2_triton(
         scores_ptr + scores_offset + lane,
         mask=mask,
         other=-float("inf"),
-    )
+    ).to(tl.float32)
 
     b = tl.load(
         bias_ptr + bias_offset + lane,
         mask=mask,
         other=0.0,
-    )
+    ).to(tl.float32)
 
-    x = x + b
+    if scoring_func == 1:
+        x = tl.sigmoid(x)
 
-    x_f32 = x.to(tl.float32)
+    x = tl.where(mask, x + b, -float("inf"))
 
-    max1 = tl.max(x_f32, axis=0)
-    is_max1 = (x_f32 == max1) & mask
+    max1 = tl.max(x, axis=0)
+    is_max1 = (x == max1) & mask
     count_max1 = tl.sum(is_max1.to(tl.int32), axis=0)
 
     x2 = tl.where(
         is_max1 & (count_max1 == 1),
         -float("inf"),
-        x_f32,
+        x,
     )
     max2 = tl.max(x2, axis=0)
 
     group_scores_offset = token_id * stride_group_scores_token + group_id
-    tl.store(
-        group_scores_ptr + group_scores_offset,
-        (max1 + max2).to(INPUT_DTYPE),
-    )
+    tl.store(group_scores_ptr + group_scores_offset, max1 + max2)
 
 
 @triton.jit
@@ -92,6 +90,7 @@ def group_idx_and_topk_triton(
     num_experts,
     num_experts_per_group,
     routed_scaling_factor,
+    scoring_func: tl.constexpr,
     stride_scores_token,
     stride_group_scores_token,
     stride_out_token,
@@ -100,7 +99,6 @@ def group_idx_and_topk_triton(
     TOPK: tl.constexpr,
     BLOCK_GROUP: tl.constexpr,
     BLOCK_EXPERT: tl.constexpr,
-    INPUT_DTYPE: tl.constexpr,
     renormalize: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -116,18 +114,15 @@ def group_idx_and_topk_triton(
         group_scores_ptr + pid * stride_group_scores_token + group_offsets,
         mask=valid_group,
         other=neg_inf,
-    )
+    ).to(tl.float32)
 
-    group_scores_f32 = group_scores.to(tl.float32)
-    is_finite = (group_scores_f32 == group_scores_f32) & (
-        group_scores_f32 != float("inf")
-    )
-    group_scores_f32 = tl.where(is_finite & valid_group, group_scores_f32, neg_inf)
+    is_finite = (group_scores == group_scores) & (group_scores != float("inf"))
+    group_scores = tl.where(is_finite & valid_group, group_scores, neg_inf)
 
-    max_group_score = tl.max(group_scores_f32, axis=0)
+    max_group_score = tl.max(group_scores, axis=0)
     if_proceed = max_group_score != neg_inf
 
-    value = group_scores_f32
+    value = group_scores
     target_num_min = BLOCK_GROUP - n_group + topk_group
     count_equal_to_top_value = BLOCK_GROUP - n_group
     pre_count_equal_to_top_value = 0
@@ -152,8 +147,8 @@ def group_idx_and_topk_triton(
 
     num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value
 
-    group_gt = group_scores_f32 > topk_group_value
-    group_eq = group_scores_f32 == topk_group_value
+    group_gt = group_scores > topk_group_value
+    group_eq = group_scores == topk_group_value
 
     eq_i = group_eq.to(tl.int32)
     prefix_eq = tl.cumsum(eq_i, axis=0) - eq_i
@@ -171,23 +166,26 @@ def group_idx_and_topk_triton(
         tl.sum((expert_in_group & group_selected[None, :]).to(tl.int32), axis=1) > 0
     ) & valid_expert
 
-    scored = tl.load(
+    raw_scores = tl.load(
         scores_ptr + pid * stride_scores_token + expert_offsets,
         mask=expert_selected,
         other=neg_inf,
-    )
+    ).to(tl.float32)
 
     expert_bias = tl.load(
         bias_ptr + expert_offsets,
         mask=valid_expert,
         other=0.0,
-    )
+    ).to(tl.float32)
 
-    selection_scores_native = scored + expert_bias
+    if scoring_func == 1:
+        scored = tl.sigmoid(raw_scores)
+    else:
+        scored = raw_scores
 
     selection_scores = tl.where(
         expert_selected,
-        selection_scores_native.to(tl.float32),
+        scored + expert_bias,
         neg_inf,
     )
 
@@ -207,6 +205,9 @@ def group_idx_and_topk_triton(
             mask=selected_idx < num_experts,
             other=neg_inf,
         ).to(tl.float32)
+
+        if scoring_func == 1:
+            selected_score = tl.sigmoid(selected_score)
 
         topk_vals = tl.where(pos_range == i, selected_score, topk_vals)
         topk_idx = tl.where(pos_range == i, selected_idx.to(tl.int32), topk_idx)
@@ -277,14 +278,6 @@ def grouped_topk(
     if scores.dtype not in (torch.float32, torch.float16, torch.bfloat16):
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
 
-    scores_f32 = scores.float()
-    bias_f32 = bias.float()
-
-    if scoring_func == 1:
-        scores_processed = torch.sigmoid(scores_f32)
-    else:
-        scores_processed = scores_f32
-
     group_scores = torch.empty(
         (num_tokens, n_group),
         device=scores.device,
@@ -307,15 +300,15 @@ def grouped_topk(
     grid1 = (num_tokens * n_group,)
 
     topk_with_k2_triton[grid1](
-        scores_processed,
-        bias_f32,
+        scores,
+        bias,
         group_scores,
         num_experts_per_group,
         n_group,
-        scores_processed.stride(0),
+        scores.stride(0),
         group_scores.stride(0),
+        scoring_func,
         BLOCK_SIZE=BLOCK1,
-        INPUT_DTYPE=tl.float32,
     )
 
     BLOCK_GROUP = triton.next_power_of_2(n_group)
@@ -323,11 +316,11 @@ def grouped_topk(
     grid2 = (num_tokens,)
 
     group_idx_and_topk_triton[grid2](
-        scores_processed,
+        scores,
         group_scores,
         topk_values,
         topk_indices,
-        bias_f32,
+        bias,
         num_tokens,
         n_group,
         topk_group,
@@ -335,7 +328,8 @@ def grouped_topk(
         num_experts,
         num_experts_per_group,
         routed_scaling_factor,
-        scores_processed.stride(0),
+        scoring_func,
+        scores.stride(0),
         group_scores.stride(0),
         topk_values.stride(0),
         N_GROUP=n_group,
@@ -343,7 +337,6 @@ def grouped_topk(
         TOPK=topk,
         BLOCK_GROUP=BLOCK_GROUP,
         BLOCK_EXPERT=BLOCK_EXPERT,
-        INPUT_DTYPE=tl.float32,
         renormalize=int(renormalize),
     )
 

--- a/src/flag_gems/fused/grouped_topk.py
+++ b/src/flag_gems/fused/grouped_topk.py
@@ -265,8 +265,6 @@ def grouped_topk(
     if scoring_func not in (0, 1):
         raise ValueError("scoring_func must be 0 (none) or 1 (sigmoid)")
 
-    if bias.dtype != scores.dtype:
-        bias = bias.to(scores.dtype)
     if bias.ndim != 1:
         bias = bias.flatten()
     if len(bias) != num_experts:
@@ -276,24 +274,21 @@ def grouped_topk(
 
     num_experts_per_group = num_experts // n_group
 
-    if scores.dtype == torch.float32:
-        INPUT_DTYPE = tl.float32
-    elif scores.dtype == torch.float16:
-        INPUT_DTYPE = tl.float16
-    elif scores.dtype == torch.bfloat16:
-        INPUT_DTYPE = tl.bfloat16
-    else:
+    if scores.dtype not in (torch.float32, torch.float16, torch.bfloat16):
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
 
+    scores_f32 = scores.float()
+    bias_f32 = bias.float()
+
     if scoring_func == 1:
-        scores_processed = torch.sigmoid(scores.float()).to(scores.dtype)
+        scores_processed = torch.sigmoid(scores_f32)
     else:
-        scores_processed = scores
+        scores_processed = scores_f32
 
     group_scores = torch.empty(
         (num_tokens, n_group),
         device=scores.device,
-        dtype=scores.dtype,
+        dtype=torch.float32,
     )
 
     topk_values = torch.empty(
@@ -313,14 +308,14 @@ def grouped_topk(
 
     topk_with_k2_triton[grid1](
         scores_processed,
-        bias,
+        bias_f32,
         group_scores,
         num_experts_per_group,
         n_group,
         scores_processed.stride(0),
         group_scores.stride(0),
         BLOCK_SIZE=BLOCK1,
-        INPUT_DTYPE=INPUT_DTYPE,
+        INPUT_DTYPE=tl.float32,
     )
 
     BLOCK_GROUP = triton.next_power_of_2(n_group)
@@ -332,7 +327,7 @@ def grouped_topk(
         group_scores,
         topk_values,
         topk_indices,
-        bias,
+        bias_f32,
         num_tokens,
         n_group,
         topk_group,
@@ -348,7 +343,7 @@ def grouped_topk(
         TOPK=topk,
         BLOCK_GROUP=BLOCK_GROUP,
         BLOCK_EXPERT=BLOCK_EXPERT,
-        INPUT_DTYPE=INPUT_DTYPE,
+        INPUT_DTYPE=tl.float32,
         renormalize=int(renormalize),
     )
 

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/grouped_topk.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/grouped_topk.py
@@ -280,8 +280,6 @@ def grouped_topk(
     if scoring_func not in (0, 1):
         raise ValueError("scoring_func must be 0 (none) or 1 (sigmoid)")
 
-    if bias.dtype != scores.dtype:
-        bias = bias.to(scores.dtype)
     if bias.ndim != 1:
         bias = bias.flatten()
     if len(bias) != num_experts:
@@ -291,19 +289,16 @@ def grouped_topk(
 
     num_experts_per_group = num_experts // n_group
 
-    if scores.dtype == torch.float32:
-        INPUT_DTYPE = tl.float32
-    elif scores.dtype == torch.float16:
-        INPUT_DTYPE = tl.float16
-    elif scores.dtype == torch.bfloat16:
-        INPUT_DTYPE = tl.bfloat16
-    else:
+    if scores.dtype not in (torch.float32, torch.float16, torch.bfloat16):
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
+
+    scores_f32 = scores.float()
+    bias_f32 = bias.float()
 
     group_scores = torch.empty(
         (num_tokens, n_group),
         device=scores.device,
-        dtype=scores.dtype,
+        dtype=torch.float32,
     )
 
     topk_values = torch.empty(
@@ -322,16 +317,16 @@ def grouped_topk(
     grid1 = (num_tokens * n_group,)
 
     topk_with_k2_triton[grid1](
-        scores,
-        bias,
+        scores_f32,
+        bias_f32,
         group_scores,
         num_experts_per_group,
         n_group,
-        scores.stride(0),
+        scores_f32.stride(0),
         group_scores.stride(0),
         scoring_func,
         BLOCK_SIZE=BLOCK1,
-        INPUT_DTYPE=INPUT_DTYPE,
+        INPUT_DTYPE=tl.float32,
     )
 
     BLOCK_GROUP = triton.next_power_of_2(n_group)
@@ -339,11 +334,11 @@ def grouped_topk(
     grid2 = (num_tokens,)
 
     group_idx_and_topk_triton[grid2](
-        scores,
+        scores_f32,
         group_scores,
         topk_values,
         topk_indices,
-        bias,
+        bias_f32,
         num_tokens,
         n_group,
         topk_group,
@@ -352,7 +347,7 @@ def grouped_topk(
         num_experts_per_group,
         routed_scaling_factor,
         scoring_func,
-        scores.stride(0),
+        scores_f32.stride(0),
         group_scores.stride(0),
         topk_values.stride(0),
         N_GROUP=n_group,
@@ -360,7 +355,7 @@ def grouped_topk(
         TOPK=topk,
         BLOCK_GROUP=BLOCK_GROUP,
         BLOCK_EXPERT=BLOCK_EXPERT,
-        INPUT_DTYPE=INPUT_DTYPE,
+        INPUT_DTYPE=tl.float32,
         renormalize=int(renormalize),
     )
 

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/grouped_topk.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/grouped_topk.py
@@ -15,7 +15,6 @@
 import torch
 import triton
 import triton.language as tl
-from triton.language.extra.cuda import libdevice
 
 
 @triton.jit
@@ -29,7 +28,6 @@ def topk_with_k2_triton(
     stride_group_scores_token,
     scoring_func: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
-    INPUT_DTYPE: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -46,39 +44,32 @@ def topk_with_k2_triton(
         scores_ptr + scores_offset + lane,
         mask=mask,
         other=-float("inf"),
-    )
+    ).to(tl.float32)
 
     b = tl.load(
         bias_ptr + bias_offset + lane,
         mask=mask,
         other=0.0,
-    )
+    ).to(tl.float32)
 
     if scoring_func == 1:
-        x_f32 = x.to(tl.float32)
-        x_f32 = 0.5 * libdevice.tanh(0.5 * x_f32) + 0.5
-        x = x_f32.to(INPUT_DTYPE)
+        x = tl.sigmoid(x)
 
-    x = x + b
+    x = tl.where(mask, x + b, -float("inf"))
 
-    x_f32 = x.to(tl.float32)
-
-    max1 = tl.max(x_f32, axis=0)
-    is_max1 = (x_f32 == max1) & mask
+    max1 = tl.max(x, axis=0)
+    is_max1 = (x == max1) & mask
     count_max1 = tl.sum(is_max1.to(tl.int32), axis=0)
 
     x2 = tl.where(
         is_max1 & (count_max1 == 1),
         -float("inf"),
-        x_f32,
+        x,
     )
     max2 = tl.max(x2, axis=0)
 
     group_scores_offset = token_id * stride_group_scores_token + group_id
-    tl.store(
-        group_scores_ptr + group_scores_offset,
-        (max1 + max2).to(INPUT_DTYPE),
-    )
+    tl.store(group_scores_ptr + group_scores_offset, max1 + max2)
 
 
 @triton.jit
@@ -104,7 +95,6 @@ def group_idx_and_topk_triton(
     TOPK: tl.constexpr,
     BLOCK_GROUP: tl.constexpr,
     BLOCK_EXPERT: tl.constexpr,
-    INPUT_DTYPE: tl.constexpr,
     renormalize: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -120,18 +110,15 @@ def group_idx_and_topk_triton(
         group_scores_ptr + pid * stride_group_scores_token + group_offsets,
         mask=valid_group,
         other=neg_inf,
-    )
+    ).to(tl.float32)
 
-    group_scores_f32 = group_scores.to(tl.float32)
-    is_finite = (group_scores_f32 == group_scores_f32) & (
-        group_scores_f32 != float("inf")
-    )
-    group_scores_f32 = tl.where(is_finite & valid_group, group_scores_f32, neg_inf)
+    is_finite = (group_scores == group_scores) & (group_scores != float("inf"))
+    group_scores = tl.where(is_finite & valid_group, group_scores, neg_inf)
 
-    max_group_score = tl.max(group_scores_f32, axis=0)
+    max_group_score = tl.max(group_scores, axis=0)
     if_proceed = max_group_score != neg_inf
 
-    value = group_scores_f32
+    value = group_scores
     target_num_min = BLOCK_GROUP - n_group + topk_group
     count_equal_to_top_value = BLOCK_GROUP - n_group
     pre_count_equal_to_top_value = 0
@@ -156,8 +143,8 @@ def group_idx_and_topk_triton(
 
     num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value
 
-    group_gt = group_scores_f32 > topk_group_value
-    group_eq = group_scores_f32 == topk_group_value
+    group_gt = group_scores > topk_group_value
+    group_eq = group_scores == topk_group_value
 
     eq_i = group_eq.to(tl.int32)
     prefix_eq = tl.cumsum(eq_i, axis=0) - eq_i
@@ -179,26 +166,22 @@ def group_idx_and_topk_triton(
         scores_ptr + pid * stride_scores_token + expert_offsets,
         mask=expert_selected,
         other=neg_inf,
-    )
+    ).to(tl.float32)
 
     expert_bias = tl.load(
         bias_ptr + expert_offsets,
         mask=valid_expert,
         other=0.0,
-    )
+    ).to(tl.float32)
 
     if scoring_func == 1:
-        scored_f32 = raw_scores.to(tl.float32)
-        scored_f32 = 0.5 * libdevice.tanh(0.5 * scored_f32) + 0.5
-        scored = scored_f32.to(INPUT_DTYPE)
+        scored = tl.sigmoid(raw_scores)
     else:
         scored = raw_scores
 
-    selection_scores_native = scored + expert_bias
-
     selection_scores = tl.where(
         expert_selected,
-        selection_scores_native.to(tl.float32),
+        scored + expert_bias,
         neg_inf,
     )
 
@@ -220,7 +203,7 @@ def group_idx_and_topk_triton(
         ).to(tl.float32)
 
         if scoring_func == 1:
-            selected_score = 0.5 * libdevice.tanh(0.5 * selected_raw) + 0.5
+            selected_score = tl.sigmoid(selected_raw)
         else:
             selected_score = selected_raw
 
@@ -292,9 +275,6 @@ def grouped_topk(
     if scores.dtype not in (torch.float32, torch.float16, torch.bfloat16):
         raise ValueError(f"Unsupported dtype: {scores.dtype}")
 
-    scores_f32 = scores.float()
-    bias_f32 = bias.float()
-
     group_scores = torch.empty(
         (num_tokens, n_group),
         device=scores.device,
@@ -317,16 +297,15 @@ def grouped_topk(
     grid1 = (num_tokens * n_group,)
 
     topk_with_k2_triton[grid1](
-        scores_f32,
-        bias_f32,
+        scores,
+        bias,
         group_scores,
         num_experts_per_group,
         n_group,
-        scores_f32.stride(0),
+        scores.stride(0),
         group_scores.stride(0),
         scoring_func,
         BLOCK_SIZE=BLOCK1,
-        INPUT_DTYPE=tl.float32,
     )
 
     BLOCK_GROUP = triton.next_power_of_2(n_group)
@@ -334,11 +313,11 @@ def grouped_topk(
     grid2 = (num_tokens,)
 
     group_idx_and_topk_triton[grid2](
-        scores_f32,
+        scores,
         group_scores,
         topk_values,
         topk_indices,
-        bias_f32,
+        bias,
         num_tokens,
         n_group,
         topk_group,
@@ -347,7 +326,7 @@ def grouped_topk(
         num_experts_per_group,
         routed_scaling_factor,
         scoring_func,
-        scores_f32.stride(0),
+        scores.stride(0),
         group_scores.stride(0),
         topk_values.stride(0),
         N_GROUP=n_group,
@@ -355,7 +334,6 @@ def grouped_topk(
         TOPK=topk,
         BLOCK_GROUP=BLOCK_GROUP,
         BLOCK_EXPERT=BLOCK_EXPERT,
-        INPUT_DTYPE=tl.float32,
         renormalize=int(renormalize),
     )
 

--- a/tests/test_grouped_topk.py
+++ b/tests/test_grouped_topk.py
@@ -199,6 +199,36 @@ def test_grouped_topk_large_scale(
 @pytest.mark.grouped_topk
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
 @pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("scoring_func", [0, 1])
+def test_grouped_topk_bfloat16_selection_precision(scoring_func):
+    scores = torch.full((1, 64), -4.0, dtype=torch.bfloat16, device=flag_gems.device)
+    scores[0, :8] = -1.0
+    scores[0, :2] = 1.0
+
+    bias = torch.zeros(64, dtype=torch.bfloat16, device=flag_gems.device)
+    # This bias only breaks the expert 0/1 tie when addition is performed in FP32.
+    bias[1] = 2**-10
+
+    ref_weights, ref_ids = vllm_grouped_topk(
+        scores, 8, 1, 1, False, 1.0, bias, scoring_func
+    )
+    res_weights, res_ids = flag_gems.grouped_topk(
+        scores, 8, 1, 1, False, 1.0, bias, scoring_func
+    )
+
+    utils.gems_assert_equal(res_ids, utils.to_reference(ref_ids))
+    atol, rtol = get_tolerance(torch.bfloat16, scoring_func, False)
+    torch.testing.assert_close(
+        utils.to_reference(res_weights),
+        utils.to_reference(ref_weights),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+@pytest.mark.grouped_topk
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 2.5])
 @pytest.mark.parametrize("renormalize", [True, False])
 def test_grouped_topk_scaling_factor(routed_scaling_factor, renormalize):


### PR DESCRIPTION
### PR Category

Operator, OP Test, Benchmark

### Type of Change

Bug Fix, Performance Optimization

### Description

- Load scores and correction bias as float32 inside both the generic and NVIDIA Hopper Triton kernels.
- Keep sigmoid, group scores, group selection, and expert selection in float32, then cast only final weights to the requested output dtype.
- Re-mask padded experts after sigmoid so non-power-of-two group sizes cannot affect selection.
- Add a deterministic BF16 public-API regression whose expert tie is resolved only when bias addition occurs in float32.

BF16 rounding previously changed close score ordering before group and expert selection. The follow-up keeps the precision fix inside the fused kernels, avoiding host-side casts and sigmoid temporary tensors.

This is a rebased replacement for #4244. Credit to @tengqm for the original investigation and cross-platform validation.

Validation on NVIDIA H20 (PyTorch 2.11.0+cu130, Triton 3.6.0, vLLM 0.21.0):

- unmodified implementation, large-scale cases: 6 failed and 10 passed; all failures used BF16;
- complete `tests/test_grouped_topk.py`: 220 passed;
- generic and Hopper checks across scoring modes and renormalization: zero index/value mismatches against the FP32 reference;
- `git diff --check`, Black, isort, Flake8, and pre-commit checks passed.

### Issue

- Resolves #4245

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

Seven-run H20 medians with BF16, 64 experts, and 32/64 tokens showed no regression:

- generic path without sigmoid: within measurement noise (-0.96% to +0.63% GPU time);
- generic path with sigmoid: about 48% lower GPU time and 33% lower wall time;
- Hopper path: 5.8-9.3% lower GPU time and 2.4-5.5% lower wall time across all measured cases.
