### PR TITLE
fix(linear): support non-contiguous activations

### DIFF
--- a/src/flag_gems/ops/linear.py
+++ b/src/flag_gems/ops/linear.py
@@ -155,7 +155,7 @@ def linear(input, weight, bias=None):
     N = weight.shape[0]  # out_features
 
     # Flatten input: (*, K) -> (M, K)
-    input_flat = input.view(M, K)
+    input_flat = input.reshape(M, K)
 
     # Ensure weight is contiguous and properly shaped
     weight = weight.contiguous()

--- a/src/flag_gems/ops/linear_backward.py
+++ b/src/flag_gems/ops/linear_backward.py
@@ -70,8 +70,8 @@ def linear_backward(
         batch_size *= dim
 
     # Flatten batch dimensions
-    input_flat = input.view(batch_size, in_features).contiguous()
-    grad_output_flat = grad_output.view(batch_size, out_features).contiguous()
+    input_flat = input.reshape(batch_size, in_features).contiguous()
+    grad_output_flat = grad_output.reshape(batch_size, out_features).contiguous()
 
     grad_input = None
     grad_weight = None

--- a/src/flag_gems/runtime/backend/_enflame/gcu300/ops/linear.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu300/ops/linear.py
@@ -155,7 +155,7 @@ def linear(input, weight, bias=None):
     N = weight.shape[0]  # out_features
 
     # Flatten input: (*, K) -> (M, K)
-    input_flat = input.view(M, K)
+    input_flat = input.reshape(M, K)
 
     # Ensure weight is contiguous and properly shaped
     weight = weight.contiguous()

--- a/src/flag_gems/runtime/backend/_enflame/gcu400/ops/linear.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu400/ops/linear.py
@@ -155,7 +155,7 @@ def linear(input, weight, bias=None):
     N = weight.shape[0]  # out_features
 
     # Flatten input: (*, K) -> (M, K)
-    input_flat = input.view(M, K)
+    input_flat = input.reshape(M, K)
 
     # Ensure weight is contiguous and properly shaped
     weight = weight.contiguous()

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/linear.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/linear.py
@@ -132,7 +132,7 @@ def linear(input, weight, bias=None):
     K = input.shape[-1]
     N = weight.shape[0]
 
-    input_flat = input.view(M, K)
+    input_flat = input.reshape(M, K)
     weight = weight.contiguous()
     output = torch.empty((M, N), device=input.device, dtype=input.dtype)
 

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/linear.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/linear.py
@@ -132,7 +132,7 @@ def linear(input, weight, bias=None):
     K = input.shape[-1]
     N = weight.shape[0]
 
-    input_flat = input.reshape(M, K)
+    input_flat = input.view(M, K)
     weight = weight.contiguous()
     output = torch.empty((M, N), device=input.device, dtype=input.dtype)
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -113,6 +113,10 @@ def test_linear_3d_with_bias(dtype):
 
 
 @pytest.mark.linear
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "iluvatar",
+    reason="Issue #5379: Iluvatar override requires separate vendor validation",
+)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.parametrize("with_bias", [False, True])
 def test_linear_3d_noncontiguous(dtype, with_bias):
@@ -141,8 +145,7 @@ def test_linear_3d_noncontiguous(dtype, with_bias):
     ref_bias = utils.to_reference(bias, True)
 
     ref_out = torch.nn.functional.linear(ref_input, ref_weight, ref_bias)
-    with flag_gems.use_gems():
-        res_out = torch.nn.functional.linear(input_tensor, weight, bias)
+    res_out = flag_gems.linear(input_tensor, weight, bias)
 
     utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=in_features)
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -114,6 +114,41 @@ def test_linear_3d_with_bias(dtype):
 
 @pytest.mark.linear
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_linear_3d_noncontiguous(dtype, with_bias):
+    batch_size = 2
+    sequence_length = 16
+    in_features = 64
+    out_features = 32
+
+    input_tensor = torch.randn(
+        (batch_size, in_features, sequence_length),
+        dtype=dtype,
+        device=flag_gems.device,
+    ).transpose(1, 2)
+    weight = torch.randn(
+        (out_features, in_features), dtype=dtype, device=flag_gems.device
+    )
+    bias = (
+        torch.randn((out_features,), dtype=dtype, device=flag_gems.device)
+        if with_bias
+        else None
+    )
+    assert not input_tensor.is_contiguous()
+
+    ref_input = utils.to_reference(input_tensor, True)
+    ref_weight = utils.to_reference(weight, True)
+    ref_bias = utils.to_reference(bias, True)
+
+    ref_out = torch.nn.functional.linear(ref_input, ref_weight, ref_bias)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.linear(input_tensor, weight, bias)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=in_features)
+
+
+@pytest.mark.linear
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_linear_1d_with_bias(dtype):
     if flag_gems.vendor_name == "tsingmicro" and dtype == torch.float32:
         pytest.skip("Issue #2834: Skipping fp32 linear test on tsingmicro platform")

--- a/tests/test_linear_backward.py
+++ b/tests/test_linear_backward.py
@@ -27,6 +27,13 @@ LINEAR_SHAPES = [
     (32, 128),
 ]
 LINEAR_OUT_FEATURES = [32, 64, 128, 256]
+NONCONTIGUOUS_OPERANDS = ["input", "grad_output", "both"]
+OUTPUT_MASKS = [
+    (True, True, True),
+    (True, False, False),
+    (False, True, False),
+    (False, False, True),
+]
 
 
 @pytest.mark.linear_backward
