### PR TITLE
[Cambricon] Fix complex dtype issues in div and mul test cases

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/utils/pointwise_dynamic.py
+++ b/src/flag_gems/runtime/backend/_cambricon/utils/pointwise_dynamic.py
@@ -1839,7 +1839,9 @@ class PointwiseDynamicFunction:
             else:
                 a = a.to(torch.float32)
                 cdtype = torch.complex64
-            return torch.complex(a, torch.zeros_like(a)).to(cdtype)
+            # Use view_as_real/view_as_complex to avoid torch.complex which falls back to CPU
+            real_imag = torch.stack([a, torch.zeros_like(a)], dim=-1)
+            return torch.view_as_complex(real_imag).to(cdtype)
         elif isinstance(a, complex):
             return torch.tensor(a, dtype=target_dtype, device=device)
         elif isinstance(a, (int, float)):

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -337,18 +337,26 @@ def test_div_complex_complex(shape, complex_dtype):
     inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
     inp2 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
 
-    ref_inp1 = utils.to_reference(inp1, True)
-    ref_inp2 = utils.to_reference(inp2, True)
+    # mthreads and cambricon MLU have issues with complex division on device.
+    # mthreads: returns incorrect results for complex / complex.
+    # cambricon: type promotion error for complex types.
+    # Also, mthreads does not support torch.isclose for complex types on device.
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        # CPU doesn't support complex32, so convert to complex64 first
+        if complex_dtype == torch.complex32:
+            ref_out = torch.div(inp1.to("cpu").to(torch.complex64), inp2.to("cpu").to(torch.complex64)).to(torch.complex32)
+        else:
+            ref_out = torch.div(inp1.to("cpu"), inp2.to("cpu")).to(dtype=complex_dtype)
+    else:
+        ref_inp1 = utils.to_reference(inp1, True)
+        ref_inp2 = utils.to_reference(inp2, True)
+        ref_out = torch.div(ref_inp1, ref_inp2)
 
