### PR TITLE
fix(kunlunxin): add logaddexp support

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
@@ -177,6 +177,7 @@ from .log import log
 from .log1p import log1p, log1p_
 from .log_sigmoid import log_sigmoid
 from .log_softmax import log_softmax, log_softmax_backward
+from .logaddexp import logaddexp, logaddexp_out
 from .logaddexp2 import logaddexp2, logaddexp2_out
 from .logical_and import logical_and, logical_and_
 from .logical_not import logical_not, logical_not_
@@ -562,6 +563,8 @@ __all__ = [
     "log_sigmoid",
     "log_softmax",
     "log_softmax_backward",
+    "logaddexp",
+    "logaddexp_out",
     "logaddexp2",
     "logaddexp2_out",
     "logsumexp",

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logaddexp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logaddexp.py
@@ -1,0 +1,35 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Capture the native kernels before FlagGems installs its CUDA registrations.
+# The explicit keyset reaches Kunlunxin's implementation without recursion.
+_NATIVE_LOGADDEXP = torch.library.get_kernel("aten::logaddexp", "CUDA")
+_NATIVE_LOGADDEXP_OUT = torch.library.get_kernel("aten::logaddexp.out", "CUDA")
+_CUDA_KEYSET = torch._C.DispatchKeySet(torch._C.DispatchKey.CUDA)
+
+
+def logaddexp(self, other):
+    logger.debug("GEMS_KUNLUNXIN LOGADDEXP_NATIVE")
+    return _NATIVE_LOGADDEXP.call_boxed(_CUDA_KEYSET, self, other)
+
+
+def logaddexp_out(self, other, out):
+    logger.debug("GEMS_KUNLUNXIN LOGADDEXP_OUT_NATIVE")
+    return _NATIVE_LOGADDEXP_OUT.call_boxed(_CUDA_KEYSET, self, other, out=out)


### PR DESCRIPTION
This PR contains the focused Kunlunxin repair from commit 1a7736eceee2. The branch is based on the latest upstream/master; unrelated local changes and intermediate attempts were excluded.