### PR TITLE
[MTHREADS] optimize matmul_bias_activation with SQMMA

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/fused/__init__.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 from .cross_entropy_loss import cross_entropy_loss
+from .matmul_bias_activation import matmul_bias_activation
 from .sparse_attention import sparse_attn_triton
 
 __all__ = [
     "cross_entropy_loss",
+    "matmul_bias_activation",
     "sparse_attn_triton",
 ]

--- a/src/flag_gems/runtime/backend/_mthreads/fused/matmul_bias_activation.py
+++ b/src/flag_gems/runtime/backend/_mthreads/fused/matmul_bias_activation.py
@@ -1,0 +1,169 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from flag_gems.fused.matmul_bias_activation import (
+    matmul_bias_activation as generic_matmul_bias_activation,
+)
+from flag_gems.runtime import torch_device_fn
+from flag_gems.runtime.backend._mthreads.fused.matmul_bias_activation_fma import (
+    matmul_bias_activation_fma,
+)
+from flag_gems.runtime.backend._mthreads.ops.mm import (
+    SQMMA_ON,
+    is_sqmma_compatible,
+    is_supported_sqmma_layout,
+)
+from flag_gems.utils import broadcastable_to, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def prev_multiple_of(a, b):
+    return tl.cdiv(a, b) * b - b
+
+
+def matmul_bias_activation_sqmma_descriptor_pre_hook(nargs):
+    nargs["a_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_K"]]
+    nargs["b_desc"].block_shape = [nargs["BLOCK_K"], nargs["BLOCK_N"]]
+    nargs["c_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_N"]]
+
+
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64, "GROUP_M": 8},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=matmul_bias_activation_sqmma_descriptor_pre_hook,
+        )
+    ],
+    key=["M", "N", "K", "dtype"],
+    strategy=["align32", "align32", "align32", "default"],
+    warmup=5,
+    rep=5,
+    flagtune_op_name="matmul_bias_activation",
+    flagtune_expand_op_name="matmul_bias_activation_sqmma",
+    flagtune_pre_hook=matmul_bias_activation_sqmma_descriptor_pre_hook,
+)
+@triton.jit
+def matmul_bias_activation_sqmma_kernel(
+    a_desc,
+    b_desc,
+    bias_ptr,
+    c_desc,
+    M,
+    N,
+    K,
+    stride_bias,
+    dtype: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = ext.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    offs_am = (pid_m * BLOCK_M).to(tl.int32)
+    offs_bn = (pid_n * BLOCK_N).to(tl.int32)
+    offs_k = tl.full((), 0, dtype=tl.int32)
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _ in range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load_tensor_descriptor(a_desc, [offs_am, offs_k])
+        b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
+        accumulator = tl.dot(a, b, acc=accumulator)
+        offs_k += BLOCK_K
+
+    bias_offsets = offs_bn + tl.arange(0, BLOCK_N)
+    bias = tl.load(
+        bias_ptr + bias_offsets * stride_bias, mask=bias_offsets < N, other=0.0
+    )
+    result = accumulator + bias[None, :]
+    result = tl.maximum(result, 0.0)
+    tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], result.to(c_desc.dtype))
+
+
+def is_matmul_bias_activation_sqmma_compatible(input, weight, bias, N, K):
+    if not (SQMMA_ON and is_sqmma_compatible(input, weight, N, K)):
+        return False
+    if bias.dim() == 1:
+        return bias.shape[0] == N and bias.stride(0) == 1
+    if bias.dim() == 2:
+        return bias.shape == (1, N) and is_supported_sqmma_layout(bias)
+    return False
+
+
+def matmul_bias_activation_sqmma(input, weight, bias, M, N, K):
+    logger.debug("GEMS_MTHREADS MATMUL_BIAS_ACTIVATION_SQMMA")
+    if not input.is_contiguous():
+        input = input.contiguous()
+    if not weight.is_contiguous():
+        weight = weight.contiguous()
+    if bias.dim() > 1:
+        bias = bias.reshape(-1)
+
+    out = torch.empty((M, N), dtype=input.dtype, device=input.device)
+    desc_a = TensorDescriptor.from_tensor(input, [1, 1])
+    desc_b = TensorDescriptor.from_tensor(weight, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(out, [1, 1])
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        1,
+        1,
+    )
+    with torch_device_fn.device(input.device):
+        matmul_bias_activation_sqmma_kernel[grid](
+            desc_a,
+            desc_b,
+            bias,
+            desc_c,
+            M,
+            N,
+            K,
+            bias.stride(0),
+            str(input.dtype).split(".")[-1],
+        )
+    return out
+
+
+def matmul_bias_activation(input, weight, bias):
+    assert input.shape[1] == weight.shape[0], "Incompatible dimensions"
+    assert broadcastable_to(
+        bias.shape, (input.shape[0], weight.shape[1])
+    ), "Incompatible input shape"
+
+    M, K = input.shape
+    _, N = weight.shape
+
+    if is_matmul_bias_activation_sqmma_compatible(input, weight, bias, N, K):
+        return matmul_bias_activation_sqmma(input, weight, bias, M, N, K)
+    if input.dtype in (torch.float16, torch.bfloat16, torch.float32):
+        return matmul_bias_activation_fma(input, weight, bias, M, N, K)
+    return generic_matmul_bias_activation(input, weight, bias)

