### PR TITLE
[KMCompiler][Ascend] Add ascend backend for replication_pad2d_backward

### DIFF
--- a/benchmark/test_replication_pad2d_backward.py
+++ b/benchmark/test_replication_pad2d_backward.py
@@ -1,7 +1,15 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base, consts
+from .conftest import Config
+
+VENDOR = flag_gems.vendor_name
+
+if VENDOR == "ascend":
+    Config.mode = consts.BenchMode.OPERATOR
 
 REPLICATION_PAD2D_BACKWARD_SHAPES = [
     (1, 3, 256, 256),

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -87,6 +87,10 @@ from .pow import (
 )
 from .randperm import randperm
 from .repeat_interleave import repeat_interleave_self_int
+from .replication_pad2d_backward import (
+    replication_pad2d_backward,
+    replication_pad2d_backward_grad_input,
+)
 from .resolve_neg import resolve_neg
 from .rms_norm import rms_norm
 from .scatter import scatter, scatter_
@@ -208,6 +212,8 @@ __all__ = [
     "pow_tensor_tensor_",
     "randperm",
     "repeat_interleave_self_int",
+    "replication_pad2d_backward",
+    "replication_pad2d_backward_grad_input",
     "resolve_neg",
     "rms_norm",
     "scatter",

--- a/src/flag_gems/runtime/backend/_ascend/ops/replication_pad2d_backward.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/replication_pad2d_backward.py
@@ -1,0 +1,411 @@
+import logging
+import os
+from contextlib import nullcontext
+
+import torch
+import triton
+import triton.language as tl
+from torch_npu._C import _npu_getCurrentRawStream
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+TILE_BYTES = 64 * 1024
+TILE_FP32_CAP = 64 * 1024
+
+
+@triton.jit
+def _backward_gather_kernel(
+    gop,
+    gip,
+    CO,
+    OH,
+    OW,
+    H,
+    W,
+    PL: tl.constexpr,
+    PR: tl.constexpr,
+    PT: tl.constexpr,
+    PB: tl.constexpr,
+    R: tl.constexpr,
+    WN: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    n_row_blocks = (H + R - 1) // R
+    nc = CO + pid // n_row_blocks
+    ih0 = (pid % n_row_blocks) * R
+    c_out = nc * OH * OW
+    c_in = nc * H * W
+
+    rr = ih0 + tl.arange(0, R)
+    iw = tl.arange(0, WN)
+    col_mask = iw < W
+    valid = (rr < H)[:, None] & col_mask[None, :]
+
+    # interior tile
+    acc = tl.load(
+        gop + c_out + (rr + PT)[:, None] * OW + (PL + iw)[None, :],
+        mask=valid,
+        other=0.0,
+    )
+    tl.store(gip + c_in + rr[:, None] * W + iw[None, :], acc, mask=valid)
+
+    # boundary row fix-ups: rows 0 and H-1 also sum the pad rows
+    if ih0 == 0:
+        row = tl.load(gop + c_out + PT * OW + (PL + iw), mask=col_mask, other=0.0).to(
+            tl.float32
+        )
+        for r in range(PT):
+            row += tl.load(gop + c_out + r * OW + (PL + iw), mask=col_mask, other=0.0)
+        if H == 1:
+            for r in range(PB):
+                row += tl.load(
+                    gop + c_out + (OH - PB + r) * OW + (PL + iw),
+                    mask=col_mask,
+                    other=0.0,
+                )
+        tl.store(gip + c_in + iw, row, mask=col_mask)
+    if (ih0 + R > H - 1) and (H > 1):
+        ih_last = H - 1
+        row = tl.load(
+            gop + c_out + (ih_last + PT) * OW + (PL + iw), mask=col_mask, other=0.0
+        ).to(tl.float32)
+        for r in range(PB):
+            row += tl.load(
+                gop + c_out + (OH - PB + r) * OW + (PL + iw),
+                mask=col_mask,
+                other=0.0,
+            )
+        tl.store(gip + c_in + ih_last * W + iw, row, mask=col_mask)
+
+    # boundary column fix-ups: main col + pad cols; rows covered by the row
+    # fix-ups or the corner kernel are excluded from the overwrite
+    if PT == 0:
+        if PB == 0:
+            col_row_mask = rr < H
+        else:
+            col_row_mask = rr < (H - 1)
+    else:
+        if PB == 0:
+            col_row_mask = rr > 0
+        else:
+            col_row_mask = (rr > 0) & (rr < (H - 1))
+    if PL > 0:
+        col_sum = tl.load(
+            gop + c_out + (rr + PT)[:, None] * OW + PL,
+            mask=(rr < H)[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        for c in range(PL):
+            col_sum += tl.load(
+                gop + c_out + (rr + PT)[:, None] * OW + c,
+                mask=(rr < H)[:, None],
+                other=0.0,
+            ).to(tl.float32)
+        if W == 1:
+            # both edges collapse onto column 0: fold the right pad cols in
+            for c in range(PR):
+                col_sum += tl.load(
+                    gop + c_out + (rr + PT)[:, None] * OW + (W + PL + c),
+                    mask=(rr < H)[:, None],
+                    other=0.0,
+                ).to(tl.float32)
+        tl.store(gip + c_in + rr[:, None] * W, col_sum, mask=col_row_mask[:, None])
+    if PR > 0:
+        if W > 1:
+            col_sum = tl.load(
+                gop + c_out + (rr + PT)[:, None] * OW + (W - 1 + PL),
+                mask=(rr < H)[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            for c in range(PR):
+                col_sum += tl.load(
+                    gop + c_out + (rr + PT)[:, None] * OW + (W + PL + c),
+                    mask=(rr < H)[:, None],
+                    other=0.0,
+                ).to(tl.float32)
+            tl.store(
+                gip + c_in + rr[:, None] * W + (W - 1),
+                col_sum,
+                mask=col_row_mask[:, None],
+            )
+        elif PL == 0:
+            # W == 1 with no left pad: column 0 is the right edge
+            col_sum = tl.load(
+                gop + c_out + (rr + PT)[:, None] * OW + (W - 1 + PL),
+                mask=(rr < H)[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            for c in range(PR):
+                col_sum += tl.load(
+                    gop + c_out + (rr + PT)[:, None] * OW + (W + PL + c),
+                    mask=(rr < H)[:, None],
+                    other=0.0,
+                ).to(tl.float32)
+            tl.store(gip + c_in + rr[:, None] * W, col_sum, mask=col_row_mask[:, None])
+
+
+@triton.jit
+def _corner_kernel(
+    gop,
+    gip,
+    OH,
+    OW,
+    H,
+    W,
+    PL: tl.constexpr,
+    PR: tl.constexpr,
+    PT: tl.constexpr,
+    PB: tl.constexpr,
+):
+    # patches the four corner elements; all-scalar, kept separate from the
+    # wide-vector main kernel (see the note above)
+    nc = ext.program_id(0)
+    c_out = nc * OH * OW
+    c_in = nc * H * W
+
+    # top-left (0, 0)
+    if ((PL > 0) or (PT > 0)) or (((H == 1) and (PB > 0)) or ((W == 1) and (PR > 0))):
+        v = tl.load(gop + c_out + PT * OW + PL).to(tl.float32)
+        for c in range(PL):
+            v += tl.load(gop + c_out + PT * OW + c)
+        for r in range(PT):
+            v += tl.load(gop + c_out + r * OW + PL)
+            for c in range(PL):
+                v += tl.load(gop + c_out + r * OW + c)
+        if H == 1:
+            for r in range(PB):
+                v += tl.load(gop + c_out + (OH - PB + r) * OW + PL)
+                for c in range(PL):
+                    v += tl.load(gop + c_out + (OH - PB + r) * OW + c)
+        if W == 1:
+            for c in range(PR):
+                v += tl.load(gop + c_out + PT * OW + (W + PL + c))
+                for r in range(PT):
+                    v += tl.load(gop + c_out + r * OW + (W + PL + c))
+            if H == 1:
+                for c in range(PR):
+                    for r in range(PB):
+                        v += tl.load(gop + c_out + (OH - PB + r) * OW + (W + PL + c))
+        tl.store(gip + c_in, v)
+
+    # top-right (0, W-1); folded into top-left when W == 1
+    if (W > 1) and (((PR > 0) or (PT > 0)) or ((H == 1) and (PB > 0))):
+        v = tl.load(gop + c_out + PT * OW + (W - 1 + PL)).to(tl.float32)
+        for c in range(PR):
+            v += tl.load(gop + c_out + PT * OW + (W + PL + c))
+        for r in range(PT):
+            v += tl.load(gop + c_out + r * OW + (W - 1 + PL))
+            for c in range(PR):
+                v += tl.load(gop + c_out + r * OW + (W + PL + c))
+        if H == 1:
+            for r in range(PB):
+                v += tl.load(gop + c_out + (OH - PB + r) * OW + (W - 1 + PL))
+                for c in range(PR):
+                    v += tl.load(gop + c_out + (OH - PB + r) * OW + (W + PL + c))
+        tl.store(gip + c_in + (W - 1), v)
+
+    # bottom-left (H-1, 0); folded into top-left when H == 1
+    if H > 1 and PB > 0:
+        v = tl.load(gop + c_out + (H - 1 + PT) * OW + PL).to(tl.float32)
+        for c in range(PL):
+            v += tl.load(gop + c_out + (H - 1 + PT) * OW + c)
+        for r in range(PB):
+            v += tl.load(gop + c_out + (OH - PB + r) * OW + PL)
+            for c in range(PL):
+                v += tl.load(gop + c_out + (OH - PB + r) * OW + c)
+        if W == 1:
+            for c in range(PR):
+                v += tl.load(gop + c_out + (H - 1 + PT) * OW + (W + PL + c))
+                for r in range(PB):
+                    v += tl.load(gop + c_out + (OH - PB + r) * OW + (W + PL + c))
+        tl.store(gip + c_in + (H - 1) * W, v)
+
+    # bottom-right (H-1, W-1); folded into the above when H == 1 or W == 1
+    if ((H > 1) and (W > 1)) and ((PB > 0) and (PR > 0)):
+        v = tl.load(gop + c_out + (H - 1 + PT) * OW + (W - 1 + PL)).to(tl.float32)
+        for c in range(PR):
+            v += tl.load(gop + c_out + (H - 1 + PT) * OW + (W + PL + c))
+        for r in range(PB):
+            v += tl.load(gop + c_out + (OH - PB + r) * OW + (W - 1 + PL))
+            for c in range(PR):
+                v += tl.load(gop + c_out + (OH - PB + r) * OW + (W + PL + c))
+        tl.store(gip + c_in + (H - 1) * W + (W - 1), v)
+
+
+def _has_edges(pl, pr, pt, pb):
+    return pl > 0 or pr > 0 or pt > 0 or pb > 0
+
+
+_fast_launch_cache = {}
+_plan_cache = {}
+_BINDER_MEMO_SIZE = 4
+_binder_memo = {}
+
+
+def _arg_sig(runtime_args):
+    sig = []
+    for a in runtime_args:
+        if isinstance(a, torch.Tensor):
+            sig.append((a.dtype, a.data_ptr()))
+        else:
+            sig.append((type(a).__name__, a))
+    return tuple(sig)
+
+
+def _fast_launch(jit_fn, grid, constexpr_args, runtime_args, device=None):
+    if device is None:
+        device = torch_device_fn.current_device()
+    all_args = runtime_args + tuple(constexpr_args)
+    # The fast path relies on triton-fork internals (binder, compiled-kernel
+    # cache); fall back to the plain python launch where they differ.
+    if not hasattr(jit_fn, "binder"):
+        jit_fn[grid](*all_args)
+        return
+    try:
+        debug_val = os.environ.get("TRITON_DEBUG", "0") == "1"
+        if jit_fn.binder is None:
+            jit_fn[grid](*all_args)
+        memo_key = (debug_val, constexpr_args, _arg_sig(runtime_args))
+        slot = _binder_memo.get(id(jit_fn))
+        if slot is None:
+            slot = {}
+            _binder_memo[id(jit_fn)] = slot
+        jit_key = slot.get(memo_key)
+        if jit_key is None:
+            (
+                _,
+                sig_and_spec,
+                constexpr_vals,
+                _,
+                excess_kwargs,
+            ) = jit_fn.binder(*all_args, debug=debug_val)
+            jit_key = "".join(sig_and_spec) + str((constexpr_vals, excess_kwargs))
+            if len(slot) >= _BINDER_MEMO_SIZE:
+                slot.pop(next(iter(slot)))  # evict the oldest entry
+            slot[memo_key] = jit_key
+        entry = _fast_launch_cache.get(jit_key)
+        if entry is None:
+            # one normal launch populates the jit's compiled-kernel cache
+            jit_fn[grid](*all_args)
+            compiled = jit_fn.cache[device][jit_key]
+            run = compiled.run  # triggers _init_handles: loads the binary once
+            entry = (run, compiled.function, compiled.packed_metadata)
+            _fast_launch_cache[jit_key] = entry
+        run, fn, pm = entry
+        stream = _npu_getCurrentRawStream(device)
+        run(grid[0], 1, 1, stream, fn, pm, None, None, None, *runtime_args)
+    except Exception:
+        jit_fn[grid](*all_args)
+
+
+def _replication_pad2d_backward_impl(
+    grad_output: torch.Tensor, self: torch.Tensor, padding, *, out: torch.Tensor = None
+) -> torch.Tensor:
+    if isinstance(padding, torch.Tensor):
+        padding = tuple(padding.tolist())
+    if isinstance(padding, int):
+        pad_left = pad_right = pad_top = pad_bottom = padding
+    elif isinstance(padding, (tuple, list)):
+        if len(padding) != 4:
+            raise ValueError(
+                "padding must be a sequence of 4 integers: "
+                "(pad_left, pad_right, pad_top, pad_bottom)"
+            )
+        pad_left, pad_right, pad_top, pad_bottom = map(int, padding)
+    else:
+        raise TypeError(f"Unexpected padding type: {type(padding)}")
+
+    if pad_left < 0 or pad_right < 0 or pad_top < 0 or pad_bottom < 0:
+        raise ValueError("Padding values must be non-negative")
+
+    is_3d = self.ndim == 3
+    if is_3d:
+        C, H, W = self.shape
+        N = 1
+        grad_output_4d = grad_output.contiguous().view(1, C, *grad_output.shape[-2:])
+    elif self.ndim == 4:
+        N, C, H, W = self.shape
+        grad_output_4d = grad_output.contiguous()
+    else:
+        raise ValueError("replication_pad2d_backward expects 3D or 4D input")
+
+    OH = H + pad_top + pad_bottom
+    OW = W + pad_left + pad_right
+
+    if not _has_edges(pad_left, pad_right, pad_top, pad_bottom):
+        result = grad_output_4d.to(self.dtype)
+        if is_3d:
+            result = result.view(C, H, W)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    device = self.device
+    dev_idx = (
+        device.index if device.index is not None else torch_device_fn.current_device()
+    )
+    if out is None:
+        out = torch.empty_strided(
+            (N, C, H, W),
+            (C * H * W, H * W, W, 1),
+            device=device,
+            dtype=self.dtype,
+        )
+
+    itemsize = grad_output_4d.element_size()
+    # tiling plan depends only on (H, W, itemsize, padding, dtypes)
+    _plan_key = (
+        H,
+        W,
+        itemsize,
+        (pad_left, pad_right, pad_top, pad_bottom),
+        grad_output_4d.dtype,
+        out.dtype,
+    )
+    plan = _plan_cache.get(_plan_key)
+    if plan is None:
+        w_next_pow2 = triton.next_power_of_2(W)
+        rows_per_block = max(1, min(H, TILE_BYTES // (W * itemsize)))
+        rows_per_block = min(rows_per_block, max(1, TILE_FP32_CAP // (w_next_pow2 * 4)))
+        plan = (w_next_pow2, rows_per_block)
+        _plan_cache[_plan_key] = plan
+    w_next_pow2, rows_per_block = plan
+    grid = (N * C * triton.cdiv(H, rows_per_block),)
+    if torch_device_fn.current_device() != dev_idx:
+        ctx = torch_device_fn.device(dev_idx)
+    else:
+        ctx = nullcontext()  # skip the guard on the single-device path
+    with ctx:
+        _fast_launch(
+            _backward_gather_kernel,
+            grid,
+            (pad_left, pad_right, pad_top, pad_bottom, rows_per_block, w_next_pow2),
+            (grad_output_4d, out, 0, OH, OW, H, W),
+            device=dev_idx,
+        )
+        if (pad_top > 0 or pad_bottom > 0) and (pad_left > 0 or pad_right > 0):
+            _fast_launch(
+                _corner_kernel,
+                (N * C,),
+                (pad_left, pad_right, pad_top, pad_bottom),
+                (grad_output_4d, out, OH, OW, H, W),
+                device=dev_idx,
+            )
+
+    if is_3d:
+        out = out.view(C, H, W)
+    return out
+
+
+def replication_pad2d_backward(grad_output, self, padding):
+    logger.debug("GEMS_ASCEND REPLICATION_PAD2D_BACKWARD")
+    return _replication_pad2d_backward_impl(grad_output, self, padding, out=None)
+
+
+def replication_pad2d_backward_grad_input(grad_output, self, padding, *, grad_input):
+    logger.debug("GEMS_ASCEND REPLICATION_PAD2D_BACKWARD_GRAD_INPUT")
+    return _replication_pad2d_backward_impl(grad_output, self, padding, out=grad_input)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add ascend backend for replication_pad2d_backward op.
The benchmark defaults to operator mode on Ascend via `Config.mode =
consts.BenchMode.OPERATOR` when `VENDOR == "ascend"`. Kernel mode is not used because it relies on `do_bench_npu` for timing, which currently returns NaN values when profiling this operator on the Ascend backend, making the kernel mode results unreliable.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
root@bm-ctyun-wq-910b-64g-0-13:/home/secure/qhait/FlagGems# pytest benchmark/test_replication_pad2d_backward.py -s
====================================================================== test session starts =======================================================================
platform linux -- Python 3.11.13, pytest-8.3.2, pluggy-1.6.0
rootdir: /home/secure/qhait/FlagGems
configfile: pytest.ini
plugins: xdist-3.6.1, anyio-4.10.0
collected 1 item                                                                                                                                                 

benchmark/test_replication_pad2d_backward.py 
Operator: replication_pad2d_backward  Performance Test (dtype=torch.float16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.073125            0.177979               0.411          [torch.Size([1, 3, 258, 258]), torch.Size([1, 3, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.071466            0.158668               0.450          [torch.Size([1, 3, 263, 259]), torch.Size([1, 3, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.072366            0.164353               0.440          [torch.Size([1, 3, 259, 259]), torch.Size([1, 3, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.071769            0.148468               0.483          [torch.Size([1, 3, 260, 260]), torch.Size([1, 3, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.165415            0.137115               1.206          [torch.Size([1, 3, 642, 642]), torch.Size([1, 3, 640, 640]), [1, 1, 1, 1]]
SUCCESS               0.163223            0.132842               1.229          [torch.Size([1, 3, 647, 643]), torch.Size([1, 3, 640, 640]), [1, 2, 3, 4]]
SUCCESS               0.164443            0.331822               0.496          [torch.Size([1, 3, 643, 643]), torch.Size([1, 3, 640, 640]), [3, 0, 0, 3]]
SUCCESS               0.182255            0.162572               1.121          [torch.Size([1, 3, 644, 644]), torch.Size([1, 3, 640, 640]), [2, 2, 2, 2]]
SUCCESS               0.249043            0.152868               1.629          [torch.Size([1, 3, 1026, 1026]), torch.Size([1, 3, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS               0.251820            0.128855               1.954          [torch.Size([1, 3, 1031, 1027]), torch.Size([1, 3, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS               0.248648            0.126203               1.970          [torch.Size([1, 3, 1027, 1027]), torch.Size([1, 3, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS               0.249180            0.157206               1.585          [torch.Size([1, 3, 1028, 1028]), torch.Size([1, 3, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.100490            0.156275               0.643          [torch.Size([1, 64, 130, 130]), torch.Size([1, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.100602            0.155006               0.649          [torch.Size([1, 64, 135, 131]), torch.Size([1, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.101748            0.153449               0.663          [torch.Size([1, 64, 131, 131]), torch.Size([1, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.101662            0.148341               0.685          [torch.Size([1, 64, 132, 132]), torch.Size([1, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.163905            0.152635               1.074          [torch.Size([1, 64, 258, 258]), torch.Size([1, 64, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.162821            0.136642               1.192          [torch.Size([1, 64, 263, 259]), torch.Size([1, 64, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.168001            0.150942               1.113          [torch.Size([1, 64, 259, 259]), torch.Size([1, 64, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.162768            0.148720               1.094          [torch.Size([1, 64, 260, 260]), torch.Size([1, 64, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.415370            0.201039               2.066          [torch.Size([1, 64, 514, 514]), torch.Size([1, 64, 512, 512]), [1, 1, 1, 1]]
SUCCESS               0.437780            0.230973               1.895          [torch.Size([1, 64, 519, 515]), torch.Size([1, 64, 512, 512]), [1, 2, 3, 4]]
SUCCESS               0.414301            0.157829               2.625          [torch.Size([1, 64, 515, 515]), torch.Size([1, 64, 512, 512]), [3, 0, 0, 3]]
SUCCESS               0.409583            0.227509               1.800          [torch.Size([1, 64, 516, 516]), torch.Size([1, 64, 512, 512]), [2, 2, 2, 2]]
SUCCESS               0.119878            0.145881               0.822          [torch.Size([1, 128, 66, 66]), torch.Size([1, 128, 64, 64]), [1, 1, 1, 1]]
SUCCESS               0.120008            0.151130               0.794          [torch.Size([1, 128, 71, 67]), torch.Size([1, 128, 64, 64]), [1, 2, 3, 4]]
SUCCESS               0.120539            0.140574               0.857          [torch.Size([1, 128, 67, 67]), torch.Size([1, 128, 64, 64]), [3, 0, 0, 3]]
SUCCESS               0.120400            0.142675               0.844          [torch.Size([1, 128, 68, 68]), torch.Size([1, 128, 64, 64]), [2, 2, 2, 2]]
SUCCESS               0.029288            0.139567               0.210          [torch.Size([1, 256, 34, 34]), torch.Size([1, 256, 32, 32]), [1, 1, 1, 1]]
SUCCESS               0.033089            0.145693               0.227          [torch.Size([1, 256, 39, 35]), torch.Size([1, 256, 32, 32]), [1, 2, 3, 4]]
SUCCESS               0.027473            0.138814               0.198          [torch.Size([1, 256, 35, 35]), torch.Size([1, 256, 32, 32]), [3, 0, 0, 3]]
SUCCESS               0.031508            0.145253               0.217          [torch.Size([1, 256, 36, 36]), torch.Size([1, 256, 32, 32]), [2, 2, 2, 2]]
SUCCESS               0.088473            0.139054               0.636          [torch.Size([4, 8, 258, 258]), torch.Size([4, 8, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.089760            0.140016               0.641          [torch.Size([4, 8, 263, 259]), torch.Size([4, 8, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.089202            0.166016               0.537          [torch.Size([4, 8, 259, 259]), torch.Size([4, 8, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.088858            0.137526               0.646          [torch.Size([4, 8, 260, 260]), torch.Size([4, 8, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.520182            0.425542               1.222          [torch.Size([8, 64, 130, 130]), torch.Size([8, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.519946            0.466550               1.114          [torch.Size([8, 64, 135, 131]), torch.Size([8, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.521553            0.243751               2.140          [torch.Size([8, 64, 131, 131]), torch.Size([8, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.519055            0.471160               1.102          [torch.Size([8, 64, 132, 132]), torch.Size([8, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS              22.173107            7.526288               2.946          [torch.Size([8, 128, 1026, 1026]), torch.Size([8, 128, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS              22.309065            8.411082               2.652          [torch.Size([8, 128, 1031, 1027]), torch.Size([8, 128, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS              22.939622            5.569249               4.119          [torch.Size([8, 128, 1027, 1027]), torch.Size([8, 128, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS              22.267759            8.700197               2.559          [torch.Size([8, 128, 1028, 1028]), torch.Size([8, 128, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.054431            0.335789               0.162          [torch.Size([3, 130, 130]), torch.Size([3, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.043795            0.167444               0.262          [torch.Size([3, 135, 131]), torch.Size([3, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.044238            0.159822               0.277          [torch.Size([3, 131, 131]), torch.Size([3, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.045940            0.159394               0.288          [torch.Size([3, 132, 132]), torch.Size([3, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.032004            0.149098               0.215          [torch.Size([1, 32, 3, 130]), torch.Size([1, 32, 1, 128]), [1, 1, 1, 1]]
SUCCESS               0.029926            0.150306               0.199          [torch.Size([1, 32, 8, 131]), torch.Size([1, 32, 1, 128]), [1, 2, 3, 4]]
SUCCESS               0.029475            0.147038               0.200          [torch.Size([1, 32, 4, 131]), torch.Size([1, 32, 1, 128]), [3, 0, 0, 3]]
SUCCESS               0.028351            0.142063               0.200          [torch.Size([1, 32, 5, 132]), torch.Size([1, 32, 1, 128]), [2, 2, 2, 2]]


Operator: replication_pad2d_backward  Performance Test (dtype=torch.float32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.065103            0.148467               0.439          [torch.Size([1, 3, 258, 258]), torch.Size([1, 3, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.066496            0.149184               0.446          [torch.Size([1, 3, 263, 259]), torch.Size([1, 3, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.065680            0.149403               0.440          [torch.Size([1, 3, 259, 259]), torch.Size([1, 3, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.066323            0.148245               0.447          [torch.Size([1, 3, 260, 260]), torch.Size([1, 3, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.156630            0.148481               1.055          [torch.Size([1, 3, 642, 642]), torch.Size([1, 3, 640, 640]), [1, 1, 1, 1]]
SUCCESS               0.155966            0.145937               1.069          [torch.Size([1, 3, 647, 643]), torch.Size([1, 3, 640, 640]), [1, 2, 3, 4]]
SUCCESS               0.156140            0.145715               1.072          [torch.Size([1, 3, 643, 643]), torch.Size([1, 3, 640, 640]), [3, 0, 0, 3]]
SUCCESS               0.156386            0.147109               1.063          [torch.Size([1, 3, 644, 644]), torch.Size([1, 3, 640, 640]), [2, 2, 2, 2]]
SUCCESS               0.238383            0.137870               1.729          [torch.Size([1, 3, 1026, 1026]), torch.Size([1, 3, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS               0.237437            0.138708               1.712          [torch.Size([1, 3, 1031, 1027]), torch.Size([1, 3, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS               0.237402            0.137584               1.726          [torch.Size([1, 3, 1027, 1027]), torch.Size([1, 3, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS               0.238168            0.136644               1.743          [torch.Size([1, 3, 1028, 1028]), torch.Size([1, 3, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.078756            0.141214               0.558          [torch.Size([1, 64, 130, 130]), torch.Size([1, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.078483            0.143757               0.546          [torch.Size([1, 64, 135, 131]), torch.Size([1, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.079138            0.144330               0.548          [torch.Size([1, 64, 131, 131]), torch.Size([1, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.078730            0.141424               0.557          [torch.Size([1, 64, 132, 132]), torch.Size([1, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.132712            0.138603               0.958          [torch.Size([1, 64, 258, 258]), torch.Size([1, 64, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.132245            0.133774               0.989          [torch.Size([1, 64, 263, 259]), torch.Size([1, 64, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.132479            0.135119               0.980          [torch.Size([1, 64, 259, 259]), torch.Size([1, 64, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.132676            0.137390               0.966          [torch.Size([1, 64, 260, 260]), torch.Size([1, 64, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.262042            0.188204               1.392          [torch.Size([1, 64, 514, 514]), torch.Size([1, 64, 512, 512]), [1, 1, 1, 1]]
SUCCESS               0.268910            0.217160               1.238          [torch.Size([1, 64, 519, 515]), torch.Size([1, 64, 512, 512]), [1, 2, 3, 4]]
SUCCESS               0.265058            0.137715               1.925          [torch.Size([1, 64, 515, 515]), torch.Size([1, 64, 512, 512]), [3, 0, 0, 3]]
SUCCESS               0.265601            0.209833               1.266          [torch.Size([1, 64, 516, 516]), torch.Size([1, 64, 512, 512]), [2, 2, 2, 2]]
SUCCESS               0.098282            0.137220               0.716          [torch.Size([1, 128, 66, 66]), torch.Size([1, 128, 64, 64]), [1, 1, 1, 1]]
SUCCESS               0.098396            0.139094               0.707          [torch.Size([1, 128, 71, 67]), torch.Size([1, 128, 64, 64]), [1, 2, 3, 4]]
SUCCESS               0.098955            0.134611               0.735          [torch.Size([1, 128, 67, 67]), torch.Size([1, 128, 64, 64]), [3, 0, 0, 3]]
SUCCESS               0.098573            0.137660               0.716          [torch.Size([1, 128, 68, 68]), torch.Size([1, 128, 64, 64]), [2, 2, 2, 2]]
SUCCESS               0.031622            0.134840               0.235          [torch.Size([1, 256, 34, 34]), torch.Size([1, 256, 32, 32]), [1, 1, 1, 1]]
SUCCESS               0.030828            0.136079               0.227          [torch.Size([1, 256, 39, 35]), torch.Size([1, 256, 32, 32]), [1, 2, 3, 4]]
SUCCESS               0.031122            0.134339               0.232          [torch.Size([1, 256, 35, 35]), torch.Size([1, 256, 32, 32]), [3, 0, 0, 3]]
SUCCESS               0.030739            0.134706               0.228          [torch.Size([1, 256, 36, 36]), torch.Size([1, 256, 32, 32]), [2, 2, 2, 2]]
SUCCESS               0.068781            0.140218               0.491          [torch.Size([4, 8, 258, 258]), torch.Size([4, 8, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.068221            0.141088               0.484          [torch.Size([4, 8, 263, 259]), torch.Size([4, 8, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.068160            0.144659               0.471          [torch.Size([4, 8, 259, 259]), torch.Size([4, 8, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.068379            0.141069               0.485          [torch.Size([4, 8, 260, 260]), torch.Size([4, 8, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.486475            0.366336               1.328          [torch.Size([8, 64, 130, 130]), torch.Size([8, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.475783            0.388868               1.224          [torch.Size([8, 64, 135, 131]), torch.Size([8, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.477191            0.133392               3.577          [torch.Size([8, 64, 131, 131]), torch.Size([8, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.477371            0.394279               1.211          [torch.Size([8, 64, 132, 132]), torch.Size([8, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS              11.531740            9.190893               1.255          [torch.Size([8, 128, 1026, 1026]), torch.Size([8, 128, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS              11.625648            9.781051               1.189          [torch.Size([8, 128, 1031, 1027]), torch.Size([8, 128, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS              11.577696            8.349744               1.387          [torch.Size([8, 128, 1027, 1027]), torch.Size([8, 128, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS              11.627555            9.763813               1.191          [torch.Size([8, 128, 1028, 1028]), torch.Size([8, 128, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.040079            0.156076               0.257          [torch.Size([3, 130, 130]), torch.Size([3, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.038263            0.166441               0.230          [torch.Size([3, 135, 131]), torch.Size([3, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.038697            0.150100               0.258          [torch.Size([3, 131, 131]), torch.Size([3, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.039203            0.146783               0.267          [torch.Size([3, 132, 132]), torch.Size([3, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.032400            0.133004               0.244          [torch.Size([1, 32, 3, 130]), torch.Size([1, 32, 1, 128]), [1, 1, 1, 1]]
SUCCESS               0.026309            0.132529               0.199          [torch.Size([1, 32, 8, 131]), torch.Size([1, 32, 1, 128]), [1, 2, 3, 4]]
SUCCESS               0.029757            0.134667               0.221          [torch.Size([1, 32, 4, 131]), torch.Size([1, 32, 1, 128]), [3, 0, 0, 3]]
SUCCESS               0.026846            0.132470               0.203          [torch.Size([1, 32, 5, 132]), torch.Size([1, 32, 1, 128]), [2, 2, 2, 2]]


Operator: replication_pad2d_backward  Performance Test (dtype=torch.bfloat16, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.071124            0.165917               0.429          [torch.Size([1, 3, 258, 258]), torch.Size([1, 3, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.071139            0.140799               0.505          [torch.Size([1, 3, 263, 259]), torch.Size([1, 3, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.070732            0.129708               0.545          [torch.Size([1, 3, 259, 259]), torch.Size([1, 3, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.071404            0.153286               0.466          [torch.Size([1, 3, 260, 260]), torch.Size([1, 3, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.168331            0.142330               1.183          [torch.Size([1, 3, 642, 642]), torch.Size([1, 3, 640, 640]), [1, 1, 1, 1]]
SUCCESS               0.163195            0.130190               1.254          [torch.Size([1, 3, 647, 643]), torch.Size([1, 3, 640, 640]), [1, 2, 3, 4]]
SUCCESS               0.163211            0.137978               1.183          [torch.Size([1, 3, 643, 643]), torch.Size([1, 3, 640, 640]), [3, 0, 0, 3]]
SUCCESS               0.163447            0.132671               1.232          [torch.Size([1, 3, 644, 644]), torch.Size([1, 3, 640, 640]), [2, 2, 2, 2]]
SUCCESS               0.248776            0.136740               1.819          [torch.Size([1, 3, 1026, 1026]), torch.Size([1, 3, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS               0.247844            0.125129               1.981          [torch.Size([1, 3, 1031, 1027]), torch.Size([1, 3, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS               0.248146            0.128054               1.938          [torch.Size([1, 3, 1027, 1027]), torch.Size([1, 3, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS               0.248747            0.130690               1.903          [torch.Size([1, 3, 1028, 1028]), torch.Size([1, 3, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.099069            0.130302               0.760          [torch.Size([1, 64, 130, 130]), torch.Size([1, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.098900            0.130564               0.757          [torch.Size([1, 64, 135, 131]), torch.Size([1, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.099854            0.132509               0.754          [torch.Size([1, 64, 131, 131]), torch.Size([1, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.099882            0.132556               0.754          [torch.Size([1, 64, 132, 132]), torch.Size([1, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.160687            0.128190               1.254          [torch.Size([1, 64, 258, 258]), torch.Size([1, 64, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.161092            0.124377               1.295          [torch.Size([1, 64, 263, 259]), torch.Size([1, 64, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.161343            0.126677               1.274          [torch.Size([1, 64, 259, 259]), torch.Size([1, 64, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.161540            0.126190               1.280          [torch.Size([1, 64, 260, 260]), torch.Size([1, 64, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.414172            0.201221               2.058          [torch.Size([1, 64, 514, 514]), torch.Size([1, 64, 512, 512]), [1, 1, 1, 1]]
SUCCESS               0.409504            0.224590               1.823          [torch.Size([1, 64, 519, 515]), torch.Size([1, 64, 512, 512]), [1, 2, 3, 4]]
SUCCESS               0.414148            0.138304               2.994          [torch.Size([1, 64, 515, 515]), torch.Size([1, 64, 512, 512]), [3, 0, 0, 3]]
SUCCESS               0.408192            0.229427               1.779          [torch.Size([1, 64, 516, 516]), torch.Size([1, 64, 512, 512]), [2, 2, 2, 2]]
SUCCESS               0.118500            0.130684               0.907          [torch.Size([1, 128, 66, 66]), torch.Size([1, 128, 64, 64]), [1, 1, 1, 1]]
SUCCESS               0.118745            0.137555               0.863          [torch.Size([1, 128, 71, 67]), torch.Size([1, 128, 64, 64]), [1, 2, 3, 4]]
SUCCESS               0.119470            0.142161               0.840          [torch.Size([1, 128, 67, 67]), torch.Size([1, 128, 64, 64]), [3, 0, 0, 3]]
SUCCESS               0.118796            0.134340               0.884          [torch.Size([1, 128, 68, 68]), torch.Size([1, 128, 64, 64]), [2, 2, 2, 2]]
SUCCESS               0.026977            0.134336               0.201          [torch.Size([1, 256, 34, 34]), torch.Size([1, 256, 32, 32]), [1, 1, 1, 1]]
SUCCESS               0.029099            0.143788               0.202          [torch.Size([1, 256, 39, 35]), torch.Size([1, 256, 32, 32]), [1, 2, 3, 4]]
SUCCESS               0.027489            0.130194               0.211          [torch.Size([1, 256, 35, 35]), torch.Size([1, 256, 32, 32]), [3, 0, 0, 3]]
SUCCESS               0.027813            0.138679               0.201          [torch.Size([1, 256, 36, 36]), torch.Size([1, 256, 32, 32]), [2, 2, 2, 2]]
SUCCESS               0.087722            0.127065               0.690          [torch.Size([4, 8, 258, 258]), torch.Size([4, 8, 256, 256]), [1, 1, 1, 1]]
SUCCESS               0.087639            0.144981               0.604          [torch.Size([4, 8, 263, 259]), torch.Size([4, 8, 256, 256]), [1, 2, 3, 4]]
SUCCESS               0.088616            0.145363               0.610          [torch.Size([4, 8, 259, 259]), torch.Size([4, 8, 256, 256]), [3, 0, 0, 3]]
SUCCESS               0.087898            0.143081               0.614          [torch.Size([4, 8, 260, 260]), torch.Size([4, 8, 256, 256]), [2, 2, 2, 2]]
SUCCESS               0.519615            0.432856               1.200          [torch.Size([8, 64, 130, 130]), torch.Size([8, 64, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.520043            0.490100               1.061          [torch.Size([8, 64, 135, 131]), torch.Size([8, 64, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.521318            0.165108               3.157          [torch.Size([8, 64, 131, 131]), torch.Size([8, 64, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.517832            0.490873               1.055          [torch.Size([8, 64, 132, 132]), torch.Size([8, 64, 128, 128]), [2, 2, 2, 2]]
SUCCESS              22.147179            7.534192               2.940          [torch.Size([8, 128, 1026, 1026]), torch.Size([8, 128, 1024, 1024]), [1, 1, 1, 1]]
SUCCESS              22.298336            8.439931               2.642          [torch.Size([8, 128, 1031, 1027]), torch.Size([8, 128, 1024, 1024]), [1, 2, 3, 4]]
SUCCESS              22.165835            5.236162               4.233          [torch.Size([8, 128, 1027, 1027]), torch.Size([8, 128, 1024, 1024]), [3, 0, 0, 3]]
SUCCESS              22.274733            8.730151               2.551          [torch.Size([8, 128, 1028, 1028]), torch.Size([8, 128, 1024, 1024]), [2, 2, 2, 2]]
SUCCESS               0.043620            0.160656               0.272          [torch.Size([3, 130, 130]), torch.Size([3, 128, 128]), [1, 1, 1, 1]]
SUCCESS               0.042889            0.141118               0.304          [torch.Size([3, 135, 131]), torch.Size([3, 128, 128]), [1, 2, 3, 4]]
SUCCESS               0.043439            0.140343               0.310          [torch.Size([3, 131, 131]), torch.Size([3, 128, 128]), [3, 0, 0, 3]]
SUCCESS               0.042875            0.142937               0.300          [torch.Size([3, 132, 132]), torch.Size([3, 128, 128]), [2, 2, 2, 2]]
SUCCESS               0.025585            0.136344               0.188          [torch.Size([1, 32, 3, 130]), torch.Size([1, 32, 1, 128]), [1, 1, 1, 1]]
SUCCESS               0.026127            0.128818               0.203          [torch.Size([1, 32, 8, 131]), torch.Size([1, 32, 1, 128]), [1, 2, 3, 4]]
SUCCESS               0.026362            0.131461               0.201          [torch.Size([1, 32, 4, 131]), torch.Size([1, 32, 1, 128]), [3, 0, 0, 3]]
SUCCESS               0.025324            0.129193               0.196          [torch.Size([1, 32, 5, 132]), torch.Size([1, 32, 1, 128]), [2, 2, 2, 2]]
```