@@ -63,6 +70,74 @@ def test_linear_backward(batch, in_features, out_features, dtype):
     utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
     utils.gems_assert_close(res_grad_weight, ref_grad_weight, dtype)
     utils.gems_assert_close(res_grad_bias, ref_grad_bias, dtype)
+
+
+@pytest.mark.linear_backward
+@pytest.mark.parametrize("noncontiguous_operand", NONCONTIGUOUS_OPERANDS)
+@pytest.mark.parametrize("output_mask", OUTPUT_MASKS)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_linear_backward_3d_noncontiguous(noncontiguous_operand, output_mask, dtype):
+    batch_size = 2
+    sequence_length = 8
+    in_features = 16
+    out_features = 32
+
+    if noncontiguous_operand in ("input", "both"):
+        input_tensor = torch.randn(
+            (batch_size, in_features, sequence_length),
+            dtype=dtype,
+            device=flag_gems.device,
+        ).transpose(1, 2)
+        assert not input_tensor.is_contiguous()
+    else:
+        input_tensor = torch.randn(
+            (batch_size, sequence_length, in_features),
+            dtype=dtype,
+            device=flag_gems.device,
+        )
+
+    if noncontiguous_operand in ("grad_output", "both"):
+        grad_output = torch.randn(
+            (batch_size, out_features, sequence_length),
+            dtype=dtype,
+            device=flag_gems.device,
+        ).transpose(1, 2)
+        assert not grad_output.is_contiguous()
+    else:
+        grad_output = torch.randn(
+            (batch_size, sequence_length, out_features),
+            dtype=dtype,
+            device=flag_gems.device,
+        )
+
+    weight = torch.randn(
+        (out_features, in_features), dtype=dtype, device=flag_gems.device
+    )
+
+    ref_input = utils.to_reference(input_tensor, True)
+    ref_grad_output = utils.to_reference(grad_output, True)
+    ref_weight = utils.to_reference(weight, True)
+    ref_grad_input = ref_grad_output @ ref_weight if output_mask[0] else None
+    ref_grad_weight = (
+        ref_grad_output.reshape(-1, out_features).t()
+        @ ref_input.reshape(-1, in_features)
+        if output_mask[1]
+        else None
+    )
+    ref_grad_bias = ref_grad_output.sum(dim=(0, 1)) if output_mask[2] else None
+
+    with flag_gems.use_gems():
+        result = torch.ops.aten.linear_backward(
+            input_tensor, grad_output, weight, output_mask
+        )
+
+    for actual, expected in zip(
+        result, (ref_grad_input, ref_grad_weight, ref_grad_bias)
+    ):
+        if expected is None:
+            assert actual is None
+        else:
+            utils.gems_assert_close(actual, expected, dtype)
 
 
 @pytest.mark.linear_backward

--- a/tests/test_linear_backward.py
+++ b/tests/test_linear_backward.py
@@ -73,6 +73,10 @@ def test_linear_backward(batch, in_features, out_features, dtype):
 
 
 @pytest.mark.linear_backward
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "iluvatar",
+    reason="Issue #5379: Iluvatar path requires separate vendor validation",
+)
 @pytest.mark.parametrize("noncontiguous_operand", NONCONTIGUOUS_OPERANDS)
 @pytest.mark.parametrize("output_mask", OUTPUT_MASKS)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
@@ -126,10 +130,7 @@ def test_linear_backward_3d_noncontiguous(noncontiguous_operand, output_mask, dt
     )
     ref_grad_bias = ref_grad_output.sum(dim=(0, 1)) if output_mask[2] else None
 
-    with flag_gems.use_gems():
-        result = torch.ops.aten.linear_backward(
-            input_tensor, grad_output, weight, output_mask
-        )
+    result = flag_gems.linear_backward(input_tensor, grad_output, weight, output_mask)
 
     for actual, expected in zip(
         result, (ref_grad_input, ref_grad_weight, ref_grad_bias)


### PR DESCRIPTION
### PR Category

Operator, OP Test

### Type of Change

Bug Fix

### Description

- Use `reshape` instead of `view` when flattening external Linear inputs in the common forward implementation.
- Reshape input and grad_output before making them contiguous in the common backward implementation.
- Update the Enflame GCU300/GCU400 forward paths reported by the issue.
- Add public-API non-contiguous rank-3 forward and backward coverage, with Iluvatar explicitly skipped because its separate override is outside this PR's scope and requires vendor validation.

The previous wrappers called `view` on user-provided tensors before `contiguous`. Transposed rank-3 activations and incoming gradients can have valid layouts that cannot be represented by that 2-D view, so the wrapper raised before reaching the kernel. `reshape` keeps a zero-copy view when possible and materializes correctly ordered storage only when required.

Validation:

- H20 non-contiguous public-API matrix: 42 passed (6 forward and 36 backward);
- public APIs versus the prior `use_gems` paths: 42 equivalent cases across three dtypes, bias modes, non-contiguous operands, and four output masks;
- complete forward/backward files before the scope-only follow-up: 246 passed;
- Black, isort, Flake8, pre-commit, and `git diff --check` passed.

The current Enflame CI failure occurs while importing `torch_gcu`, before test collection: `/opt/triton_gcu/utils/gcu.cpp` is missing from the runner. No Linear test reaches the changed code.

### Issue

- Resolves #5379

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

This is a correctness fix. Contiguous/view-compatible inputs preserve the zero-copy path; only incompatible non-contiguous layouts require materialization.