-    ref_out = torch.div(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.div(inp1, inp2)
 
-    # mthreads does not support torch.isclose for complex types on device,
-    # so move to CPU before comparison.
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
-        ref_out = ref_out.to("cpu")
     utils.gems_assert_close(res_out, ref_out, complex_dtype, equal_nan=True)
 
 
@@ -383,8 +391,13 @@ def test_div_complex_float_tensor(shape, complex_dtype):
     # mthreads native torch.div returns incorrect results for complex / float,
     # so compute ref on CPU to get correct baseline.
     # Also, mthreads does not support torch.isclose for complex types on device.
-    if flag_gems.vendor_name == "mthreads":
-        ref_out = torch.div(inp1.to("cpu"), inp2.to("cpu")).to(dtype=complex_dtype)
+    # cambricon MLU does not support type promotion for complex / float division.
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        # CPU doesn't support complex32, so convert to complex64 first
+        if complex_dtype == torch.complex32:
+            ref_out = torch.div(inp1.to("cpu").to(torch.complex64), inp2.to("cpu").to(torch.float32)).to(torch.complex32)
+        else:
+            ref_out = torch.div(inp1.to("cpu"), inp2.to("cpu")).to(dtype=complex_dtype)
     else:
         ref_inp1 = utils.to_reference(inp1, True)
         ref_inp2 = utils.to_reference(inp2, True)
@@ -393,7 +406,7 @@ def test_div_complex_float_tensor(shape, complex_dtype):
     with flag_gems.use_gems():
         res_out = torch.div(inp1, inp2)
 
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
     utils.gems_assert_close(res_out, ref_out, complex_dtype, equal_nan=True)
 
@@ -420,8 +433,13 @@ def test_div_tensor_int(shape, complex_dtype):
     # mthreads native torch.div returns incorrect results for complex / int,
     # so compute ref on CPU to get correct baseline.
     # Also, mthreads does not support torch.isclose for complex types on device.
-    if flag_gems.vendor_name == "mthreads":
-        ref_out = torch.div(inp1.to("cpu"), inp2.to("cpu")).to(dtype=complex_dtype)
+    # cambricon MLU does not support type promotion for complex / int division.
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        # CPU doesn't support complex32, so convert to complex64 first
+        if complex_dtype == torch.complex32:
+            ref_out = torch.div(inp1.to("cpu").to(torch.complex64), inp2.to("cpu")).to(torch.complex32)
+        else:
+            ref_out = torch.div(inp1.to("cpu"), inp2.to("cpu")).to(dtype=complex_dtype)
     else:
         ref_inp1 = utils.to_reference(inp1, True)
         ref_inp2 = utils.to_reference(inp2, True)
@@ -430,7 +448,7 @@ def test_div_tensor_int(shape, complex_dtype):
     with flag_gems.use_gems():
         res_out = torch.div(inp1, inp2)
 
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
     utils.gems_assert_close(res_out, ref_out, complex_dtype, equal_nan=True)
 
@@ -452,16 +470,23 @@ def test_div_complex_int_scalar(shape, complex_dtype):
     inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
     inp2 = 3
 
-    ref_inp1 = utils.to_reference(inp1, True)
-    ref_inp2 = inp2
+    # cambricon MLU does not support type promotion for complex / int scalar division.
+    if flag_gems.vendor_name == "cambricon":
+        if complex_dtype == torch.complex32:
+            ref_out = torch.div(inp1.to("cpu").to(torch.complex64), inp2).to(torch.complex32)
+        else:
+            ref_out = torch.div(inp1.to("cpu"), inp2)
+    else:
+        ref_inp1 = utils.to_reference(inp1, True)
+        ref_inp2 = inp2
+        ref_out = torch.div(ref_inp1, ref_inp2)
 
-    ref_out = torch.div(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.div(inp1, inp2)
 
     # mthreads does not support torch.isclose for complex types on device,
     # so move to CPU before comparison.
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
         ref_out = ref_out.to("cpu")
     utils.gems_assert_close(res_out, ref_out, complex_dtype, equal_nan=True)

--- a/tests/test_mul.py
+++ b/tests/test_mul.py
@@ -169,18 +169,23 @@ def test_mul_complex_complex(shape, complex_dtype):
     inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
     inp2 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
 
-    ref_inp1 = utils.to_reference(inp1, True)
-    ref_inp2 = utils.to_reference(inp2, True)
+    # cambricon MLU does not support comparing complex32 tensors on device.
+    if flag_gems.vendor_name == "cambricon":
+        if complex_dtype == torch.complex32:
+            ref_out = torch.mul(inp1.to("cpu").to(torch.complex64), inp2.to("cpu").to(torch.complex64)).to(torch.complex32)
+        else:
+            ref_out = torch.mul(inp1.to("cpu"), inp2.to("cpu"))
+    else:
+        ref_inp1 = utils.to_reference(inp1, True)
+        ref_inp2 = utils.to_reference(inp2, True)
+        ref_out = torch.mul(ref_inp1, ref_inp2)
 
-    ref_out = torch.mul(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.mul(inp1, inp2)
 
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        res_out = res_out.to("cpu")
     if flag_gems.vendor_name == "cambricon" and complex_dtype == torch.complex32:
-        from .accuracy_utils import to_cpu
-
-        res_out = to_cpu(res_out, ref_out)
-        ref_out = ref_out.to(complex_dtype)
         torch.testing.assert_close(res_out, ref_out, atol=5e-3, rtol=2e-3)
     else:
         utils.gems_assert_close(res_out, ref_out, complex_dtype)
@@ -212,21 +217,22 @@ def test_mul_complex_float_tensor(shape, complex_dtype):
 
     inp2 = torch.randn(shape, dtype=float_dtype, device=flag_gems.device)
 
-    # mthreads torch.mul unsupport complex x float.
-    if flag_gems.vendor_name == "mthreads":
-        ref_inp1 = inp1.to("cpu")
-        ref_inp2 = inp2.to("cpu")
+    # mthreads/cambricon does not support complex x float type promotion.
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        if complex_dtype == torch.complex32:
+            ref_out = torch.mul(inp1.to("cpu").to(torch.complex64), inp2.to("cpu").to(torch.float32)).to(torch.complex32)
+        else:
+            ref_out = torch.mul(inp1.to("cpu"), inp2.to("cpu"))
     else:
         ref_inp1 = utils.to_reference(inp1, True)
         ref_inp2 = utils.to_reference(inp2, True)
+        ref_out = torch.mul(ref_inp1, ref_inp2)
 
-    ref_out = torch.mul(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.mul(inp1, inp2)
 
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
-        ref_out = ref_out.to(complex_dtype)
     utils.gems_assert_close(res_out, ref_out, complex_dtype)
 
 
@@ -248,21 +254,22 @@ def test_mul_complex_int_tensor(shape, complex_dtype):
     inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
     inp2 = torch.randint(10, 20, shape, device=flag_gems.device)
 
-    # mthreads torch.mul unsupport complex x int.
-    if flag_gems.vendor_name == "mthreads":
-        ref_inp1 = inp1.to("cpu")
-        ref_inp2 = inp2.to("cpu")
+    # mthreads/cambricon does not support complex x int type promotion.
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        if complex_dtype == torch.complex32:
+            ref_out = torch.mul(inp1.to("cpu").to(torch.complex64), inp2.to("cpu")).to(torch.complex32)
+        else:
+            ref_out = torch.mul(inp1.to("cpu"), inp2.to("cpu"))
     else:
         ref_inp1 = utils.to_reference(inp1, True)
         ref_inp2 = utils.to_reference(inp2, True)
+        ref_out = torch.mul(ref_inp1, ref_inp2)
 
-    ref_out = torch.mul(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.mul(inp1, inp2)
 
-    if flag_gems.vendor_name == "mthreads":
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
         res_out = res_out.to("cpu")
-        ref_out = ref_out.to(complex_dtype)
     utils.gems_assert_close(res_out, ref_out, complex_dtype)
 
 
@@ -284,11 +291,20 @@ def test_mul_complex_int_scalar(shape, complex_dtype):
     inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
     inp2 = 3
 
-    ref_inp1 = utils.to_reference(inp1, True)
-    ref_inp2 = inp2
+    # cambricon MLU does not support type promotion for complex x int scalar.
+    if flag_gems.vendor_name == "cambricon":
+        if complex_dtype == torch.complex32:
+            ref_out = torch.mul(inp1.to("cpu").to(torch.complex64), inp2).to(torch.complex32)
+        else:
+            ref_out = torch.mul(inp1.to("cpu"), inp2)
+    else:
+        ref_inp1 = utils.to_reference(inp1, True)
+        ref_out = torch.mul(ref_inp1, inp2)
 
-    ref_out = torch.mul(ref_inp1, ref_inp2)
     with flag_gems.use_gems():
         res_out = torch.mul(inp1, inp2)
 
+    if flag_gems.vendor_name in ("mthreads", "cambricon"):
+        res_out = res_out.to("cpu")
+        ref_out = ref_out.to("cpu") if ref_out.device.type != "cpu" else ref_out
     utils.gems_assert_close(res_out, ref_out, complex_dtype)


### PR DESCRIPTION
### PR Category
Operator | OP Test

### Type of Change
Bug Fix

### Description
  **Problem**

  The Cambricon MLU native PyTorch backend has the following limitations that cause multiple complex-related test cases in test_div and test_mul to fail:

  1. No complex/real type promotion: torch.div(complex_tensor, real_tensor) and torch.mul(complex_tensor, real_tensor) on MLU raise RuntimeError: MLU div/mul Can't get a promote dtype when common dtype is ComplexFloat
  2. Triton does not support complex dtype canonicalization: torch.complex() triggers Triton's canonicalize_dtype, which raises KeyError: 'complex64'
  3. No complex32 comparison on device: calling torch.isclose / torch.testing.assert_close on complex32 tensors on MLU raises RuntimeError: Comparing

  **Changes**

  1. src/flag_gems/runtime/backend/_cambricon/utils/pointwise_dynamic.py

  Replace torch.complex(a, torch.zeros_like(a)) with torch.stack([a, torch.zeros_like(a)], dim=-1) + torch.view_as_complex() in _to_complex_tensor to avoid triggering Triton's unsupported complex dtype canonicalization.

  2. tests/test_div.py

  - test_div_complex_complex: compute reference on CPU; upcast complex32 to complex64 before computation
  - test_div_complex_float_tensor: same
  - test_div_tensor_int: same
  - test_div_complex_int_scalar: same
  - Move res_out to CPU before comparison for all complex test cases

  3. tests/test_mul.py

  - test_mul_complex_complex: compute reference on CPU; relax tolerance for complex32 (atol=5e-3, rtol=2e-3)
  - test_mul_complex_float_tensor: compute reference on CPU; upcast complex32 to complex64
  - test_mul_complex_int_tensor: same
  - test_mul_complex_int_scalar: same
  - Move res_out to CPU before comparison for all complex test cases

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [✔ ] Change is fully covered by a UT.

### Performance
mul test

```
tests/test_mul.py ................................................................................................................................................................................................................................                      [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
../../../usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2: FutureWarning: `torch_mlu.utils.model_transfer` is deprecated. Please use `torch_mlu.utils.gpu_migration` instead.
    warnings.warn("`torch_mlu.utils.model_transfer` is deprecated. "

src/flag_gems/utils/libentry.py:411: 2 warnings
tests/test_mul.py: 12 warnings
  /data/changsu/FlagGems/src/flag_gems/utils/libentry.py:411: RuntimeWarning: active Triton backend does not provide a replay benchmarker; falling back to event timing
    resolved_benchmark = resolve_benchmarker(

../../../usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250
  /usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250: UserWarning: The PyTorch API of nested tensors is in prototype stage and will change in the near future. We recommend specifying layout=torch.jagged when constructing a nested tensor, as this layout receives active development, has better operator coverage, and works with torch.compile. (Triggered internally at /pytorch/aten/src/ATen/NestedTensorImpl.cpp:178.)
    return _nested.nested_tensor(

tests/test_has_compatible_shallow_copy_type.py:56
  /data/changsu/FlagGems/tests/test_has_compatible_shallow_copy_type.py:56: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)
    "sparse_csr": base.to_sparse_csr(),

tests/test_mul.py::test_mul_complex_complex[complex_dtype0-shape0]
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/gpu_migration/migration.py:592: UserWarning: ComplexHalf support is experimental and many operators don't support it yet. (Triggered internally at /pytorch/aten/src/ATen/EmptyTensor.cpp:57.)
    return fn(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================= 224 passed, 56660 deselected, 18 warnings in 34.98s =============================================================================================================
```

div_tensor test

```
tests/test_div.py ..............................................................................................................................                                                                                                                        [ 87%]
tests/test_true_divide.py ..................                                                                                                                                                                                                                            [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
../../../usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2: FutureWarning: `torch_mlu.utils.model_transfer` is deprecated. Please use `torch_mlu.utils.gpu_migration` instead.
    warnings.warn("`torch_mlu.utils.model_transfer` is deprecated. "

src/flag_gems/utils/libentry.py:411: 2 warnings
tests/test_div.py: 10 warnings
  /data/changsu/FlagGems/src/flag_gems/utils/libentry.py:411: RuntimeWarning: active Triton backend does not provide a replay benchmarker; falling back to event timing
    resolved_benchmark = resolve_benchmarker(

../../../usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250
  /usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250: UserWarning: The PyTorch API of nested tensors is in prototype stage and will change in the near future. We recommend specifying layout=torch.jagged when constructing a nested tensor, as this layout receives active development, has better operator coverage, and works with torch.compile. (Triggered internally at /pytorch/aten/src/ATen/NestedTensorImpl.cpp:178.)
    return _nested.nested_tensor(

tests/test_has_compatible_shallow_copy_type.py:56
  /data/changsu/FlagGems/tests/test_has_compatible_shallow_copy_type.py:56: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)
    "sparse_csr": base.to_sparse_csr(),

tests/test_div.py::test_div_complex_complex[complex_dtype0-shape0]
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/gpu_migration/migration.py:592: UserWarning: ComplexHalf support is experimental and many operators don't support it yet. (Triggered internally at /pytorch/aten/src/ATen/EmptyTensor.cpp:57.)
    return fn(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================= 144 passed, 56740 deselected, 16 warnings in 30.57s =============================================================================================================
```

div_scalar test

```
tests/test_div.py ......................................................................................                                                                                                                                                                [ 37%]
tests/test_true_divide.py ................................................................................................................................................                                                                                              [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
../../../usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/model_transfer/__init__.py:2: FutureWarning: `torch_mlu.utils.model_transfer` is deprecated. Please use `torch_mlu.utils.gpu_migration` instead.
    warnings.warn("`torch_mlu.utils.model_transfer` is deprecated. "

src/flag_gems/utils/libentry.py:411
src/flag_gems/utils/libentry.py:411
tests/test_div.py::test_div_scalar_tensor[dtype0-0.001-shape0]
tests/test_div.py::test_div_complex_int_scalar[complex_dtype0-shape0]
tests/test_div.py::test_div_complex_int_scalar[complex_dtype0-shape2]
tests/test_div.py::test_div_complex_int_scalar[complex_dtype0-shape3]
tests/test_div.py::test_div_complex_int_scalar[complex_dtype0-shape4]
tests/test_true_divide.py::test_true_divide_tensor_scalar[dtype0-0.001-shape0]
  /data/changsu/FlagGems/src/flag_gems/utils/libentry.py:411: RuntimeWarning: active Triton backend does not provide a replay benchmarker; falling back to event timing
    resolved_benchmark = resolve_benchmarker(

../../../usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250
  /usr/local/lib/python3.10/dist-packages/torch/nested/__init__.py:250: UserWarning: The PyTorch API of nested tensors is in prototype stage and will change in the near future. We recommend specifying layout=torch.jagged when constructing a nested tensor, as this layout receives active development, has better operator coverage, and works with torch.compile. (Triggered internally at /pytorch/aten/src/ATen/NestedTensorImpl.cpp:178.)
    return _nested.nested_tensor(

tests/test_has_compatible_shallow_copy_type.py:56
  /data/changsu/FlagGems/tests/test_has_compatible_shallow_copy_type.py:56: UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues. (Triggered internally at /pytorch/aten/src/ATen/SparseCsrTensorImpl.cpp:53.)
    "sparse_csr": base.to_sparse_csr(),

tests/test_div.py::test_div_complex_int_scalar[complex_dtype0-shape0]
  /usr/local/lib/python3.10/dist-packages/torch_mlu/utils/gpu_migration/migration.py:592: UserWarning: ComplexHalf support is experimental and many operators don't support it yet. (Triggered internally at /pytorch/aten/src/ATen/EmptyTensor.cpp:57.)
    return fn(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================= 230 passed, 56654 deselected, 12 warnings in 23.53s =============================================================================================================
```