--- a/src/flag_gems/runtime/backend/_mthreads/fused/matmul_bias_activation_fma.py
+++ b/src/flag_gems/runtime/backend/_mthreads/fused/matmul_bias_activation_fma.py
@@ -1,0 +1,179 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def prev_multiple_of(a, b):
+    return tl.cdiv(a, b) * b - b
+
+
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+            num_stages=1,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+            num_stages=2,
+            num_warps=4,
+        ),
+    ],
+    key=["M", "N", "K"],
+    strategy=["align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
+)
+@triton.jit
+def matmul_bias_activation_fma_kernel(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_bias,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    IS_FP32: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    if IS_FP32:
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+        a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            a = tl.load(
+                a_ptrs,
+                mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+                other=0.0,
+            )
+            accumulator += tl.dot(a, b, allow_tf32=False)
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
+    else:
+        ram = offs_am % M
+        rbn = offs_bn % N
+        prev_multiple = prev_multiple_of(K, BLOCK_SIZE_K)
+        for start_k in range(0, prev_multiple, BLOCK_SIZE_K):
+            rk = start_k + tl.arange(0, BLOCK_SIZE_K)
+            a = tl.load(a_ptr + (ram[:, None] * stride_am + rk[None, :] * stride_ak))
+            b = tl.load(b_ptr + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn))
+            accumulator += tl.dot(a, b, allow_tf32=False)
+        rk = prev_multiple + tl.arange(0, BLOCK_SIZE_K)
+        mask_k = rk < K
+        a = tl.load(
+            a_ptr + (ram[:, None] * stride_am + rk[None, :] * stride_ak),
+            mask=mask_k[None, :],
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptr + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn),
+            mask=mask_k[:, None],
+            other=0.0,
+        )
+        accumulator += tl.dot(a, b, allow_tf32=False)
+
+    bias = tl.load(bias_ptr + offs_bn * stride_bias, mask=offs_bn < N, other=0.0)
+    accumulator = tl.where(
+        accumulator + bias[None, :] > 0, accumulator + bias[None, :], 0.0
+    )
+
+    c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
+    c_mask = (offs_am[:, None] < M) & (offs_bn[None, :] < N)
+    tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+
+
+def matmul_bias_activation_fma(input, weight, bias, M, N, K):
+    logger.debug("GEMS_MTHREADS MATMUL_BIAS_ACTIVATION_FMA")
+    if input.stride(0) > 1 and input.stride(1) > 1:
+        input = input.contiguous()
+    if weight.stride(0) > 1 and weight.stride(1) > 1:
+        weight = weight.contiguous()
+    if bias.dim() > 1:
+        bias = bias.reshape(-1)
+
+    out = torch.empty((M, N), device=input.device, dtype=input.dtype)
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
+    with torch_device_fn.device(input.device):
+        matmul_bias_activation_fma_kernel[grid](
+            input,
+            weight,
+            bias,
+            out,
+            M,
+            N,
+            K,
+            input.stride(0),
+            input.stride(1),
+            weight.stride(0),
+            weight.stride(1),
+            bias.stride(0),
+            out.stride(0),
+            out.stride(1),
+            GROUP_M=8,
+            IS_FP32=input.dtype == torch.float32,
+        )
+    return out


### PR DESCRIPTION
### Description

Add a MTHREADS fused override for matmul_bias_activation that routes fp16/bfloat16 compatible layouts through a TensorDescriptor SQMMA kernel. The kernel fuses matmul accumulation, vector bias add, and ReLU before storing.

Also add a MTHREADS FMA fallback for fp32 and non-SQMMA fp16/bfloat16 shapes. The fallback uses the generic matmul_bias_activation tuning: libtuner configs, GROUP_M program reordering, and dtype-aware K-loop handling. fp32 keeps the masked inner loop because it benchmarks faster, while fp16/bfloat16 fallback uses a peeled K loop.

### Performance
#### 1. fp16
| Status | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | TFLOPS | Size Detail |
|---|---|---|---|---|---|
| SUCCESS | 0.028080 | 0.022160 | 1.267 | 5.11 | [torch.Size([384, 384]), torch.Size([384, 384]), torch.Size([384])] |
| SUCCESS | 0.033240 | 0.041120 | 0.808 | 52.23 | [torch.Size([1024, 1024]), torch.Size([1024, 1024]), torch.Size([1024])] |
| SUCCESS | 0.071400 | 0.138240 | 0.516 | 124.27 | [torch.Size([2048, 2048]), torch.Size([2048, 2048]), torch.Size([2048])] |
| SUCCESS | 0.401360 | 0.779860 | 0.515 | 176.23 | [torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096])] |
#### 2. bf16
| Status | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | TFLOPS | Size Detail |
|---|---|---|---|---|---|
| SUCCESS | 0.020080 | 0.020440 | 0.982 | 5.54 | [torch.Size([384, 384]), torch.Size([384, 384]), torch.Size([384])] |
| SUCCESS | 0.033920 | 0.039540 | 0.858 | 54.31 | [torch.Size([1024, 1024]), torch.Size([1024, 1024]), torch.Size([1024])] |
| SUCCESS | 0.072000 | 0.134280 | 0.536 | 127.94 | [torch.Size([2048, 2048]), torch.Size([2048, 2048]), torch.Size([2048])] |
| SUCCESS | 0.397040 | 0.770640 | 0.515 | 178.34 | [torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096])] |

### Key improvements 
Gems latency, before -> after  

- fp16 4096x4096: 1.603/1.593 ms -> 0.780/0.782 ms (~2.05x)
- fp16 2048x2048: 0.300 ms -> 0.138 ms (~2.17x)
- bf16 4096x4096: 1.601/1.611 ms -> 0.771/0.773 ms (~2.08x)
- bf16 2048x2048: 0.300 ms -> 0.134 ms (~2.23x)
- fp32 4096x4096: 97.938/99.542 ms -> 27.599/27.558 ms (~3.55x)
- fp32 2048x2048: 14.632 ms -> 3.908 ms (~3.74x)

