### PR TITLE
fix(cambricon): stop index autotune from killing the process on untileable expand_shape

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_cambricon/tune_configs.yaml
@@ -1462,10 +1462,14 @@ index:
   - 1
   - 2
   - 4
+  # BLOCK_SIZE1=4096 excluded: with the default num_stages=2 a 4096-wide tile
+  # exceeds NRAM (always OutOfResources, can never win) and BLOCK_SIZE0=4 x
+  # BLOCK_SIZE1=4096 trips an MLU AutoTileForTritonPass failure
+  # ("PassManager::run failed" on an untileable tensor.expand_shape that
+  # collapses [1, 4, 4096]) in inductor-wrapped contexts with dynamic shapes.
   block_size1:
   - 1024
   - 2048
-  - 4096
   warps:
   - 1
   - 4

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -995,7 +995,20 @@ class LibTuner(triton.runtime.Autotuner):
                 def bench(config: triton.Config) -> List[float]:
                     ret = cache.get(config)
                     if ret is None:
-                        ret = self._bench(*args, config=config, **kwargs)
+                        try:
+                            ret = self._bench(*args, config=config, **kwargs)
+                        except RuntimeError as e:
+                            # A config whose COMPILE raises a plain RuntimeError
+                            # is outside triton's autotuner catch list
+                            # (OutOfResources / CompileTimeAssertionFailure /
+                            # PTXASError) and would kill the whole process. Some
+                            # backend compilers do this — e.g. cambricon MLU
+                            # AutoTileForTritonPass raises "PassManager::run
+                            # failed" on a tensor.expand_shape it cannot tile.
+                            # Treat such a config as a non-candidate (inf) so
+                            # tuning continues and a working config is selected.
+                            print(f"[libentry] config {config} failed to compile: {e}")
+                            ret = (float("inf"), float("inf"), float("inf"))
                         # Some Triton backends (e.g. tsingmicro with
                         # use_cuda_graph=True) return a scalar float from
                         # _bench instead of the standard (p50, p20, p80) tuple.


### PR DESCRIPTION
## Problem

E2E on cambricon MLU590 (vLLM 0.20.2 + flag_gems 5.3.4, inductor-wrapped context), the `index` op autotune **kills the whole process** instead of skipping a bad config:

```
RuntimeError: PassManager::run failed
'tensor.expand_shape' op expected dimension 0 of collapsed type to be static value of 4
```

Root cause: the MLU backend's `AutoTileForTritonPass` raises a **plain `RuntimeError`** on the `tensor.expand_shape` generated for the `BLOCK_SIZE0=4 x BLOCK_SIZE1=4096` config (collapse `[1, 4, 4096]`). `RuntimeError` is outside triton's autotuner catch list (`OutOfResources`, `CompileTimeAssertionFailure`, `PTXASError` — all `TritonError` subclasses), so the exception escapes the tuner, propagates through libentry, and kills the caller (vLLM `EngineCore` dead).

Standalone (non-wrapped) the config compiles fine; the failure only manifests in inductor-wrapped contexts where shapes are dynamic. Reproducer: `index` on a (15, 4096) bf16 tensor under inductor wrap, `BLOCK_SIZE0=4`, `BLOCK_SIZE1=4096`, `num_stages=2`.

## Fix (two-part, E2E-verified)

1. **`libentry.py` bench()**: any `RuntimeError` from `_bench` is treated as a non-candidate (`inf`) so tuning survives backend compiler failures on *any* config. This is the general robustness fix — the failure mode is 'backend raises non-TritonError on an untileable config'.
2. **`_cambricon/tune_configs.yaml` index block**: drop `BLOCK_SIZE1=4096`. With the default `num_stages=2`, a 4096-wide tile always exceeds NRAM (standalone-tested: `OutOfResources`, can never win), and `BLOCK_SIZE0=4 x 4096` is the exact config that trips the compiler bug.

Verified on MLU590: with the previous blacklist removed, the request that used to crash now returns correct output, the engine stays alive across repeated requests, and no errors appear in the log.

## Note

The underlying `AutoTileForTritonPass` expand_shape failure is a vendor (cambricon triton-MLU) compiler bug; this change makes flag_gems resilient to it. If the vendor fixes it, `BLOCK_SIZE1=4096` can be re-added.

closes: #5509

This PR was written in part with the assistance of generative AI.