### PR TITLE
test(kunlunxin): skip unsupported GLU family tests

### DIFF
--- a/tests/test_dgeglu.py
+++ b/tests/test_dgeglu.py
@@ -19,6 +19,8 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
@@ -29,6 +31,10 @@ except ImportError:
 
 @pytest.mark.dgeglu
 @pytest.mark.skipif(TE_OP is None, reason="'dgeglu' not found in TransformerEngine")
+@pytest.mark.skipif(
+    vendor_name == "kunlunxin",
+    reason="Kunlunxin TE/API and Triton kernel are unsupported",
+)
 @pytest.mark.parametrize("shape", utils.GLU_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_dgeglu(shape, dtype):

--- a/tests/test_dswiglu.py
+++ b/tests/test_dswiglu.py
@@ -19,6 +19,8 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
@@ -48,6 +50,10 @@ VALID_POINTWISE_SHAPES = filter_valid_shapes(utils.SWIGLU_SPECIAL_SHAPES)
 
 @pytest.mark.dswiglu
 @pytest.mark.skipif(TE_OP is None, reason="'dswiglu' not found in TransformerEngine")
+@pytest.mark.skipif(
+    vendor_name == "kunlunxin",
+    reason="Kunlunxin TE/API and Triton kernel are unsupported",
+)
 @pytest.mark.parametrize("shape", VALID_POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_dswiglu(shape: tuple[int, ...], dtype: torch.dtype):

--- a/tests/test_geglu.py
+++ b/tests/test_geglu.py
@@ -19,6 +19,8 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
@@ -31,6 +33,10 @@ except ImportError:
 @pytest.mark.parametrize("shape", utils.GLU_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.skipif(TE_OP is None, reason="'geglu' not found in TransformerEngine")
+@pytest.mark.skipif(
+    vendor_name == "kunlunxin",
+    reason="Kunlunxin TE/API and Triton kernel are unsupported",
+)
 def test_geglu(shape, dtype):
     input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 

--- a/tests/test_reglu.py
+++ b/tests/test_reglu.py
@@ -19,6 +19,8 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
@@ -31,6 +33,10 @@ except ImportError:
 @pytest.mark.parametrize("shape", utils.GLU_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.skipif(TE_OP is None, reason="'reglu' not found in TransformerEngine")
+@pytest.mark.skipif(
+    vendor_name == "kunlunxin",
+    reason="Kunlunxin TE/API and Triton kernel are unsupported",
+)
 def test_reglu(shape, dtype):
     input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 

--- a/tests/test_swiglu.py
+++ b/tests/test_swiglu.py
@@ -19,6 +19,8 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+vendor_name = flag_gems.vendor_name
+
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
@@ -50,6 +52,10 @@ VALID_POINTWISE_SHAPES = filter_valid_shapes(utils.SWIGLU_SPECIAL_SHAPES)
 @pytest.mark.parametrize("shape", VALID_POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.skipif(TE_OP is None, reason="'swiglu' not found in TransformerEngine")
+@pytest.mark.skipif(
+    vendor_name == "kunlunxin",
+    reason="Kunlunxin TE/API and Triton kernel are unsupported",
+)
 def test_swiglu(shape: tuple[int, ...], dtype: torch.dtype):
     torch.manual_seed(42)
     device = flag_gems.device


### PR DESCRIPTION
This PR contains the focused Kunlunxin repair from commit d094ff340231. The branch is based on the latest upstream/master; unrelated local changes and intermediate attempts were excluded.