### PR TITLE
[KernelGen][MThreads] Add 20 operators for MThreads

### DIFF
--- a/benchmark/test_bucketize.py
+++ b/benchmark/test_bucketize.py
@@ -15,6 +15,8 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base, consts
 
 
@@ -26,10 +28,15 @@ def _input_fn(shape, cur_dtype, device):
 
 @pytest.mark.bucketize
 def test_bucketize_perf():
+    if flag_gems.vendor_name == "mthreads":
+        dtypes = [torch.float32]
+    else:
+        dtypes = consts.FLOAT_DTYPES
+
     bench = base.GenericBenchmark(
         op_name="bucketize",
         input_fn=_input_fn,
         torch_op=torch.bucketize,
-        dtypes=consts.FLOAT_DTYPES,
+        dtypes=dtypes,
     )
     bench.run()

--- a/benchmark/test_linalg_cholesky.py
+++ b/benchmark/test_linalg_cholesky.py
@@ -15,7 +15,11 @@
 import pytest
 import torch
 
+import flag_gems
+
 from . import base
+
+fp64_is_supported = flag_gems.runtime.device.support_fp64
 
 # Cholesky decomposition benchmark shapes
 # Square matrices from 2x2 to 256x256 covering small to medium-large use cases
@@ -52,7 +56,8 @@ def test_linalg_cholesky():
     bench = CholeskyBenchmark(
         op_name="linalg_cholesky",
         torch_op=torch.ops.aten.linalg_cholesky,
-        # Cholesky only supports float32/float64; fp16/bf16 not supported by PyTorch
-        dtypes=[torch.float32, torch.float64],
+        # Cholesky only supports float32/float64; fp16/bf16 not supported by
+        # PyTorch. fp64 is gated on device support (Moore Threads has no fp64).
+        dtypes=[torch.float32] + ([torch.float64] if fp64_is_supported else []),
     )
     bench.run()

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -20,6 +20,7 @@ from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmin import argmin
 from .batch_norm import batch_norm, batch_norm_backward
+from .bucketize import bucketize, bucketize_kernel
 from .celu import celu
 from .conv2d import conv2d
 from .div import (
@@ -32,13 +33,27 @@ from .div import (
     true_divide_out,
 )
 from .dropout import dropout, dropout_backward
+from .erfinv import erfinv, erfinv_kernel
+from .erfinv_ import erfinv_
 from .flip import flip
+from .fmod_ import (
+    fmod_,
+    fmod_inplace_scalar_kernel,
+    fmod_inplace_tensor_kernel,
+    fmod_scalar_,
+    fmod_tensor_,
+)
 from .gather import gather, gather_backward
+from .histc import histc, histc_kernel, histc_local_reduce_kernel
+from .im2col import im2col, im2col_kernel
 from .index_add import index_add, index_add_
+from .index_copy_ import index_copy, index_copy_, index_copy_kernel
 from .index_put import _index_put_impl_, index_put, index_put_
 from .index_select import index_select
+from .linalg_cholesky import cholesky_kernel, linalg_cholesky
 from .log import log
 from .log10 import log10, log10_, log10_out
+from .log_normal_ import log_normal_, log_normal_kernel, pair_uniform_to_normal
 from .log_softmax import (
     log_softmax,
     log_softmax_backward,
@@ -46,20 +61,47 @@ from .log_softmax import (
     log_softmax_out,
 )
 from .max import max, max_dim
+from .median import (
+    median,
+    median_dim,
+    median_dim_values,
+    median_out,
+    median_sort_select_kernel,
+)
 from .min import min, min_dim
+from .mish import mish, mish_, mish_kernel
 from .mode import mode
 from .mul import mul, mul_
+from .nonzero_numpy import (
+    nonzero_count_kernel,
+    nonzero_fill_kernel,
+    nonzero_numpy,
+    nonzero_single_kernel,
+)
+from .norm import (
+    norm,
+    norm_finalize_kernel,
+    norm_partial_kernel,
+    norm_scalar,
+    norm_scalaropt_dim,
+)
 from .normal import normal_
 from .one_hot import one_hot
 from .ones import ones
 from .ones_like import ones_like
 from .pad import constant_pad_nd
+from .permute_copy import permute_copy
 from .prod import prod, prod_dim
 from .rand import rand
 from .rand_like import rand_like
 from .randn import randn
 from .randn_like import randn_like
 from .randperm import randperm
+from .reflection_pad3d_backward import (
+    reflection_pad3d_backward,
+    reflection_pad3d_backward_kernel,
+)
+from .renorm_ import renorm_, renorm_kernel, renorm_kernel_single_pass
 from .repeat import repeat
 from .repeat_interleave import (
     repeat_interleave_self_int,
@@ -67,8 +109,12 @@ from .repeat_interleave import (
     repeat_interleave_tensor,
 )
 from .resolve_conj import resolve_conj
+from .round_ import round_, round_inplace_kernel
+from .softplus_backward import softplus_backward, softplus_backward_kernel
 from .sort import sort, sort_stable
+from .special_gammainc import gammainc_kernel, special_gammainc
 from .tile import tile
+from .trunc import trunc, trunc_, trunc_kernel
 from .unique import _unique2
 from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
 from .zeros import zero_, zeros
@@ -148,6 +194,61 @@ __all__ = [
     "zero_",
     "zeros",
     "zeros_like",
+    "bucketize",
+    "bucketize_kernel",
+    "cholesky_kernel",
+    "erfinv",
+    "erfinv_",
+    "erfinv_kernel",
+    "fmod_",
+    "fmod_inplace_scalar_kernel",
+    "fmod_inplace_tensor_kernel",
+    "fmod_scalar_",
+    "fmod_tensor_",
+    "gammainc_kernel",
+    "histc",
+    "histc_kernel",
+    "histc_local_reduce_kernel",
+    "im2col",
+    "im2col_kernel",
+    "index_copy",
+    "index_copy_",
+    "index_copy_kernel",
+    "linalg_cholesky",
+    "log_normal_",
+    "log_normal_kernel",
+    "median",
+    "median_dim",
+    "median_dim_values",
+    "median_out",
+    "median_sort_select_kernel",
+    "mish",
+    "mish_",
+    "mish_kernel",
+    "nonzero_count_kernel",
+    "nonzero_fill_kernel",
+    "nonzero_numpy",
+    "nonzero_single_kernel",
+    "norm",
+    "norm_finalize_kernel",
+    "norm_partial_kernel",
+    "norm_scalar",
+    "norm_scalaropt_dim",
+    "pair_uniform_to_normal",
+    "permute_copy",
+    "reflection_pad3d_backward",
+    "reflection_pad3d_backward_kernel",
+    "renorm_",
+    "renorm_kernel",
+    "renorm_kernel_single_pass",
+    "round_",
+    "round_inplace_kernel",
+    "softplus_backward",
+    "softplus_backward_kernel",
+    "special_gammainc",
+    "trunc",
+    "trunc_",
+    "trunc_kernel",
 ]
 
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -20,7 +20,7 @@ from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmin import argmin
 from .batch_norm import batch_norm, batch_norm_backward
-from .bucketize import bucketize, bucketize_kernel
+from .bucketize import bucketize
 from .celu import celu
 from .conv2d import conv2d
 from .div import (
@@ -33,27 +33,21 @@ from .div import (
     true_divide_out,
 )
 from .dropout import dropout, dropout_backward
-from .erfinv import erfinv, erfinv_kernel
+from .erfinv import erfinv
 from .erfinv_ import erfinv_
 from .flip import flip
-from .fmod_ import (
-    fmod_,
-    fmod_inplace_scalar_kernel,
-    fmod_inplace_tensor_kernel,
-    fmod_scalar_,
-    fmod_tensor_,
-)
+from .fmod_ import fmod_, fmod_scalar_, fmod_tensor_
 from .gather import gather, gather_backward
-from .histc import histc, histc_kernel, histc_local_reduce_kernel
-from .im2col import im2col, im2col_kernel
+from .histc import histc
+from .im2col import im2col
 from .index_add import index_add, index_add_
-from .index_copy_ import index_copy, index_copy_, index_copy_kernel
+from .index_copy_ import index_copy, index_copy_
 from .index_put import _index_put_impl_, index_put, index_put_
 from .index_select import index_select
-from .linalg_cholesky import cholesky_kernel, linalg_cholesky
+from .linalg_cholesky import linalg_cholesky
 from .log import log
 from .log10 import log10, log10_, log10_out
-from .log_normal_ import log_normal_, log_normal_kernel, pair_uniform_to_normal
+from .log_normal_ import log_normal_
 from .log_softmax import (
     log_softmax,
     log_softmax_backward,
@@ -61,30 +55,13 @@ from .log_softmax import (
     log_softmax_out,
 )
 from .max import max, max_dim
-from .median import (
-    median,
-    median_dim,
-    median_dim_values,
-    median_out,
-    median_sort_select_kernel,
-)
+from .median import median, median_dim, median_dim_values, median_out
 from .min import min, min_dim
-from .mish import mish, mish_, mish_kernel
+from .mish import mish, mish_
 from .mode import mode
 from .mul import mul, mul_
-from .nonzero_numpy import (
-    nonzero_count_kernel,
-    nonzero_fill_kernel,
-    nonzero_numpy,
-    nonzero_single_kernel,
-)
-from .norm import (
-    norm,
-    norm_finalize_kernel,
-    norm_partial_kernel,
-    norm_scalar,
-    norm_scalaropt_dim,
-)
+from .nonzero_numpy import nonzero_numpy
+from .norm import norm, norm_scalar, norm_scalaropt_dim
 from .normal import normal_
 from .one_hot import one_hot
 from .ones import ones
@@ -97,11 +74,8 @@ from .rand_like import rand_like
 from .randn import randn
 from .randn_like import randn_like
 from .randperm import randperm
-from .reflection_pad3d_backward import (
-    reflection_pad3d_backward,
-    reflection_pad3d_backward_kernel,
-)
-from .renorm_ import renorm_, renorm_kernel, renorm_kernel_single_pass
+from .reflection_pad3d_backward import reflection_pad3d_backward
+from .renorm_ import renorm_
 from .repeat import repeat
 from .repeat_interleave import (
     repeat_interleave_self_int,
@@ -109,12 +83,12 @@ from .repeat_interleave import (
     repeat_interleave_tensor,
 )
 from .resolve_conj import resolve_conj
-from .round_ import round_, round_inplace_kernel
-from .softplus_backward import softplus_backward, softplus_backward_kernel
+from .round_ import round_
+from .softplus_backward import softplus_backward
 from .sort import sort, sort_stable
-from .special_gammainc import gammainc_kernel, special_gammainc
+from .special_gammainc import special_gammainc
 from .tile import tile
-from .trunc import trunc, trunc_, trunc_kernel
+from .trunc import trunc, trunc_
 from .unique import _unique2
 from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
 from .zeros import zero_, zeros
@@ -133,40 +107,63 @@ __all__ = [
     "argmin",
     "batch_norm",
     "batch_norm_backward",
+    "bucketize",
     "celu",
     # "celu_",
     "conv2d",
     "dropout",
     "dropout_backward",
+    "erfinv",
+    "erfinv_",
     "flip",
+    "fmod_",
+    "fmod_scalar_",
+    "fmod_tensor_",
     "gather",
     "gather_backward",
+    "histc",
+    "im2col",
     "index_add",
     "index_add_",
+    "index_copy",
+    "index_copy_",
     "index_put",
     "index_put_",
     "_index_put_impl_",
     "index_select",
+    "linalg_cholesky",
     "log",
     "log10",
     "log10_",
     "log10_out",
+    "log_normal_",
     "log_softmax",
     "log_softmax_backward",
     "log_softmax_backward_out",
     "log_softmax_out",
     "max",
     "max_dim",
+    "median",
+    "median_dim",
+    "median_dim_values",
+    "median_out",
     "min",
     "min_dim",
+    "mish",
+    "mish_",
     "mode",
     "mul",
     "mul_",
+    "nonzero_numpy",
+    "norm",
+    "norm_scalar",
+    "norm_scalaropt_dim",
     "normal_",
     "one_hot",
     "ones",
     "ones_like",
     "constant_pad_nd",
+    "permute_copy",
     "prod",
     "prod_dim",
     "rand",
@@ -174,13 +171,18 @@ __all__ = [
     "randn",
     "randn_like",
     "randperm",
+    "reflection_pad3d_backward",
+    "renorm_",
     "repeat",
     "repeat_interleave_self_int",
     "repeat_interleave_self_tensor",
     "repeat_interleave_tensor",
     "resolve_conj",
+    "round_",
+    "softplus_backward",
     "sort",
     "sort_stable",
+    "special_gammainc",
     "tile",
     "true_divide",
     "true_divide_",
@@ -190,65 +192,12 @@ __all__ = [
     "floor_divide",
     "floor_divide_",
     "_unique2",
+    "trunc",
+    "trunc_",
     "w8a8_block_fp8_matmul",
     "zero_",
     "zeros",
     "zeros_like",
-    "bucketize",
-    "bucketize_kernel",
-    "cholesky_kernel",
-    "erfinv",
-    "erfinv_",
-    "erfinv_kernel",
-    "fmod_",
-    "fmod_inplace_scalar_kernel",
-    "fmod_inplace_tensor_kernel",
-    "fmod_scalar_",
-    "fmod_tensor_",
-    "gammainc_kernel",
-    "histc",
-    "histc_kernel",
-    "histc_local_reduce_kernel",
-    "im2col",
-    "im2col_kernel",
-    "index_copy",
-    "index_copy_",
-    "index_copy_kernel",
-    "linalg_cholesky",
-    "log_normal_",
-    "log_normal_kernel",
-    "median",
-    "median_dim",
-    "median_dim_values",
-    "median_out",
-    "median_sort_select_kernel",
-    "mish",
-    "mish_",
-    "mish_kernel",
-    "nonzero_count_kernel",
-    "nonzero_fill_kernel",
-    "nonzero_numpy",
-    "nonzero_single_kernel",
-    "norm",
-    "norm_finalize_kernel",
-    "norm_partial_kernel",
-    "norm_scalar",
-    "norm_scalaropt_dim",
-    "pair_uniform_to_normal",
-    "permute_copy",
-    "reflection_pad3d_backward",
-    "reflection_pad3d_backward_kernel",
-    "renorm_",
-    "renorm_kernel",
-    "renorm_kernel_single_pass",
-    "round_",
-    "round_inplace_kernel",
-    "softplus_backward",
-    "softplus_backward_kernel",
-    "special_gammainc",
-    "trunc",
-    "trunc_",
-    "trunc_kernel",
 ]
 
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/bucketize.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/bucketize.py
@@ -1,0 +1,134 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.bucketize import bucketize as default_bucketize
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=1),
+    ],
+    key=["n_elements", "n_boundaries"],
+)
+@triton.jit
+def bucketize_kernel(
+    inp_ptr,
+    boundaries_ptr,
+    out_ptr,
+    n_elements,
+    n_boundaries,
+    right: tl.constexpr,
+    N_BOUNDARY_ITERS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    inp_val = tl.load(inp_ptr + offsets, mask=mask, other=0)
+
+    # Vectorized binary search: each lane keeps its own [lo, hi) window and
+    # narrows it over a fixed iteration count (ceil(log2(n_boundaries + 1))).
+    lo = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    hi = tl.full([BLOCK_SIZE], n_boundaries, dtype=tl.int32)
+
+    for _ in range(N_BOUNDARY_ITERS):
+        mid = tl.minimum((lo + hi) // 2, n_boundaries - 1)
+        mid_val = tl.load(boundaries_ptr + mid)
+        # right=True  -> upper_bound (first boundary strictly greater than val)
+        # right=False -> lower_bound (first boundary >= val)
+        if right:
+            cond = mid_val <= inp_val
+        else:
+            cond = mid_val < inp_val
+        lo = tl.where(cond, mid + 1, lo)
+        hi = tl.where(cond, hi, mid)
+
+    tl.store(out_ptr + offsets, lo, mask=mask)
+
+
+# Moore Threads hardware does not support fp64 compute. The specialized kernel
+# targets the real floating types; other dtypes / empty boundaries / dtype
+# mismatches defer to the generic implementation for correctness.
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+def _use_triton_kernel(inp, boundaries):
+    if inp.device.type != "musa":
+        return False
+    if inp.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if boundaries.numel() == 0:
+        return False
+    # Binary search compares input against boundaries; keep them the same
+    # element type so the search is exact and no implicit promotion is needed.
+    if boundaries.dtype != inp.dtype:
+        return False
+    return True
+
+
+def bucketize(input, boundaries, *, out_int32=False, right=False):
+    logger.debug("GEMS_MTHREADS BUCKETIZE")
+
+    if not _use_triton_kernel(input, boundaries):
+        return default_bucketize(input, boundaries, out_int32=out_int32, right=right)
+
+    output_dtype = torch.int32 if out_int32 else torch.int64
+
+    n_elements = input.numel()
+    n_boundaries = boundaries.numel()
+    search_iterations = math.ceil(math.log2(n_boundaries + 1))
+
+    # Allocate a contiguous flat output so kernel stores land in the returned
+    # tensor regardless of the input's memory layout (empty_like would inherit a
+    # non-contiguous layout and flatten() could then copy).
+    input_flat = input.contiguous().flatten()
+    output_flat = torch.empty(n_elements, dtype=output_dtype, device=input.device)
+    boundaries = boundaries.contiguous()
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+
+    with torch_device_fn.device(input.device):
+        bucketize_kernel[grid](
+            input_flat,
+            boundaries,
+            output_flat,
+            n_elements,
+            n_boundaries,
+            right,
+            search_iterations,
+        )
+
+    return output_flat.reshape(input.shape)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/erfinv.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/erfinv.py
@@ -1,0 +1,141 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.erfinv_ import erfinv as default_erfinv
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@triton.jit
+def _erfinv(xf):
+    # Polynomial approximation of the inverse error function evaluated in fp32.
+    # The MThreads llc backend cannot lower the libdevice erfinv intrinsic, so we
+    # inline the same rational approximation the generic experimental kernel uses.
+    one = 1.0
+    absx = tl.abs(xf)
+    w = -tl.log((one - xf) * (one + xf))
+
+    use_low = w < 5.0
+
+    wl = w - 2.5
+    pl = 2.81022636e-08
+    pl = 3.43273939e-07 + pl * wl
+    pl = -3.5233877e-06 + pl * wl
+    pl = -4.39150654e-06 + pl * wl
+    pl = 2.1858087e-04 + pl * wl
+    pl = -1.25372503e-03 + pl * wl
+    pl = -4.17768164e-03 + pl * wl
+    pl = 2.46640727e-01 + pl * wl
+    pl = 1.50140941e00 + pl * wl
+
+    wh = tl.sqrt(w) - 3.0
+    ph = -2.00214257e-04
+    ph = 1.00950558e-04 + ph * wh
+    ph = 1.34934322e-03 + ph * wh
+    ph = -3.67342844e-03 + ph * wh
+    ph = 5.73950773e-03 + ph * wh
+    ph = -7.62246130e-03 + ph * wh
+    ph = 9.43887047e-03 + ph * wh
+    ph = 1.00167406e00 + ph * wh
+    ph = 2.83297682e00 + ph * wh
+
+    p = tl.where(use_low, pl, ph)
+    res = p * xf
+
+    nan_val = float("nan")
+    inf_val = float("inf")
+    res = tl.where(xf != xf, nan_val, res)
+    res = tl.where(absx > 1.0, nan_val, res)
+    res = tl.where(xf == 1.0, inf_val, res)
+    res = tl.where(xf == -1.0, -inf_val, res)
+    return res
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def erfinv_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Moore Threads hardware does not support fp64; compute in fp32.
+    out = _erfinv(x.to(tl.float32)).to(x.dtype)
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+# NOTE: the libdevice erfinv intrinsic crashes the MThreads llc backend, so the
+# polynomial helper above is used instead of tl_extra_shim.erfinv.
+
+
+def _use_triton_kernel(x: torch.Tensor) -> bool:
+    if not isinstance(x, torch.Tensor):
+        return False
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if not x.is_contiguous() or x.numel() == 0:
+        return False
+    return True
+
+
+def _launch_erfinv(x: torch.Tensor, out: torch.Tensor):
+    x_flat = x.view(-1)
+    out_flat = out.view(-1)
+    n_elements = out_flat.numel()
+    dtype_size = out_flat.element_size()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(out.device):
+        erfinv_kernel[grid](x_flat, out_flat, n_elements, dtype_size)
+    return out
+
+
+def erfinv(x):
+    logger.debug("GEMS_MTHREADS ERFINV")
+    if not _use_triton_kernel(x):
+        return default_erfinv(x)
+
+    out = torch.empty_like(x)
+    return _launch_erfinv(x, out)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/erfinv_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/erfinv_.py
@@ -1,0 +1,143 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.erfinv_ import erfinv_ as default_erfinv_
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@triton.jit
+def _erfinv(xf):
+    # Polynomial approximation of the inverse error function evaluated in fp32.
+    # The MThreads llc backend cannot lower the libdevice erfinv intrinsic, so we
+    # inline the same rational approximation the generic experimental kernel uses.
+    one = 1.0
+    absx = tl.abs(xf)
+    w = -tl.log((one - xf) * (one + xf))
+
+    use_low = w < 5.0
+
+    wl = w - 2.5
+    pl = 2.81022636e-08
+    pl = 3.43273939e-07 + pl * wl
+    pl = -3.5233877e-06 + pl * wl
+    pl = -4.39150654e-06 + pl * wl
+    pl = 2.1858087e-04 + pl * wl
+    pl = -1.25372503e-03 + pl * wl
+    pl = -4.17768164e-03 + pl * wl
+    pl = 2.46640727e-01 + pl * wl
+    pl = 1.50140941e00 + pl * wl
+
+    wh = tl.sqrt(w) - 3.0
+    ph = -2.00214257e-04
+    ph = 1.00950558e-04 + ph * wh
+    ph = 1.34934322e-03 + ph * wh
+    ph = -3.67342844e-03 + ph * wh
+    ph = 5.73950773e-03 + ph * wh
+    ph = -7.62246130e-03 + ph * wh
+    ph = 9.43887047e-03 + ph * wh
+    ph = 1.00167406e00 + ph * wh
+    ph = 2.83297682e00 + ph * wh
+
+    p = tl.where(use_low, pl, ph)
+    res = p * xf
+
+    nan_val = float("nan")
+    inf_val = float("inf")
+    res = tl.where(xf != xf, nan_val, res)
+    res = tl.where(absx > 1.0, nan_val, res)
+    res = tl.where(xf == 1.0, inf_val, res)
+    res = tl.where(xf == -1.0, -inf_val, res)
+    return res
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+    # Inplace: autotune reruns the kernel on the same buffer, so restore the
+    # input between trials to avoid applying erfinv repeatedly in place.
+    restore_value=["x_ptr"],
+)
+@triton.jit
+def erfinv_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Moore Threads hardware does not support fp64; compute in fp32.
+    out = _erfinv(x.to(tl.float32)).to(x.dtype)
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+# NOTE: the libdevice erfinv intrinsic crashes the MThreads llc backend, so the
+# polynomial helper above is used instead of tl_extra_shim.erfinv.
+
+
+def _use_triton_kernel(x: torch.Tensor) -> bool:
+    if not isinstance(x, torch.Tensor):
+        return False
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if not x.is_contiguous() or x.numel() == 0:
+        return False
+    return True
+
+
+def _launch_erfinv(x: torch.Tensor, out: torch.Tensor):
+    x_flat = x.view(-1)
+    out_flat = out.view(-1)
+    n_elements = out_flat.numel()
+    dtype_size = out_flat.element_size()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(out.device):
+        erfinv_kernel[grid](x_flat, out_flat, n_elements, dtype_size)
+    return out
+
+
+def erfinv_(x):
+    logger.debug("GEMS_MTHREADS ERFINV_")
+    if not _use_triton_kernel(x):
+        return default_erfinv_(x)
+
+    return _launch_erfinv(x, x)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/fmod_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/fmod_.py
@@ -1,0 +1,168 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.fmod import fmod_scalar_ as default_fmod_scalar_
+from flag_gems.ops.fmod import fmod_tensor_ as default_fmod_tensor_
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@triton.jit
+def _fmod_fp32(x, y):
+    # fmod rounds the quotient toward zero (C fmod / torch.fmod semantics),
+    # unlike the modulo operator which floors. Compute in fp32 so half/bf16
+    # inputs keep full intermediate precision before narrowing back.
+    q = x / y
+    q_trunc = tl.where(q >= 0, tl.floor(q), tl.ceil(q))
+    return x - y * q_trunc
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def fmod_inplace_tensor_kernel(
+    x_ptr,
+    y_ptr,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+
+    out = _fmod_fp32(x.to(tl.float32), y.to(tl.float32)).to(x.dtype)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit(do_not_specialize=["scalar"])
+def fmod_inplace_scalar_kernel(
+    x_ptr,
+    scalar,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    y = tl.full((1,), scalar, tl.float32)
+    out = _fmod_fp32(x.to(tl.float32), y).to(x.dtype)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _use_triton_kernel(A) -> bool:
+    if not isinstance(A, torch.Tensor):
+        return False
+    if A.device.type != "musa" or A.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if not A.is_contiguous() or A.numel() == 0:
+        return False
+    return True
+
+
+def _launch_tensor(A: torch.Tensor, B: torch.Tensor):
+    x_flat = A.view(-1)
+    y_flat = B.view(-1)
+    n_elements = x_flat.numel()
+    dtype_size = x_flat.element_size()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(A.device):
+        fmod_inplace_tensor_kernel[grid](x_flat, y_flat, n_elements, dtype_size)
+    return A
+
+
+def _launch_scalar(A: torch.Tensor, scalar: float):
+    x_flat = A.view(-1)
+    n_elements = x_flat.numel()
+    dtype_size = x_flat.element_size()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(A.device):
+        fmod_inplace_scalar_kernel[grid](x_flat, scalar, n_elements, dtype_size)
+    return A
+
+
+def fmod_tensor_(A, B):
+    logger.debug("GEMS_MTHREADS FMOD_")
+    if (
+        _use_triton_kernel(A)
+        and isinstance(B, torch.Tensor)
+        and B.shape == A.shape
+        and B.dtype == A.dtype
+        and B.is_contiguous()
+    ):
+        return _launch_tensor(A, B)
+    return default_fmod_tensor_(A, B)
+
+
+def fmod_scalar_(A, B):
+    logger.debug("GEMS_MTHREADS FMOD_")
+    if _use_triton_kernel(A) and not isinstance(B, torch.Tensor):
+        try:
+            scalar = float(B)
+        except Exception:
+            return default_fmod_scalar_(A, B)
+        return _launch_scalar(A, scalar)
+    return default_fmod_scalar_(A, B)
+
+
+def fmod_(A, B):
+    logger.debug("GEMS_MTHREADS FMOD_")
+    if isinstance(B, torch.Tensor):
+        return fmod_tensor_(A, B)
+    return fmod_scalar_(A, B)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/histc.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/histc.py
@@ -1,0 +1,273 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.histc import histc as default_histc
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+# Upper bound on the number of bins handled by the local-reduce kernel (which
+# builds a per-program bin-count vector). Beyond this we use the direct atomic
+# kernel that issues one atomic add per element.
+MAX_BINS_LOCAL_REDUCE = 1024
+
+NUM_SIPS = 24
+
+
+@libentry()
+@triton.jit
+def histc_kernel(
+    inp_ptr,
+    out_ptr,
+    n_elements,
+    bins: tl.constexpr,
+    min_val,
+    max_val,
+    inv_bin_width,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Direct histogram kernel.
+
+    Each program loads a contiguous tile of ``BLOCK_SIZE`` elements, computes
+    the bin index for every element in fp32 (using int32 indices) and
+    atomically increments the matching global bin counter. Elements outside
+    ``[min_val, max_val]`` and NaNs are ignored. Used when the bin count is
+    too large for the local-reduce kernel.
+    """
+    pid = tl.program_id(0)
+    num_pids = tl.num_programs(0)
+    arange = tl.arange(0, BLOCK_SIZE)
+
+    for block_id in tl.range(
+        pid, (n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE, num_pids
+    ):
+        offset = block_id * BLOCK_SIZE + arange
+        mask = offset < n_elements
+
+        inp_val = tl.load(inp_ptr + offset, mask=mask, other=float("nan")).to(
+            tl.float32
+        )
+
+        # Elements equal to max go to the last bin; out-of-range/NaN ignored.
+        in_range = (inp_val >= min_val) & (inp_val <= max_val)
+
+        # Compute bin index in fp32, then cast to int32 (mthreads has no int64).
+        bin_idx = tl.floor((inp_val - min_val) * inv_bin_width).to(tl.int32)
+        bin_idx = tl.where(inp_val == max_val, bins - 1, bin_idx)
+        # Clamp stray indices (only the in-range ones are stored anyway).
+        bin_idx = tl.where(bin_idx < 0, 0, bin_idx)
+        bin_idx = tl.where(bin_idx >= bins, bins - 1, bin_idx)
+
+        valid_mask = mask & in_range
+        ones = tl.full((BLOCK_SIZE,), 1.0, tl.float32)
+        tl.atomic_add(out_ptr + bin_idx, ones, mask=valid_mask, sem="relaxed")
+
+
+HISTC_LOCAL_REDUCE_CONFIGS = [
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 8192}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 8192}, num_warps=16, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 16384}, num_warps=16, num_stages=2),
+]
+
+
+def _prune_local_reduce_configs(configs, nargs, **meta):
+    n = meta.get("n_elements", nargs["n_elements"])
+    out = []
+    for cfg in configs:
+        bs = cfg.kwargs["BLOCK_SIZE"]
+        # A program loops over ceil(n / BLOCK_SIZE) tiles. When BLOCK_SIZE is
+        # much larger than n, only one program does useful work and the others
+        # sit idle; prefer configs that keep a reasonable number of programs.
+        if bs <= n:
+            out.append(cfg)
+    # Always keep the smallest config as a fallback for tiny inputs.
+    if not out and configs:
+        out = [configs[0]]
+    return out
+
+
+@libentry()
+@triton.autotune(
+    configs=HISTC_LOCAL_REDUCE_CONFIGS,
+    key=["n_elements", "BINS_PADDED"],
+    reset_to_zero=["out_ptr"],
+    prune_configs_by={"early_config_prune": _prune_local_reduce_configs},
+)
+@triton.jit
+def histc_local_reduce_kernel(
+    inp_ptr,
+    out_ptr,
+    n_elements,
+    min_val,
+    max_val,
+    inv_bin_width,
+    BLOCK_SIZE: tl.constexpr,
+    BINS: tl.constexpr,
+    BINS_PADDED: tl.constexpr,
+):
+    """Histogram kernel with a per-program local reduce.
+
+    Each program loads a tile, builds a local bin-count vector of length
+    ``BINS_PADDED`` (a power-of-two >= ``BINS``) with the hardware-accelerated
+    ``tl.histogram`` intrinsic, and only issues ``BINS`` (or fewer) atomic adds
+    to the global histogram instead of ``BLOCK_SIZE``. This greatly reduces
+    global-memory atomic contention when the bin count is modest relative to
+    the tile size.
+    """
+    pid = tl.program_id(0)
+    num_pids = tl.num_programs(0)
+    arange = tl.arange(0, BLOCK_SIZE)
+    bin_arange = tl.arange(0, BINS_PADDED)
+    bin_mask = bin_arange < BINS
+
+    for block_id in tl.range(
+        pid, (n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE, num_pids
+    ):
+        offset = block_id * BLOCK_SIZE + arange
+        mask = offset < n_elements
+
+        inp_val = tl.load(inp_ptr + offset, mask=mask, other=float("nan")).to(
+            tl.float32
+        )
+
+        in_range = (inp_val >= min_val) & (inp_val <= max_val)
+        bin_idx = tl.floor((inp_val - min_val) * inv_bin_width).to(tl.int32)
+        bin_idx = tl.where(inp_val == max_val, BINS - 1, bin_idx)
+        # Invalid lanes are masked out of the histogram; clamp to keep indices
+        # in range so the intrinsic never sees out-of-bounds values.
+        bin_idx = tl.where(in_range, bin_idx, 0)
+
+        valid_mask = mask & in_range
+
+        # Local histogram over the tile (hardware intrinsic).
+        local_counts = tl.histogram(bin_idx, BINS_PADDED, mask=valid_mask).to(
+            tl.float32
+        )
+
+        # Flush the non-zero local counts to the global histogram.
+        flush_mask = bin_mask & (local_counts > 0)
+        tl.atomic_add(
+            out_ptr + bin_arange, local_counts, mask=flush_mask, sem="relaxed"
+        )
+
+
+def _use_triton_kernel(inp: torch.Tensor, bins: int) -> Tuple[bool, int]:
+    if not isinstance(inp, torch.Tensor):
+        return False, 0
+    if inp.device.type != "musa" or inp.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if not inp.is_contiguous() or inp.numel() == 0:
+        return False, 0
+    if bins <= 0:
+        return False, 0
+    return True, inp.element_size()
+
+
+def _resolve_range(inp: torch.Tensor, min_val: float, max_val: float):
+    """Resolve the histogram range, mirroring torch.histc semantics."""
+    if min_val == 0 and max_val == 0:
+        min_val = float(inp.min().item())
+        max_val = float(inp.max().item())
+    return min_val, max_val
+
+
+def histc(inp, bins=100, min=0, max=0):
+    """Compute the histogram of a tensor (mthreads specialized)."""
+    logger.debug("GEMS_MTHREADS HISTC")
+
+    use_triton, _ = _use_triton_kernel(inp, bins)
+    if not use_triton:
+        return default_histc(inp, bins=bins, min=min, max=max)
+
+    inp = inp.contiguous()
+
+    min_val = float(min)
+    max_val = float(max)
+    min_val, max_val = _resolve_range(inp, min_val, max_val)
+
+    out_dtype = inp.dtype
+    # Accumulate in fp32: atomic_add on fp16/bf16 is unsupported on mthreads,
+    # and fp32 accumulation avoids the per-element atomic on the small output.
+    acc = torch.zeros(bins, dtype=torch.float32, device=inp.device)
+    n_elements = inp.numel()
+
+    # Degenerate range: all in-range elements equal min_val, counted in bin 0.
+    if min_val == max_val:
+        count = ((inp == min_val) & ~torch.isnan(inp)).sum().item()
+        acc[0] = count
+        return acc.to(out_dtype)
+
+    inv_bin_width = float(bins) / (max_val - min_val)
+
+    # Use the local-reduce kernel when the bin count is small enough: it
+    # amortizes the global atomics across the whole tile and is markedly faster
+    # for moderate bin counts. Fall back to the direct atomic kernel otherwise.
+    if bins <= MAX_BINS_LOCAL_REDUCE:
+        bins_padded = triton.next_power_of_2(bins)
+        # Cap the grid to a moderate number of programs; each program streams
+        # over multiple tiles, so a small grid is enough to saturate the device
+        # while keeping the autotune key stable.
+        num_programs = builtins.min(triton.cdiv(n_elements, 1024), NUM_SIPS * 4)
+        grid = lambda meta: (
+            builtins.min(
+                triton.cdiv(n_elements, meta["BLOCK_SIZE"]),
+                num_programs,
+            ),
+        )
+        with torch_device_fn.device(inp.device):
+            histc_local_reduce_kernel[grid](
+                inp,
+                acc,
+                n_elements,
+                min_val,
+                max_val,
+                inv_bin_width,
+                BINS=bins,
+                BINS_PADDED=bins_padded,
+            )
+    else:
+        block_size = 8192
+        n_blocks = (n_elements + block_size - 1) // block_size
+        grid = builtins.min(n_blocks, NUM_SIPS * 2)
+        with torch_device_fn.device(inp.device):
+            histc_kernel[(grid,)](
+                inp,
+                acc,
+                n_elements,
+                bins,
+                min_val,
+                max_val,
+                inv_bin_width,
+                BLOCK_SIZE=block_size,
+                num_warps=4,
+                num_stages=2,
+            )
+
+    return acc.to(out_dtype)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/im2col.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/im2col.py
@@ -1,0 +1,200 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.im2col import _compute_output_dims, _parse_2tuple
+from flag_gems.ops.im2col import im2col as default_im2col
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["rows_total", "L"],
+)
+@triton.jit
+def im2col_kernel(
+    x_ptr,  # *Pointer* to input tensor [N, C, H, W]
+    out_ptr,  # *Pointer* to output tensor [N, C*kH*kW, outH*outW]
+    N,
+    C,
+    H,
+    W,
+    kH,
+    kW,
+    dH,
+    dW,
+    pH,
+    pW,
+    sH,
+    sW,
+    outH,
+    outW,
+    rows_total,  # C * kH * kW
+    L,  # outH * outW
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    num_row_tiles = tl.cdiv(rows_total, BLOCK_M)
+    n = pid0 // num_row_tiles
+    row_tile = pid0 % num_row_tiles
+
+    row_offsets = row_tile * BLOCK_M + tl.arange(0, BLOCK_M)
+    col_offsets = pid1 * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_rows = row_offsets < rows_total
+    mask_cols = col_offsets < L
+
+    k_area = kH * kW
+
+    c_idx = row_offsets // k_area
+    rem = row_offsets % k_area
+    kh_idx = rem // kW
+    kw_idx = rem % kW
+
+    oh_vec = col_offsets // outW
+    ow_vec = col_offsets % outW
+
+    # Broadcast to [BLOCK_M, BLOCK_N]
+    oh = oh_vec[None, :]
+    ow = ow_vec[None, :]
+    kh = kh_idx[:, None]
+    kw = kw_idx[:, None]
+    c = c_idx[:, None]
+
+    ih = oh * sH - pH + kh * dH
+    iw = ow * sW - pW + kw * dW
+
+    in_h = (ih >= 0) & (ih < H)
+    in_w = (iw >= 0) & (iw < W)
+    in_bounds = in_h & in_w
+
+    # Base offsets (int64 to avoid overflow on large tensors)
+    base_in = (n.to(tl.int64) * C * H * W).to(tl.int64)
+    base_out = (n.to(tl.int64) * rows_total * L).to(tl.int64)
+
+    ptrs_in = (
+        x_ptr + base_in + ((c.to(tl.int64) * H + ih.to(tl.int64)) * W + iw.to(tl.int64))
+    )
+
+    ptrs_out = (
+        out_ptr
+        + base_out
+        + (row_offsets[:, None].to(tl.int64) * L + col_offsets[None, :].to(tl.int64))
+    )
+
+    mask = mask_rows[:, None] & mask_cols[None, :] & in_bounds
+
+    vals = tl.load(ptrs_in, mask=mask, other=0)
+    tl.store(ptrs_out, vals, mask=(mask_rows[:, None] & mask_cols[None, :]))
+
+
+def _use_triton_kernel(x: torch.Tensor) -> bool:
+    if not isinstance(x, torch.Tensor):
+        return False
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    return True
+
+
+def _launch_im2col(x, out, kH, kW, dH, dW, pH, pW, sH, sW):
+    x = x.contiguous()
+    out = out.contiguous()
+
+    N, C, H, W = x.shape
+    outH, outW = _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW)
+    rows_total = C * kH * kW
+    L = outH * outW
+
+    if rows_total == 0 or L == 0 or N == 0:
+        return out
+
+    grid = lambda META: (
+        N * triton.cdiv(rows_total, META["BLOCK_M"]),
+        triton.cdiv(L, META["BLOCK_N"]),
+    )
+
+    with torch_device_fn.device(out.device):
+        im2col_kernel[grid](
+            x,
+            out,
+            N,
+            C,
+            H,
+            W,
+            kH,
+            kW,
+            dH,
+            dW,
+            pH,
+            pW,
+            sH,
+            sW,
+            outH,
+            outW,
+            rows_total,
+            L,
+        )
+    return out
+
+
+def im2col(input, kernel_size, dilation=1, padding=0, stride=1):
+    logger.debug("GEMS_MTHREADS IM2COL")
+    if not _use_triton_kernel(input):
+        return default_im2col(input, kernel_size, dilation, padding, stride)
+
+    x = input
+    if x.ndim == 3:
+        x = x.unsqueeze(0)
+    if x.ndim != 4:
+        return default_im2col(input, kernel_size, dilation, padding, stride)
+
+    kH, kW = _parse_2tuple(kernel_size, "kernel_size")
+    dH, dW = _parse_2tuple(dilation, "dilation")
+    pH, pW = _parse_2tuple(padding, "padding")
+    sH, sW = _parse_2tuple(stride, "stride")
+
+    N, C, H, W = x.shape
+    outH, outW = _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW)
+    rows_total = C * kH * kW
+    L = outH * outW
+
+    out = torch.empty((N, rows_total, L), device=x.device, dtype=x.dtype)
+    if L == 0 or rows_total == 0 or N == 0:
+        return out if input.ndim == 4 else out.squeeze(0)
+
+    _launch_im2col(x, out, kH, kW, dH, dW, pH, pW, sH, sW)
+    return out if input.ndim == 4 else out.squeeze(0)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/index_copy_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/index_copy_.py
@@ -1,0 +1,164 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.index_copy_ import index_copy as default_index_copy
+from flag_gems.ops.index_copy_ import index_copy_ as default_index_copy_
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+# mthreads hardware does not support fp64/int64 arithmetic inside kernels.
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+# All linear offsets must fit into int32 (int64 not supported on mthreads).
+_INT32_MAX = 2**31 - 1
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+    ],
+    key=["N"],
+)
+@triton.jit
+def index_copy_kernel(
+    index_ptr,
+    src_ptr,
+    out_ptr,
+    N,
+    inp_numel,
+    inp_stride_dim,
+    inp_shape_dim,
+    src_shape_dim,
+    delta,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Flat scatter kernel for index_copy.
+
+    `src` is contiguous, so its linear offset equals `offsets`. `out` is
+    contiguous with the same layout as `src` for all dims != dim, hence
+    `inp_stride_dim == out.stride(dim) == src.stride(dim)`.
+
+    For each src linear offset:
+        pre_idx    -> flattened index over dims before `dim`
+        dim_idx    -> position along `dim` inside src
+        src_dim_idx = index[dim_idx] -> target position along `dim` in out
+        out_idx    = src_offset + (delta*pre_idx + src_dim_idx - dim_idx) * inp_stride_dim
+
+    All arithmetic stays in int32; callers guarantee offsets fit in int32.
+    """
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+
+    src_offset = offsets
+    pre_cal = inp_stride_dim * src_shape_dim
+    pre_idx = src_offset // pre_cal
+    dim_idx = (src_offset % pre_cal) // inp_stride_dim
+
+    src_dim_idx = tl.load(index_ptr + dim_idx, mask=mask, other=0)
+
+    out_idx = src_offset + (delta * pre_idx + src_dim_idx - dim_idx) * inp_stride_dim
+    out_mask = mask & (out_idx >= 0) & (out_idx < inp_numel)
+
+    src_val = tl.load(src_ptr + src_offset, mask=mask, other=0.0)
+    tl.store(out_ptr + out_idx, src_val, mask=out_mask)
+
+
+def _use_triton_kernel(inp, index, src):
+    if not (
+        isinstance(inp, torch.Tensor)
+        and isinstance(index, torch.Tensor)
+        and isinstance(src, torch.Tensor)
+    ):
+        return False
+    if inp.device.type != "musa":
+        return False
+    if inp.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if inp.numel() == 0 or src.numel() == 0:
+        return False
+    if inp.ndim != src.ndim:
+        return False
+    # Keep all offsets inside int32 range (no int64 on mthreads).
+    if inp.numel() > _INT32_MAX or src.numel() > _INT32_MAX:
+        return False
+    return True
+
+
+def _launch_index_copy(out, dim, index, src):
+    """Scatter `src` into the contiguous tensor `out` in place along `dim`."""
+    dim = dim % out.ndim
+    inp_stride_dim = out.stride(dim)
+    src_shape_dim = src.size(dim)
+    inp_shape_dim = out.size(dim)
+    delta = inp_shape_dim - src_shape_dim
+    N = src.numel()
+
+    # index must be int32 (int64 not supported on mthreads hardware)
+    index = index.contiguous().to(torch.int32)
+    src = src.contiguous()
+
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+
+    with torch_device_fn.device(out.device):
+        index_copy_kernel[grid](
+            index,
+            src,
+            out,
+            N,
+            out.numel(),
+            inp_stride_dim,
+            inp_shape_dim,
+            src_shape_dim,
+            delta,
+        )
+    return out
+
+
+def index_copy(inp, dim, index, src):
+    logger.debug("GEMS_MTHREADS INDEX_COPY")
+    if not _use_triton_kernel(inp, index, src):
+        return default_index_copy(inp, dim, index, src)
+
+    out = inp.clone().contiguous()
+    return _launch_index_copy(out, dim, index, src)
+
+
+def index_copy_(inp, dim, index, src):
+    logger.debug("GEMS_MTHREADS INDEX_COPY_")
+    if not _use_triton_kernel(inp, index, src):
+        return default_index_copy_(inp, dim, index, src)
+
+    if inp.is_contiguous():
+        _launch_index_copy(inp, dim, index, src)
+    else:
+        work = inp.contiguous()
+        _launch_index_copy(work, dim, index, src)
+        inp.copy_(work)
+    return inp

--- a/src/flag_gems/runtime/backend/_mthreads/ops/linalg_cholesky.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/linalg_cholesky.py
@@ -1,0 +1,173 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.linalg_cholesky import linalg_cholesky as default_linalg_cholesky
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+# PyTorch's linalg_cholesky only accepts fp32/fp64, and Moore Threads hardware
+# does not support fp64 compute (support_fp64 is False). The specialized kernel
+# therefore targets fp32 only; fp64 (and any other dtype) falls back to the
+# generic implementation. Accumulation happens in the native element type.
+_SUPPORTED_DTYPES = {torch.float32}
+
+
+@libentry()
+@triton.jit
+def cholesky_kernel(
+    A,
+    L,
+    N,
+    batch_stride,
+    stride_a,
+    stride_l,
+    BLOCK_ROW: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Cholesky decomposition kernel (column-by-column, right-looking).
+
+    Each program computes the lower-triangular factor L of one matrix in the
+    batch such that A = L @ L^T. Columns are processed sequentially (they are
+    data-dependent), but within a column all rows i >= j are computed in
+    parallel and the dot-product reduction over previous columns is vectorized.
+    Accumulation uses the input element type to preserve precision.
+    """
+    pid = tl.program_id(0)
+    base = pid * batch_stride
+
+    rows = tl.arange(0, BLOCK_ROW)
+    ks = tl.arange(0, BLOCK_K)
+
+    for j in range(N):
+        k_mask = ks < j
+        # L[j, k] for k < j
+        ljk = tl.load(L + base + j * stride_l + ks, mask=k_mask, other=0.0)
+
+        # Diagonal: L[j, j] = sqrt(A[j, j] - sum_{k<j} L[j, k]^2)
+        diag_sum = tl.sum(ljk * ljk, axis=0)
+        a_diag = tl.load(A + base + j * stride_a + j)
+        l_diag = tl.sqrt(a_diag - diag_sum)
+        tl.store(L + base + j * stride_l + j, l_diag)
+
+        # Off-diagonal rows i > j, all computed in parallel:
+        #   L[i, j] = (A[i, j] - sum_{k<j} L[i, k] * L[j, k]) / L[j, j]
+        row_mask = (rows > j) & (rows < N)
+        lik = tl.load(
+            L + base + rows[:, None] * stride_l + ks[None, :],
+            mask=row_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        dot = tl.sum(lik * ljk[None, :], axis=1)
+        a_col = tl.load(A + base + rows * stride_a + j, mask=row_mask, other=0.0)
+        l_col = (a_col - dot) / l_diag
+        tl.store(L + base + rows * stride_l + j, l_col, mask=row_mask)
+
+        # Column j+1 reads column j, which was just written cooperatively by
+        # multiple threads. Synchronize so those stores are visible before the
+        # next iteration loads them.
+        tl.debug_barrier()
+
+
+def _use_triton_kernel(x):
+    if not isinstance(x, torch.Tensor):
+        return False
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if x.numel() == 0 or x.dim() < 2:
+        return False
+    if x.is_complex():
+        return False
+    if x.shape[-1] != x.shape[-2]:
+        return False
+    return True
+
+
+def linalg_cholesky(A, upper=False):
+    logger.debug("GEMS_MTHREADS LINALG_CHOLESKY")
+
+    if not _use_triton_kernel(A):
+        return default_linalg_cholesky(A, upper=upper)
+
+    shape = A.shape
+    n = shape[-1]
+
+    if len(shape) == 2:
+        batch_size = 1
+    else:
+        batch_size = 1
+        for dim in shape[:-2]:
+            batch_size *= dim
+
+    # Symmetrize to guard against non-symmetric inputs and improve stability.
+    if len(shape) == 2:
+        A_sym = (A + A.transpose(-2, -1)) / 2
+    else:
+        A_view = A.reshape(-1, n, n)
+        A_sym = ((A_view + A_view.transpose(1, 2)) / 2).reshape(shape)
+
+    A_sym = A_sym.contiguous()
+    L = torch.empty_like(A_sym)
+
+    if len(shape) > 2:
+        A_kernel = A_sym.reshape(-1, n, n)
+        L_kernel = L.reshape(-1, n, n)
+        stride_a = A_kernel.stride(1)
+        stride_l = L_kernel.stride(1)
+        batch_stride = A_kernel.stride(0)
+    else:
+        A_kernel = A_sym
+        L_kernel = L
+        stride_a = A_sym.stride(0)
+        stride_l = L.stride(0)
+        batch_stride = stride_a * n
+
+    grid = (batch_size,)
+    block = triton.next_power_of_2(n)
+    # More rows per column benefit from more warps; keep it bounded.
+    num_warps = max(1, min(16, block // 32))
+
+    with torch_device_fn.device(A.device):
+        with torch.no_grad():
+            cholesky_kernel[grid](
+                A_kernel,
+                L_kernel,
+                n,
+                batch_stride,
+                stride_a,
+                stride_l,
+                BLOCK_ROW=block,
+                BLOCK_K=block,
+                num_warps=num_warps,
+            )
+
+    # Keep only the lower triangle (kernel does not touch the upper part).
+    if len(shape) > 2:
+        L = torch.tril(L.reshape(-1, n, n)).reshape(shape)
+    else:
+        L = torch.tril(L)
+
+    if upper:
+        L = L.transpose(-2, -1).conj()
+
+    return L

--- a/src/flag_gems/runtime/backend/_mthreads/ops/log_normal_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/log_normal_.py
@@ -1,0 +1,123 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.ops.log_normal_ import log_normal_ as default_log_normal_
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.random_utils import (
+    philox_backend_seed_offset,
+    uint_to_uniform_float,
+)
+from flag_gems.utils.shape_utils import volume
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+UNROLL = 4
+
+try:
+    pair_uniform_to_normal = tl.pair_uniform_to_normal
+except AttributeError:
+
+    @triton.jit
+    def pair_uniform_to_normal(u1, u2):
+        """Box-Muller transform"""
+        u1 = tl.maximum(1.0e-7, u1)
+        th = 6.283185307179586 * u2
+        r = tl.sqrt(-2.0 * tl.log(u1))
+        return r * tl.cos(th), r * tl.sin(th)
+
+
+@triton.heuristics(runtime.get_heuristic_config("randn"))
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "mean", "std"])
+def log_normal_kernel(
+    out_ptr,
+    N,
+    mean,
+    std,
+    philox_seed,
+    philox_offset,
+    BLOCK: tl.constexpr,
+):
+    # Fused single-kernel log-normal sampler: Philox RNG -> uniform float ->
+    # Box-Muller normal -> exp(n*std + mean). The generic implementation writes
+    # the normal samples to a temporary fp32 buffer and runs a second
+    # elementwise kernel to apply the exp() transform into the output tensor.
+    # Fusing everything into one kernel drops the temporary allocation and the
+    # second launch, which is the win on large shapes.
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+    i4 = (tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)).to(tl.uint32)
+    c0 += i4
+    _O = c0 * 0
+    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
+    r0 = uint_to_uniform_float(r0)
+    r1 = uint_to_uniform_float(r1)
+    r2 = uint_to_uniform_float(r2)
+    r3 = uint_to_uniform_float(r3)
+    n0, n1 = pair_uniform_to_normal(r0, r1)
+    n2, n3 = pair_uniform_to_normal(r2, r3)
+
+    y0 = tl.exp(n0 * std + mean)
+    y1 = tl.exp(n1 * std + mean)
+    y2 = tl.exp(n2 * std + mean)
+    y3 = tl.exp(n3 * std + mean)
+
+    off_0 = (tl.program_id(0) * BLOCK * 4).to(tl.int64) + tl.arange(0, BLOCK)
+    off_1 = off_0 + BLOCK
+    off_2 = off_1 + BLOCK
+    off_3 = off_2 + BLOCK
+
+    tl.store(out_ptr + off_0, y0, mask=off_0 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_1, y1, mask=off_1 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_2, y2, mask=off_2 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_3, y3, mask=off_3 < N, eviction_policy="evict_first")
+
+
+def _use_triton_kernel(self) -> bool:
+    if not isinstance(self, torch.Tensor):
+        return False
+    if self.device.type != "musa" or self.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if not self.is_contiguous() or self.numel() == 0:
+        return False
+    return True
+
+
+def log_normal_(self, mean=1.0, std=2.0, *, generator=None):
+    logger.debug("GEMS_MTHREADS LOG_NORMAL_")
+    if not _use_triton_kernel(self):
+        return default_log_normal_(self, mean=mean, std=std, generator=generator)
+
+    N = volume(self.shape)
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+    increment = triton.cdiv(N, UNROLL)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
+    with torch_device_fn.device(self.device):
+        log_normal_kernel[grid_fn](
+            self, N, float(mean), float(std), philox_seed, philox_offset
+        )
+    return self

--- a/src/flag_gems/runtime/backend/_mthreads/ops/median.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/median.py
@@ -1,0 +1,221 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.median import (
+    MedianResult,
+    _canonical_dim,
+    _copy_out,
+    _has_names,
+    _name_to_dim,
+)
+from flag_gems.ops.median import median as default_median
+from flag_gems.ops.median import median_dim as default_median_dim
+from flag_gems.ops.topk import _get_iinfo_val
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+# Moore Threads hardware does not support fp64/int64 compute. The in-register
+# sort kernel below handles the fixed-width dtypes listed here; any other dtype
+# falls back to the generic implementation for correctness.
+_SUPPORTED_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.int8,
+    torch.uint8,
+    torch.int16,
+    torch.int32,
+}
+
+# Above this reduction width an in-register sort becomes too costly; hand those
+# rows to the generic implementation (which switches to a binary-search select).
+_SORT_SELECT_LIMIT = 8192
+
+
+@libentry()
+@triton.jit
+def median_sort_select_kernel(
+    inp,
+    values,
+    indices,
+    M,
+    N,
+    RANK,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    rows = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    row_mask = rows < M
+
+    cols = tl.arange(0, BLOCK_N)
+    valid = (cols[None, :] < N) & row_mask[:, None]
+    ptrs = inp + rows[:, None] * N + cols[None, :]
+
+    is_float: tl.constexpr = inp.dtype.element_ty.is_floating()
+    rank_mask = cols[None, :] == RANK
+
+    if is_float:
+        # Sort in fp32: the mthreads LLVM backend cannot lower bf16 comparisons.
+        high = tl.full((), float("inf"), dtype=tl.float32)
+        data = tl.load(ptrs, mask=valid, other=0.0)
+        fdata = data.to(tl.float32)
+        nan_mask = valid & (fdata != fdata)
+        sortable = tl.where(valid & ~nan_mask, fdata, high)
+        ordered = tl.sort(sortable, dim=1, descending=False)
+        median_key = tl.sum(
+            tl.where(rank_mask, ordered, tl.zeros_like(ordered)), axis=1
+        )
+        first_match = tl.argmax(
+            (valid & ~nan_mask & (fdata == median_key[:, None])).to(tl.int32), axis=1
+        )
+        nan_i32 = nan_mask.to(tl.int32)
+        has_nan = tl.max(nan_i32, axis=1) != 0
+        first_nan = tl.argmax(nan_i32, axis=1)
+        first_match = tl.where(has_nan, first_nan, first_match)
+    else:
+        high = tl.full(
+            (),
+            _get_iinfo_val(inp.dtype.element_ty, return_max=True),
+            dtype=inp.dtype.element_ty,
+        )
+        data = tl.load(ptrs, mask=valid, other=high)
+        sortable = tl.where(valid, data, high)
+        ordered = tl.sort(sortable, dim=1, descending=False)
+        median_key = tl.sum(
+            tl.where(rank_mask, ordered, tl.zeros_like(ordered)), axis=1
+        )
+        first_match = tl.argmax(
+            (valid & (data == median_key[:, None])).to(tl.int32), axis=1
+        )
+
+    # Gather the original element at the selected index so the stored value keeps
+    # the input dtype exactly (also preserves signed zero / NaN payloads).
+    selected_value = tl.load(inp + rows * N + first_match, mask=row_mask, other=0)
+
+    tl.store(values + rows, selected_value, mask=row_mask)
+    tl.store(indices + rows, first_match.to(tl.int64), mask=row_mask)
+
+
+def _use_triton_kernel(inp):
+    if not isinstance(inp, torch.Tensor):
+        return False
+    if inp.device.type != "musa":
+        return False
+    if inp.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if _has_names(inp):
+        return False
+    return True
+
+
+def _median_select(work_2d):
+    """Lower-median value and a selecting index for each row of a (M, N) tensor."""
+    m, n = work_2d.shape
+    device = work_2d.device
+
+    values = torch.empty((m,), dtype=work_2d.dtype, device=device)
+    indices = torch.empty((m,), dtype=torch.int64, device=device)
+
+    block_n = triton.next_power_of_2(n)
+    if block_n >= 512:
+        block_m = 1
+    elif block_n >= 128:
+        block_m = 4
+    else:
+        block_m = 16
+    num_warps = min(8, max(4, block_n // 512)) if block_n >= 128 else 1
+
+    rank = (n - 1) // 2
+    grid = (triton.cdiv(m, block_m),)
+    with torch_device_fn.device(device):
+        median_sort_select_kernel[grid](
+            work_2d,
+            values,
+            indices,
+            m,
+            n,
+            rank,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            num_warps=num_warps,
+        )
+    return values, indices
+
+
+def median(inp):
+    logger.debug("GEMS_MTHREADS MEDIAN")
+    if (
+        not _use_triton_kernel(inp)
+        or inp.numel() <= 1
+        or inp.numel() > _SORT_SELECT_LIMIT
+    ):
+        return default_median(inp)
+
+    work_2d = inp.contiguous().reshape(1, inp.numel())
+    values, _ = _median_select(work_2d)
+    return values.reshape(())
+
+
+def median_out(inp, *, out):
+    logger.debug("GEMS_MTHREADS MEDIAN.OUT")
+    return _copy_out(median(inp), out, "out")
+
+
+def median_dim(inp, dim=0, keepdim=False):
+    logger.debug("GEMS_MTHREADS MEDIAN.DIM")
+    if not _use_triton_kernel(inp) or inp.ndim == 0:
+        return default_median_dim(inp, dim=dim, keepdim=keepdim)
+
+    # Resolve/validate the reduction dim exactly like the generic path so
+    # out-of-range dims still raise IndexError before we launch any kernel.
+    if isinstance(dim, str):
+        dim = _name_to_dim(inp, dim)
+    dim = _canonical_dim(inp.ndim, dim)
+
+    if inp.shape[dim] == 0 or inp.numel() == 0 or inp.shape[dim] > _SORT_SELECT_LIMIT:
+        return default_median_dim(inp, dim=dim, keepdim=keepdim)
+
+    work = torch.movedim(inp, dim, -1).contiguous()
+    batch_shape = work.shape[:-1]
+    n = work.shape[-1]
+    m = work.numel() // n
+    work_2d = work.reshape(m, n)
+
+    values, indices = _median_select(work_2d)
+    values = values.reshape(batch_shape)
+    indices = indices.reshape(batch_shape)
+
+    if keepdim:
+        values = values.unsqueeze(dim)
+        indices = indices.unsqueeze(dim)
+
+    return MedianResult(values=values, indices=indices)
+
+
+def median_dim_values(inp, dim=0, keepdim=False, *, values, indices):
+    logger.debug("GEMS_MTHREADS MEDIAN.DIM_VALUES")
+    result = median_dim(inp, dim=dim, keepdim=keepdim)
+    _copy_out(result.values, values, "values")
+    _copy_out(result.indices, indices, "indices")
+    return MedianResult(values=values, indices=indices)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/mish.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/mish.py
@@ -1,0 +1,113 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.mish import mish as default_mish
+from flag_gems.ops.mish import mish_ as default_mish_
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+exp = tl_extra_shim.exp
+log = tl_extra_shim.log
+fast_tanh = tl_extra_shim.fast_tanh
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048, "VEC": 4}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096, "VEC": 1}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096, "VEC": 2}, num_warps=16, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def mish_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # mish(x) = x * tanh(softplus(x)) = x * tanh(ln(1 + e^x))
+    # compute in fp32 (mthreads has no fp64); tails are stable since for
+    # large |x| mish -> x (pos) or 0 (neg) and tanh saturates accordingly.
+    x_fp32 = x.to(tl.float32)
+    out = (x_fp32 * fast_tanh(log(1.0 + exp(x_fp32)))).to(x.dtype)
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def _use_triton_kernel(x: torch.Tensor) -> Tuple[bool, int]:
+    if not isinstance(x, torch.Tensor):
+        return False, 0
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if x.numel() == 0 or not x.is_contiguous():
+        return False, 0
+    return True, x.element_size()
+
+
+def _launch_mish(x: torch.Tensor, out: torch.Tensor, dtype_size: int):
+    x_flat = x.view(-1)
+    out_flat = out.view(-1)
+    n_elements = out_flat.numel()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(out.device):
+        mish_kernel[grid](x_flat, out_flat, n_elements, dtype_size)
+    return out
+
+
+def mish(A):
+    logger.debug("GEMS_MTHREADS MISH")
+    use_triton, dtype_size = _use_triton_kernel(A)
+    if not use_triton:
+        return default_mish(A)
+
+    out = torch.empty_like(A)
+    return _launch_mish(A, out, dtype_size)
+
+
+def mish_(A):
+    logger.debug("GEMS_MTHREADS MISH_")
+    use_triton, dtype_size = _use_triton_kernel(A)
+    if not use_triton:
+        return default_mish_(A)
+
+    return _launch_mish(A, A, dtype_size)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/nonzero_numpy.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/nonzero_numpy.py
@@ -1,0 +1,273 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.nonzero_numpy import nonzero_numpy as default_nonzero_numpy
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+# Threshold for single-block vs two-pass strategy. A block-local cumsum is cheap
+# up to a few thousand lanes; past that the two-pass count + fill avoids the
+# full-tensor scan bottleneck of the generic nonzero() path.
+SINGLE_BLOCK_THRESHOLD = 8192
+
+# Block size for the two-pass count + fill kernels.
+TWO_PASS_BLOCK = 2048
+
+# Per-axis sizes are passed as scalar kernel arguments (up to MAX_NDIM). Building
+# a device tensor of the shape would cost host + H2D overhead per call that would
+# dominate on the small shapes.
+MAX_NDIM = 4
+
+
+@libentry()
+@triton.jit
+def nonzero_single_kernel(
+    inp,
+    out,
+    count_ptr,
+    n_elements,
+    s0,
+    s1,
+    s2,
+    s3,
+    ndim: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Single-block nonzero for small tensors (grid == (1,)).
+
+    Fuses the (!=0) test, block-local prefix-sum, per-axis index decomposition
+    and structure-of-arrays scatter into one launch, so the local cumsum is
+    already the global prefix sum -- no cross-block scan needed.
+    """
+    pid = tl.program_id(0)
+    off = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = off < n_elements
+
+    vals = tl.load(inp + off, mask=mask, other=0)
+    nz = (vals != 0) & mask
+
+    local_pos = tl.cumsum(nz.to(tl.int32))
+    local_pos = tl.where(nz, local_pos - 1, 0)
+
+    cnt = tl.sum(nz.to(tl.int32))
+    if pid == 0:
+        tl.store(count_ptr, cnt)
+
+    idx_flat = off
+    if ndim >= 4:
+        d = idx_flat % s3
+        idx_flat = idx_flat // s3
+        tl.store(out + 3 * n_elements + local_pos, d.to(tl.int64), mask=nz)
+    if ndim >= 3:
+        d = idx_flat % s2
+        idx_flat = idx_flat // s2
+        tl.store(out + 2 * n_elements + local_pos, d.to(tl.int64), mask=nz)
+    if ndim >= 2:
+        d = idx_flat % s1
+        idx_flat = idx_flat // s1
+        tl.store(out + 1 * n_elements + local_pos, d.to(tl.int64), mask=nz)
+    if ndim >= 1:
+        d = idx_flat % s0
+        tl.store(out + 0 * n_elements + local_pos, d.to(tl.int64), mask=nz)
+
+
+@libentry()
+@triton.jit
+def nonzero_count_kernel(
+    inp,
+    block_counts,
+    n_elements,
+    BLOCK: tl.constexpr,
+):
+    """First pass for large tensors: count nonzeros per block."""
+    pid = tl.program_id(0)
+    off = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = off < n_elements
+    vals = tl.load(inp + off, mask=mask, other=0)
+    nz = (vals != 0) & mask
+    tl.store(block_counts + pid, tl.sum(nz.to(tl.int32)))
+
+
+@libentry()
+@triton.jit
+def nonzero_fill_kernel(
+    inp,
+    block_counts,
+    offsets,
+    out,
+    n_elements,
+    s0,
+    s1,
+    s2,
+    s3,
+    n_total,
+    ndim: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Second pass: scatter indices with a per-block exclusive-prefix offset.
+
+    ``offsets`` holds the inclusive prefix sum of per-block counts; a block's
+    exclusive base is ``offsets[pid] - block_counts[pid]``. This preserves stable
+    input order without atomics.
+    """
+    pid = tl.program_id(0)
+    off = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = off < n_elements
+    vals = tl.load(inp + off, mask=mask, other=0)
+    nz = (vals != 0) & mask
+
+    cnt = tl.load(block_counts + pid)
+    incl = tl.load(offsets + pid)
+    base = incl - cnt
+
+    local_pos = tl.cumsum(nz.to(tl.int32))
+    local_pos = tl.where(nz, local_pos - 1, 0)
+    pos = base + local_pos
+
+    idx_flat = off
+    if ndim >= 4:
+        d = idx_flat % s3
+        idx_flat = idx_flat // s3
+        tl.store(out + 3 * n_total + pos, d.to(tl.int64), mask=nz)
+    if ndim >= 3:
+        d = idx_flat % s2
+        idx_flat = idx_flat // s2
+        tl.store(out + 2 * n_total + pos, d.to(tl.int64), mask=nz)
+    if ndim >= 2:
+        d = idx_flat % s1
+        idx_flat = idx_flat // s1
+        tl.store(out + 1 * n_total + pos, d.to(tl.int64), mask=nz)
+    if ndim >= 1:
+        d = idx_flat % s0
+        tl.store(out + 0 * n_total + pos, d.to(tl.int64), mask=nz)
+
+
+def _shape_scalars(inp):
+    """Per-axis sizes as scalar ints, outermost axis first, padded to MAX_NDIM."""
+    shape = list(inp.shape)
+    return shape + [1] * (MAX_NDIM - len(shape))
+
+
+def _nonzero_single(inp, n_elements, ndim, shape):
+    flat = inp.contiguous().view(n_elements)
+    block = triton.next_power_of_2(max(n_elements, 4))
+    num_warps = 4 if block <= 4096 else 8
+    out = torch.empty(ndim, n_elements, dtype=torch.int64, device=inp.device)
+    count = torch.empty(1, dtype=torch.int32, device=inp.device)
+    with torch_device_fn.device(inp.device):
+        nonzero_single_kernel[(1,)](
+            flat,
+            out,
+            count,
+            n_elements,
+            shape[0],
+            shape[1],
+            shape[2],
+            shape[3],
+            ndim,
+            BLOCK=block,
+            num_warps=num_warps,
+        )
+    nnz = int(count.item())
+    return [out[d, :nnz] for d in range(ndim)]
+
+
+def _nonzero_two_pass(inp, n_elements, ndim, shape):
+    flat = inp.contiguous().view(n_elements)
+    block = TWO_PASS_BLOCK
+    grid = triton.cdiv(n_elements, block)
+    block_counts = torch.empty(grid, dtype=torch.int32, device=inp.device)
+    with torch_device_fn.device(inp.device):
+        nonzero_count_kernel[(grid,)](
+            flat,
+            block_counts,
+            n_elements,
+            BLOCK=block,
+        )
+    offsets = block_counts.cumsum(axis=0)
+    nnz = int(offsets[grid - 1].item())
+    if nnz == 0:
+        return [inp.new_empty(0, dtype=torch.int64) for _ in range(ndim)]
+    out = torch.empty(ndim, nnz, dtype=torch.int64, device=inp.device)
+    with torch_device_fn.device(inp.device):
+        nonzero_fill_kernel[(grid,)](
+            flat,
+            block_counts,
+            offsets,
+            out,
+            n_elements,
+            shape[0],
+            shape[1],
+            shape[2],
+            shape[3],
+            nnz,
+            ndim,
+            BLOCK_SIZE=block,
+            num_warps=8,
+        )
+    return [out[d] for d in range(ndim)]
+
+
+def _use_triton_kernel(inp) -> bool:
+    if not isinstance(inp, torch.Tensor):
+        return False
+    if inp.device.type != "musa":
+        return False
+    # The optimized kernels decompose the flat index using per-axis scalar
+    # arguments up to MAX_NDIM; higher-rank inputs defer to the generic path.
+    if inp.ndim == 0 or inp.ndim > MAX_NDIM:
+        return False
+    return True
+
+
+def nonzero_numpy(inp):
+    """Moore Threads (MUSA) specialized ``nonzero_numpy``.
+
+    Two-tier strategy (matching the thead/iluvatar backends):
+
+    * small tensor (<= SINGLE_BLOCK_THRESHOLD, <= 4-D): single-block fused
+      kernel (count + index decompose + scatter, one launch)
+    * large tensor (<= 4-D): two-pass count + cumsum + fill, avoiding the
+      full-tensor scan of the generic path
+    * otherwise: fall back to the generic ``nonzero()`` + ``unbind()``.
+
+    The generic implementation delegates to ``nonzero()`` which issues three
+    separate kernels per call (elementwise !=0, full-tensor cumsum, scatter);
+    that launch overhead dominates on the benchmark shapes.
+    """
+    logger.debug("GEMS_MTHREADS NONZERO_NUMPY")
+    if not _use_triton_kernel(inp):
+        return default_nonzero_numpy(inp)
+
+    inp = inp.contiguous()
+    n_elements = inp.numel()
+    ndim = inp.ndim
+
+    if n_elements == 0:
+        return [inp.new_empty(0, dtype=torch.int64) for _ in range(ndim)]
+
+    shape = _shape_scalars(inp)
+    if n_elements <= SINGLE_BLOCK_THRESHOLD:
+        return _nonzero_single(inp, n_elements, ndim, shape)
+    return _nonzero_two_pass(inp, n_elements, ndim, shape)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/norm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/norm.py
@@ -1,0 +1,223 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.norm import norm as default_norm
+from flag_gems.ops.norm import norm_scalar as default_norm_scalar
+from flag_gems.ops.norm import norm_scalaropt_dim as default_norm_scalaropt_dim
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+from flag_gems.utils import triton_lang_extension as tle
+
+pow = tl_extra_shim.pow
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+# Reduction identifiers. Wrapped as tl.constexpr so they can be referenced from
+# within @triton.jit kernels (plain module globals are not accessible there).
+# 0: L2 (sum of squares), 1: +inf (max abs), 2: -inf (min abs),
+# 3: L0 (count nonzero), 4: general Lp (sum of |x|^p).
+_RED_L2 = tl.constexpr(0)
+_RED_MAX = tl.constexpr(1)
+_RED_MIN = tl.constexpr(2)
+_RED_L0 = tl.constexpr(3)
+_RED_LP = tl.constexpr(4)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=1),
+    ],
+    key=["M"],
+)
+@triton.jit(do_not_specialize=["ord"])
+def norm_partial_kernel(
+    X,
+    Partial,
+    M,
+    ord,
+    num_blocks,
+    RED: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Grid-stride pass 1: each program folds many BLOCK_SIZE-wide tiles into a
+    # single partial, so the grid stays bounded regardless of M (the generic
+    # kernel launches ~sqrt(M) programs each doing one giant vector load, which
+    # collapses occupancy on large tensors).
+    pid = tle.program_id(0)
+    if RED == _RED_MAX:
+        acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    elif RED == _RED_MIN:
+        acc = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+    else:
+        acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+
+    start = pid * BLOCK_SIZE
+    stride = num_blocks * BLOCK_SIZE
+    for off in range(start, M, stride):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < M
+        if RED == _RED_MIN:
+            a = tl.load(X + cols, mask=mask, other=float("inf")).to(tl.float32)
+            acc = tl.minimum(tl.abs(a), acc)
+        else:
+            a = tl.load(X + cols, mask=mask, other=0.0).to(tl.float32)
+            if RED == _RED_L2:
+                acc += a * a
+            elif RED == _RED_MAX:
+                acc = tl.maximum(tl.abs(a), acc)
+            elif RED == _RED_L0:
+                acc += tl.where(a != 0, 1.0, 0.0)
+            else:  # _RED_LP
+                acc += pow(tl.abs(a), ord)
+
+    if RED == _RED_MAX:
+        val = tl.max(acc)
+    elif RED == _RED_MIN:
+        val = tl.min(acc)
+    else:
+        val = tl.sum(acc)
+    tl.store(Partial + pid, val)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["ord"])
+def norm_finalize_kernel(
+    Partial,
+    Out,
+    num_blocks,
+    ord,
+    RED: tl.constexpr,
+    BLOCK_MID: tl.constexpr,
+):
+    offset = tl.arange(0, BLOCK_MID)
+    mask = offset < num_blocks
+    if RED == _RED_MIN:
+        p = tl.load(Partial + offset, mask=mask, other=float("inf")).to(tl.float32)
+        out = tl.min(p)
+    elif RED == _RED_MAX:
+        p = tl.load(Partial + offset, mask=mask, other=0.0).to(tl.float32)
+        out = tl.max(p)
+    else:
+        p = tl.load(Partial + offset, mask=mask, other=0.0).to(tl.float32)
+        s = tl.sum(p)
+        if RED == _RED_L2:
+            out = tl.sqrt(s)
+        elif RED == _RED_L0:
+            out = s
+        else:  # _RED_LP
+            out = pow(tl.abs(s), 1.0 / ord)
+    tl.store(Out, out)
+
+
+def _red_kind(p):
+    if p == 2:
+        return _RED_L2.value, 2.0
+    if p == float("inf"):
+        return _RED_MAX.value, 0.0
+    if p == -float("inf"):
+        return _RED_MIN.value, 0.0
+    if p == 0:
+        return _RED_L0.value, 0.0
+    return _RED_LP.value, float(p)
+
+
+def _is_full_reduction(x, dim) -> bool:
+    if dim is None:
+        return True
+    if isinstance(dim, (list, tuple)):
+        if len(dim) == 0:
+            return True
+        axes = {d % x.ndim for d in dim}
+        return len(axes) == x.ndim
+    return False
+
+
+def _use_triton_kernel(x, p, dim) -> bool:
+    if not isinstance(x, torch.Tensor):
+        return False
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False
+    # Only the full-tensor reduction is specialized here; a partial per-dim
+    # reduction defers to the generic implementation. torch expresses a full
+    # reduction as dim=None, dim=[] (empty sequence), or a dim list covering
+    # every axis (e.g. [0, 1] for a 2-D input) -- all handled as full reduction.
+    if not _is_full_reduction(x, dim):
+        return False
+    if x.numel() == 0:
+        return False
+    if p is not None and not isinstance(p, (int, float)):
+        return False
+    if isinstance(p, float) and math.isnan(p):
+        return False
+    return True
+
+
+def norm(x, p=2, dim=None, keepdim=False):
+    logger.debug("GEMS_MTHREADS NORM")
+    if not _use_triton_kernel(x, p, dim):
+        return default_norm(x, p=p, dim=dim, keepdim=keepdim)
+
+    dtype = x.dtype
+    red, ord_val = _red_kind(p)
+
+    x = x.contiguous()
+    M = x.numel()
+    # Cap the grid so pass 1 stays occupancy-bound rather than launch-bound; a
+    # few thousand programs saturate the device while keeping the pass-2 reduce
+    # over the partials small.
+    max_blocks = 4096
+    x_flat = x.view(-1)
+    out = torch.empty([1] * x.ndim, dtype=dtype, device=x.device)
+
+    with torch_device_fn.device(x.device):
+        num_blocks = min(max_blocks, triton.cdiv(M, 1024))
+        num_blocks = max(1, num_blocks)
+        partial = torch.empty([num_blocks], dtype=torch.float32, device=x.device)
+        grid = (num_blocks,)
+        norm_partial_kernel[grid](x_flat, partial, M, ord_val, num_blocks, red)
+        block_mid = triton.next_power_of_2(num_blocks)
+        norm_finalize_kernel[(1,)](partial, out, num_blocks, ord_val, red, block_mid)
+
+    if not keepdim:
+        out = out.reshape([])
+    return out
+
+
+def norm_scalar(x, p=2):
+    logger.debug("GEMS_MTHREADS NORM_SCALAR")
+    if not _use_triton_kernel(x, p, None):
+        return default_norm_scalar(x, p=p)
+    return norm(x, p=p, dim=None, keepdim=False)
+
+
+def norm_scalaropt_dim(x, p, dim, keepdim=False):
+    logger.debug("GEMS_MTHREADS NORM_SCALAR_OPT_DIM")
+    # Only the full-tensor case is specialized; dim reductions defer to generic.
+    if not _use_triton_kernel(x, p, dim):
+        return default_norm_scalaropt_dim(x, p, dim, keepdim=keepdim)
+    return norm(x, p=p, dim=None, keepdim=keepdim)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/permute_copy.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/permute_copy.py
@@ -1,0 +1,296 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.permute_copy import permute_copy as default_permute_copy
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+# Moore Threads hardware does not support fp64; int64 is supported for
+# indexing, but we keep the supported dtype set aligned with the other
+# mthreads specialized operators and fall back to the generic impl
+# otherwise.
+_SUPPORTED_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.int32,
+    torch.int64,
+    torch.bool,
+}
+
+# Highest tensor rank handled directly by the specialized kernel. Tensors
+# with a larger rank fall back to the generic implementation.
+_MAX_KERNEL_RANK = 5
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        # BLOCK_M = 1: one output row per program, large inner block. Best when
+        # the last output dimension (N) is large, giving a long coalesced run.
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 1024}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 2048}, num_warps=8, num_stages=2),
+        # BLOCK_M = 1, small inner block, 2 warps: best for rank-3 permutes
+        # where the last output dim is small (N ~= 64) — a short coalesced run
+        # with minimal thread overhead.
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 128}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 256}, num_warps=2, num_stages=2),
+        # BLOCK_M = 2 / 4: a few rows per program, mid-sized inner block.
+        triton.Config({"BLOCK_M": 2, "BLOCK_N": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 2, "BLOCK_N": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 512}, num_warps=4, num_stages=2),
+        # BLOCK_M = 8 / 16: many rows per program, small inner block. Best when
+        # the last output dimension is small (e.g. rank-3 permutes with N=64),
+        # so each program still has enough work without wasting threads on
+        # masked-out elements.
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 256}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "N", "dtype_size"],
+)
+@triton.jit
+def _permute_copy_kernel(
+    src_ptr,
+    dst_ptr,
+    n_elements,
+    M,
+    N,
+    dtype_size,
+    # Outer (all-but-last) output shapes, padded to 4 with leading 1s.
+    out_shape0,
+    out_shape1,
+    out_shape2,
+    out_shape3,
+    # Reordered source strides (``src_stride_j = input.stride(perm[j])``),
+    # padded to 5 with leading 0s; index 4 is the inner (last) dim.
+    src_stride0,
+    src_stride1,
+    src_stride2,
+    src_stride3,
+    src_stride4,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)  # outer flat index
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)  # last-dim index
+    mask_m = rm < M
+    mask_n = rn < N
+    mask = mask_m[:, None] & mask_n[None, :]
+
+    # Decompose the outer flat index into per-dimension output indices. This is
+    # done once per program (scalar work over BLOCK_M rows) rather than per
+    # element, which is the key difference from a flat 1-D kernel and keeps the
+    # inner-dim load/store loop free of integer divisions. Leading size-1
+    # dimensions (padding for ranks < 5) simply yield index 0.
+    rem = rm
+    o3 = rem % out_shape3
+    rem = rem // out_shape3
+    o2 = rem % out_shape2
+    rem = rem // out_shape2
+    o1 = rem % out_shape1
+    rem = rem // out_shape1
+    o0 = rem % out_shape0
+
+    # Source offset: dot product of the (reordered) source strides with the
+    # output indices. The outer part is constant across the inner dim, so it
+    # forms a per-row base; the inner part is the strided last-dim access.
+    src_base = o0 * src_stride0 + o1 * src_stride1 + o2 * src_stride2 + o3 * src_stride3
+    src_offset = src_base[:, None] + rn[None, :] * src_stride4
+
+    # Destination offset: the output is row-major contiguous, so the flat index
+    # is simply ``outer_index * N + inner_index`` (inner stride == 1).
+    dst_offset = rm[:, None] * N + rn[None, :]
+
+    vals = tl.load(src_ptr + src_offset, mask=mask)
+    tl.store(dst_ptr + dst_offset, vals, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        # For rank-3 permutes the output is small and launch-bound, so a tight
+        # 3-D grid (one program per (d0, d1) cell, BLOCK_N covering the last
+        # dim) with few warps minimizes per-program overhead and avoids the
+        # integer divisions of the flat-index decomposition above.
+        # num_warps=2 gives the best warm latency on Moore Threads for the
+        # small per-program workloads (one row of the last dim).
+        triton.Config({"BLOCK_N": 64}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_N": 256}, num_warps=2, num_stages=2),
+    ],
+    key=["n_elements", "d2", "dtype_size"],
+)
+@triton.jit
+def _permute_copy_kernel_3d(
+    src_ptr,
+    dst_ptr,
+    n_elements,
+    d0,
+    d1,
+    d2,
+    dtype_size,
+    # Reordered source strides (``src_stride_j = input.stride(perm[j])``).
+    src_stride0,
+    src_stride1,
+    src_stride2,
+    # Output strides (row-major contiguous).
+    out_stride0,
+    out_stride1,
+    out_stride2,
+    BLOCK_N: tl.constexpr,
+):
+    p0 = tl.program_id(0)  # output dim 0
+    p1 = tl.program_id(1)  # output dim 1
+    p2 = tl.program_id(2)  # output dim 2 (blocked)
+
+    rn = p2 * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = rn < d2
+
+    # Source offset: dot product of the reordered source strides with the
+    # output indices. p0/p1 are scalar per program; rn is the inner run.
+    src_offset = p0 * src_stride0 + p1 * src_stride1 + rn * src_stride2
+    # Destination offset: the output is row-major contiguous.
+    dst_offset = p0 * out_stride0 + p1 * out_stride1 + rn * out_stride2
+
+    vals = tl.load(src_ptr + src_offset, mask=mask)
+    tl.store(dst_ptr + dst_offset, vals, mask=mask)
+
+
+def _use_triton_kernel(x: torch.Tensor, dims) -> Tuple[bool, int]:
+    if not isinstance(x, torch.Tensor):
+        return False, 0
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if x.ndim == 0 or x.ndim > _MAX_KERNEL_RANK:
+        return False, 0
+    if x.numel() == 0 or not x.is_contiguous():
+        return False, 0
+    # ``dims`` must be a genuine permutation of range(ndim); otherwise the
+    # copy semantics differ from ``aten::permute_copy``.
+    ndim = x.ndim
+    try:
+        normalized = [d if d >= 0 else d + ndim for d in dims]
+    except TypeError:
+        return False, 0
+    if sorted(normalized) != list(range(ndim)) or len(normalized) != ndim:
+        return False, 0
+    return True, x.element_size()
+
+
+def _launch_permute_copy(
+    x: torch.Tensor, out: torch.Tensor, dims, dtype_size: int
+) -> torch.Tensor:
+    ndim = x.ndim
+
+    # Reorder the input strides by the permutation so the kernel can compute
+    # the source offset as a plain dot product of the output indices.
+    in_strides = list(x.stride())
+    src_strides = [in_strides[dims[j]] for j in range(ndim)]
+    out_strides = list(out.stride())
+    out_shapes = list(out.shape)
+    n_elements = out.numel()
+
+    with torch_device_fn.device(out.device):
+        if ndim == 3:
+            # Rank-3 fast path: a 3-D grid with no flat-index decomposition.
+            grid = lambda meta: (
+                out_shapes[0],
+                out_shapes[1],
+                triton.cdiv(out_shapes[2], meta["BLOCK_N"]),
+            )
+            _permute_copy_kernel_3d[grid](
+                x,
+                out,
+                n_elements,
+                out_shapes[0],
+                out_shapes[1],
+                out_shapes[2],
+                dtype_size,
+                src_strides[0],
+                src_strides[1],
+                src_strides[2],
+                out_strides[0],
+                out_strides[1],
+                out_strides[2],
+            )
+            return out
+
+        # General path for ranks 1, 2, 4, 5: pad shapes/strides up to the fixed
+        # 5-D kernel signature. The inner (last) dimension is kept real; leading
+        # dimensions are padded with shape 1 (index always 0) and stride 0 (no
+        # offset contribution).
+        pad_n = _MAX_KERNEL_RANK - ndim
+        out_shapes_pad = [1] * pad_n + out_shapes
+        src_strides_pad = [0] * pad_n + src_strides
+
+        # Outer = all but the last dim; inner = last dim.
+        M = 1
+        for s in out_shapes_pad[:-1]:
+            M = M * s
+        N = out_shapes_pad[-1]
+
+        grid = lambda meta: (
+            triton.cdiv(M, meta["BLOCK_M"]),
+            triton.cdiv(N, meta["BLOCK_N"]),
+        )
+        _permute_copy_kernel[grid](
+            x,
+            out,
+            n_elements,
+            M,
+            N,
+            dtype_size,
+            out_shapes_pad[0],
+            out_shapes_pad[1],
+            out_shapes_pad[2],
+            out_shapes_pad[3],
+            src_strides_pad[0],
+            src_strides_pad[1],
+            src_strides_pad[2],
+            src_strides_pad[3],
+            src_strides_pad[4],
+        )
+    return out
+
+
+def permute_copy(x: torch.Tensor, dims):
+    logger.debug("GEMS_MTHREADS PERMUTE_COPY")
+    use_triton, dtype_size = _use_triton_kernel(x, dims)
+    if not use_triton:
+        return default_permute_copy(x, dims)
+
+    ndim = x.ndim
+    normalized = [d if d >= 0 else d + ndim for d in dims]
+    out_shape = [x.shape[d] for d in normalized]
+    out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
+    return _launch_permute_copy(x, out, normalized, dtype_size)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/reflection_pad3d_backward.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/reflection_pad3d_backward.py
@@ -1,0 +1,280 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.reflection_pad3d_backward import (
+    reflection_pad3d_backward as default_reflection_pad3d_backward,
+)
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+# Map a torch dtype to its triton counterpart for the kernel store.
+_TORCH_TO_TL_DTYPE = {
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+    torch.float32: tl.float32,
+}
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK": 128}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK": 1024}, num_warps=16, num_stages=1),
+        triton.Config({"BLOCK": 2048}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=1),
+        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=2),
+        triton.Config({"BLOCK": 4096}, num_warps=16, num_stages=1),
+    ],
+    key=["dhw_in", "dtype_size"],
+)
+@triton.jit(do_not_specialize=["pad_d0", "pad_h0", "pad_w0"])
+def reflection_pad3d_backward_kernel(
+    out_ptr,
+    grad_ptr,
+    D_out,
+    H_out,
+    W_out,
+    D_in: tl.constexpr,
+    H_in: tl.constexpr,
+    W_in: tl.constexpr,
+    pad_d0,
+    pad_h0,
+    pad_w0,
+    dhw_in,
+    dtype_size,  # used for autotune key
+    OUT_DTYPE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Gather-based backward kernel.
+
+    Each program handles ``BLOCK`` input positions. For every input position
+    ``i`` the forward reflection maps it to one output position directly, plus
+    up to two extra output positions produced by the reflection on the padded
+    borders (``-i`` and ``2*(size-1)-i``). The gradient w.r.t. an input element
+    is therefore the sum of ``grad_output`` over (at most) three output
+    positions per spatial axis -- ``3*3*3 = 27`` candidates, statically
+    unrolled. This avoids atomic operations and the associated fp32
+    accumulator, which matters on mthreads where atomic_add of half precision
+    is not directly supported.
+    """
+    pid = ext.program_id(0)
+    pid_nc = ext.program_id(1)
+
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < dhw_in
+
+    HW_in: tl.constexpr = H_in * W_in
+    d_in = offs // HW_in
+    hw_rem = offs - d_in * HW_in
+    w_in = hw_rem % W_in
+    h_in = (hw_rem - w_in) // W_in
+
+    # Candidate output coordinates per axis. ``a`` is the central copy
+    # (``pad + i``); ``b`` (``pad - i``) and ``c`` (``pad + 2*(size-1) - i``)
+    # are the border reflections. ``b`` duplicates ``a`` at ``i == 0`` and
+    # ``c`` duplicates ``a`` at ``i == size-1``, so those are masked out.
+    Dm1: tl.constexpr = D_in - 1
+    Dp: tl.constexpr = 2 * Dm1
+    od_a = pad_d0 + d_in
+    od_b = pad_d0 - d_in
+    od_c = pad_d0 + (Dp - d_in)
+    vd_a = mask & (od_a < D_out) & (od_a >= 0)
+    vd_b = mask & (od_b < D_out) & (od_b >= 0) & (d_in != 0)
+    vd_c = mask & (od_c < D_out) & (od_c >= 0) & (d_in != Dm1)
+
+    Hm1: tl.constexpr = H_in - 1
+    Hp: tl.constexpr = 2 * Hm1
+    oh_a = pad_h0 + h_in
+    oh_b = pad_h0 - h_in
+    oh_c = pad_h0 + (Hp - h_in)
+    vh_a = mask & (oh_a < H_out) & (oh_a >= 0)
+    vh_b = mask & (oh_b < H_out) & (oh_b >= 0) & (h_in != 0)
+    vh_c = mask & (oh_c < H_out) & (oh_c >= 0) & (h_in != Hm1)
+
+    Wm1: tl.constexpr = W_in - 1
+    Wp: tl.constexpr = 2 * Wm1
+    ow_a = pad_w0 + w_in
+    ow_b = pad_w0 - w_in
+    ow_c = pad_w0 + (Wp - w_in)
+    vw_a = mask & (ow_a < W_out) & (ow_a >= 0)
+    vw_b = mask & (ow_b < W_out) & (ow_b >= 0) & (w_in != 0)
+    vw_c = mask & (ow_c < W_out) & (ow_c >= 0) & (w_in != Wm1)
+
+    HW_out = H_out * W_out
+    grad_base = pid_nc * (D_out * HW_out)
+
+    # Accumulate in float32 (mthreads has no fp64) and downcast on store.
+    acc = tl.zeros((BLOCK,), dtype=tl.float32)
+    for di in tl.static_range(0, 3):
+        od = tl.where(di == 0, od_a, tl.where(di == 1, od_b, od_c))
+        vd = tl.where(di == 0, vd_a, tl.where(di == 1, vd_b, vd_c))
+        for hi in tl.static_range(0, 3):
+            oh = tl.where(hi == 0, oh_a, tl.where(hi == 1, oh_b, oh_c))
+            vh = tl.where(hi == 0, vh_a, tl.where(hi == 1, vh_b, vh_c))
+            for wi in tl.static_range(0, 3):
+                ow = tl.where(wi == 0, ow_a, tl.where(wi == 1, ow_b, ow_c))
+                vw = tl.where(wi == 0, vw_a, tl.where(wi == 1, vw_b, vw_c))
+                vmask = vd & vh & vw
+                grad_off = grad_base + od * HW_out + oh * W_out + ow
+                grad_val = tl.load(grad_ptr + grad_off, mask=vmask, other=0.0).to(
+                    tl.float32
+                )
+                acc += grad_val
+
+    out_off = pid_nc * (D_in * HW_in) + offs
+    tl.store(out_ptr + out_off, acc.to(OUT_DTYPE), mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_DHW": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_DHW": 512}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_DHW": 1024}, num_warps=8, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def _copy_kernel(in_ptr, out_ptr, n_elements, dtype_size, BLOCK_DHW: tl.constexpr):
+    pid = ext.program_id(0)
+    offs = pid * BLOCK_DHW + tl.arange(0, BLOCK_DHW)
+    mask = offs < n_elements
+    vals = tl.load(in_ptr + offs, mask=mask, other=0)
+    tl.store(out_ptr + offs, vals, mask=mask)
+
+
+def _use_triton_kernel(grad_output: torch.Tensor, self: torch.Tensor) -> bool:
+    if not isinstance(grad_output, torch.Tensor) or not isinstance(self, torch.Tensor):
+        return False
+    if grad_output.device.type != "musa" or self.device.type != "musa":
+        return False
+    if (
+        grad_output.dtype not in _SUPPORTED_DTYPES
+        or self.dtype not in _SUPPORTED_DTYPES
+    ):
+        return False
+    if grad_output.dtype != self.dtype:
+        return False
+    if grad_output.numel() == 0 or self.numel() == 0:
+        return False
+    if not grad_output.is_contiguous() or not self.is_contiguous():
+        return False
+    if self.dim() != 5:
+        return False
+    return True
+
+
+def _launch_reflection_pad3d_backward(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    padding: Tuple[int, ...],
+) -> torch.Tensor:
+    if isinstance(padding, int):
+        pad_d0 = pad_d1 = pad_h0 = pad_h1 = pad_w0 = pad_w1 = padding
+    else:
+        pad_d0, pad_d1, pad_h0, pad_h1, pad_w0, pad_w1 = padding
+
+    N, C, D_in, H_in, W_in = self.shape
+    D_out = D_in + pad_d0 + pad_d1
+    H_out = H_in + pad_h0 + pad_h1
+    W_out = W_in + pad_w0 + pad_w1
+
+    output_dtype = self.dtype
+    grad_output = grad_output.contiguous()
+
+    # No padding: grad_input is a copy of grad_output.
+    if (
+        pad_d0 == 0
+        and pad_d1 == 0
+        and pad_h0 == 0
+        and pad_h1 == 0
+        and pad_w0 == 0
+        and pad_w1 == 0
+    ):
+        out = torch.empty_like(self)
+        n_elements = out.numel()
+        dtype_size = out.element_size()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_DHW"]),)
+        with torch_device_fn.device(out.device):
+            _copy_kernel[grid](grad_output, out, n_elements, dtype_size)
+        return out
+
+    # For pure reflection padding (pad < corresponding dim) each input element
+    # receives at most 3 contributions per axis, so the backward can be computed
+    # with a gather (no atomics). When padding is large enough that a single
+    # output could reflect to the same input more than 3 times per axis the
+    # closed-form fold used by the general kernel is required: fall back there.
+    if (
+        pad_d0 >= D_in
+        or pad_d1 >= D_in
+        or pad_h0 >= H_in
+        or pad_h1 >= H_in
+        or pad_w0 >= W_in
+        or pad_w1 >= W_in
+    ):
+        return default_reflection_pad3d_backward(grad_output, self, padding)
+
+    out = torch.empty_like(self)
+    dhw_in = D_in * H_in * W_in
+    dtype_size = grad_output.element_size()
+    out_dtype = _TORCH_TO_TL_DTYPE[output_dtype]
+    grid = lambda meta: (triton.cdiv(dhw_in, meta["BLOCK"]), N * C)
+
+    with torch_device_fn.device(out.device):
+        reflection_pad3d_backward_kernel[grid](
+            out,
+            grad_output,
+            D_out,
+            H_out,
+            W_out,
+            D_in,
+            H_in,
+            W_in,
+            pad_d0,
+            pad_h0,
+            pad_w0,
+            dhw_in,
+            dtype_size,
+            OUT_DTYPE=out_dtype,
+        )
+    return out
+
+
+def reflection_pad3d_backward(grad_output, self, padding):
+    logger.debug("GEMS_MTHREADS REFLECTION_PAD3D_BACKWARD")
+    if not _use_triton_kernel(grad_output, self):
+        return default_reflection_pad3d_backward(grad_output, self, padding)
+    return _launch_reflection_pad3d_backward(grad_output, self, padding)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/renorm_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/renorm_.py
@@ -1,0 +1,164 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.renorm_ import renorm_ as default_renorm_  # fallback
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+pow = tl_extra_shim.pow
+
+# Largest slice length handled by the single-pass kernel (one tile per row).
+_MAX_SINGLE_PASS_N = 8192
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=16, num_stages=2),
+    ],
+    key=["N", "dtype_size"],
+)
+@triton.jit(do_not_specialize=["p", "maxnorm"])
+def renorm_kernel(X, N, p, maxnorm, dtype_size, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    row_ptr = X + pid * N
+
+    inv_p = 1.0 / p
+
+    # Pass 1: accumulate the p-norm of this slice in fp32 (mthreads has no
+    # fp64). Drop the loaded tiles from L2 (``evict_first``) since they will be
+    # re-read in pass 2 -- this keeps the cache warm for the rescaling store.
+    acc = tl.zeros((), dtype=tl.float32)
+    for off in range(0, N, BLOCK_SIZE):
+        idx = off + tl.arange(0, BLOCK_SIZE)
+        mask = idx < N
+        x = tl.load(
+            row_ptr + idx, mask=mask, other=0.0, eviction_policy="evict_first"
+        ).to(tl.float32)
+        acc += tl.sum(pow(tl.abs(x), p))
+
+    norm = pow(acc, inv_p)
+    # Slices whose norm already fits within maxnorm are left unchanged.
+    scale = tl.where(norm > maxnorm, maxnorm / norm, 1.0)
+
+    # Pass 2: rescale every element of the slice in place.
+    for off in range(0, N, BLOCK_SIZE):
+        idx = off + tl.arange(0, BLOCK_SIZE)
+        mask = idx < N
+        x = tl.load(row_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+        tl.store(row_ptr + idx, x * scale, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=16, num_stages=2),
+    ],
+    key=["N", "dtype_size"],
+)
+@triton.jit(do_not_specialize=["p", "maxnorm"])
+def renorm_kernel_single_pass(X, N, p, maxnorm, dtype_size, BLOCK_SIZE: tl.constexpr):
+    # Single-pass fast path: the whole slice fits in one tile, so we can load
+    # every element exactly once, reduce it in registers, and rescale it in
+    # place -- halving the memory traffic of the two-pass kernel.
+    pid = tl.program_id(0)
+    row_ptr = X + pid * N
+
+    idx = tl.arange(0, BLOCK_SIZE)
+    mask = idx < N
+    x = tl.load(row_ptr + idx, mask=mask, other=0.0).to(tl.float32)
+
+    norm = pow(tl.sum(pow(tl.abs(x), p)), 1.0 / p)
+    # Slices whose norm already fits within maxnorm are left unchanged.
+    scale = tl.where(norm > maxnorm, maxnorm / norm, 1.0)
+
+    tl.store(row_ptr + idx, x * scale, mask=mask)
+
+
+def _use_triton_kernel(x: torch.Tensor) -> Tuple[bool, int]:
+    if not isinstance(x, torch.Tensor):
+        return False, 0
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if x.numel() == 0 or not x.is_contiguous():
+        return False, 0
+    return True, x.element_size()
+
+
+def renorm_(x, p, dim, maxnorm):
+    logger.debug("GEMS_MTHREADS RENORM_")
+    use_triton, dtype_size = _use_triton_kernel(x)
+    if not use_triton:
+        return default_renorm_(x, p, dim, maxnorm)
+
+    dim = dim % x.ndim
+    # Normalize scalars to float once; mthreads kernels compute in fp32 only.
+    p = float(p)
+    maxnorm = float(maxnorm)
+
+    def _launch(x_flat, M, N):
+        grid = (M,)
+        with torch_device_fn.device(x.device):
+            if N <= _MAX_SINGLE_PASS_N:
+                renorm_kernel_single_pass[grid](x_flat, N, p, maxnorm, dtype_size)
+            else:
+                renorm_kernel[grid](x_flat, N, p, maxnorm, dtype_size)
+
+    if dim == x.ndim - 1:
+        # Fast in-place path: the reduced dimension is the last (contiguous)
+        # axis, so each slice is already a contiguous run in memory and no
+        # transpose / materialization / copy-back is required.
+        N = x.shape[-1]
+        M = x.numel() // N
+        _launch(x.reshape(M, N), M, N)
+        return x
+
+    # General path: move the reduced dimension to the front so that each slice
+    # becomes a contiguous row, run the kernel, then scatter the result back.
+    perm = [dim] + [i for i in range(x.ndim) if i != dim]
+    x_perm = x.permute(perm).contiguous()
+    M = x_perm.shape[0]
+    N = x_perm[0].numel()
+    x_flat = x_perm.reshape(M, N)
+    _launch(x_flat, M, N)
+
+    inv_perm = [0] * x.ndim
+    for i, pi in enumerate(perm):
+        inv_perm[pi] = i
+    x.copy_(x_flat.reshape(x_perm.shape).permute(inv_perm))
+
+    return x

--- a/src/flag_gems/runtime/backend/_mthreads/ops/round_.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/round_.py
@@ -1,0 +1,93 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.round import round_ as default_round_  # fallback
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@triton.jit
+def _round_half_to_even(x):
+    """Round to nearest, ties to even. x must be fp32."""
+    r = tl.floor(x)
+    d = x - r  # fractional part in [0, 1)
+    is_odd = tl.abs(r - 2.0 * tl.floor(r / 2.0)) > 0.5
+    return tl.where((d > 0.5) | ((tl.abs(d - 0.5) < 1e-10) & is_odd), r + 1.0, r)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def round_inplace_kernel(
+    x_ptr,
+    n_elements,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+    out = _round_half_to_even(x_fp32).to(x.dtype)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _use_triton_kernel(x, decimals) -> Tuple[bool, int]:
+    if not isinstance(x, torch.Tensor):
+        return False, 0
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if x.numel() == 0 or not x.is_contiguous():
+        return False, 0
+    # Only the common decimals == 0 path is specialized here; the scaled
+    # variant is rare and left to the generic implementation.
+    if decimals != 0:
+        return False, 0
+    return True, x.element_size()
+
+
+def round_(input, *, decimals=0):
+    logger.debug("GEMS_MTHREADS ROUND_")
+    use_triton, dtype_size = _use_triton_kernel(input, decimals)
+    if not use_triton:
+        return default_round_(input, decimals=decimals)
+
+    n_elements = input.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input.device):
+        round_inplace_kernel[grid](input, n_elements, dtype_size)
+    return input

--- a/src/flag_gems/runtime/backend/_mthreads/ops/softplus_backward.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/softplus_backward.py
@@ -1,0 +1,149 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.softplus import (
+    softplus_backward as default_softplus_backward,  # fallback
+)
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+exp = tl_extra_shim.exp
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 4}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 256, "VEC": 2}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 2}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 512, "VEC": 4}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 1}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024, "VEC": 2}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048, "VEC": 1}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096, "VEC": 1}, num_warps=16, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit(do_not_specialize=["beta", "threshold"])
+def softplus_backward_kernel(
+    grad_ptr,
+    x_ptr,
+    out_ptr,
+    n_elements,
+    beta,
+    threshold,
+    dtype_size,  # used for autotune key
+    BLOCK_SIZE: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    BLOCK_ELEMS: tl.constexpr = BLOCK_SIZE * VEC
+    offsets = (pid * BLOCK_ELEMS + tl.arange(0, BLOCK_ELEMS)).to(tl.int64)
+    mask = offsets < n_elements
+
+    dy = tl.load(grad_ptr + offsets, mask=mask, other=0.0)
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+
+    x_fp32 = x.to(tl.float32)
+    z = x_fp32 * beta
+    # d/dx softplus(x) = sigmoid(beta * x) when z <= threshold, else 1
+    # sigmoid(z) = 1 / (1 + exp(-z))
+    sig = 1.0 / (1.0 + exp(-z))
+    dydx = tl.where(z > threshold, 1.0, sig)
+    dx = (dy.to(tl.float32) * dydx).to(x.dtype)
+
+    tl.store(out_ptr + offsets, dx, mask=mask)
+
+
+def _coerce_scalar(value, name: str) -> Tuple[float, bool]:
+    try:
+        v = float(value) if not isinstance(value, torch.Tensor) else float(value.item())
+    except Exception:
+        return 0.0, False
+    if not math.isfinite(v):
+        return 0.0, False
+    return v, True
+
+
+def _use_triton_kernel(
+    grad_output: torch.Tensor, x: torch.Tensor, beta, threshold
+) -> Tuple[bool, float, float]:
+    if not isinstance(grad_output, torch.Tensor) or not isinstance(x, torch.Tensor):
+        return False, 0.0, 0.0
+    if grad_output.device.type != "musa" or x.device.type != "musa":
+        return False, 0.0, 0.0
+    if grad_output.dtype != x.dtype or grad_output.dtype not in _SUPPORTED_DTYPES:
+        return False, 0.0, 0.0
+    if (
+        grad_output.numel() != x.numel()
+        or grad_output.numel() == 0
+        or not grad_output.is_contiguous()
+        or not x.is_contiguous()
+    ):
+        return False, 0.0, 0.0
+    beta_value, ok_beta = _coerce_scalar(beta, "beta")
+    threshold_value, ok_thr = _coerce_scalar(threshold, "threshold")
+    if not ok_beta or not ok_thr:
+        return False, 0.0, 0.0
+    return True, beta_value, threshold_value
+
+
+def _launch_softplus_backward(
+    grad_output: torch.Tensor,
+    x: torch.Tensor,
+    out: torch.Tensor,
+    beta: float,
+    threshold: float,
+    dtype_size: int,
+):
+    grad_flat = grad_output.view(-1)
+    x_flat = x.view(-1)
+    out_flat = out.view(-1)
+    n_elements = out_flat.numel()
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"] * META["VEC"]),)
+    with torch_device_fn.device(out.device):
+        softplus_backward_kernel[grid](
+            grad_flat, x_flat, out_flat, n_elements, beta, threshold, dtype_size
+        )
+    return out
+
+
+def softplus_backward(grad_output, self, beta=1.0, threshold=20.0):
+    logger.debug("GEMS_MTHREADS SOFTPLUS_BACKWARD")
+    use_triton, beta_value, threshold_value = _use_triton_kernel(
+        grad_output, self, beta, threshold
+    )
+    if not use_triton:
+        return default_softplus_backward(
+            grad_output, self, beta=beta, threshold=threshold
+        )
+
+    out = torch.empty_like(self)
+    dtype_size = self.element_size()
+    return _launch_softplus_backward(
+        grad_output, self, out, beta_value, threshold_value, dtype_size
+    )

--- a/src/flag_gems/runtime/backend/_mthreads/ops/special_gammainc.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/special_gammainc.py
@@ -1,0 +1,203 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.special_gammainc import special_gammainc as default_special_gammainc
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+exp = tl_extra_shim.exp
+log = tl_extra_shim.log
+lgamma = tl_extra_shim.lgamma
+
+# Fixed iteration counts. The mthreads Triton frontend rejects python-level
+# `break` inside a vectorized loop (the boolean reduction is ambiguous), so the
+# kernel runs a constant number of iterations and masks already-converged lanes.
+SERIES_ITERS = 128
+CF_ITERS = 200
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=16, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def gammainc_kernel(
+    a_ptr,
+    x_ptr,
+    out_ptr,
+    n_elements,
+    dtype_size,
+    BLOCK_SIZE: tl.constexpr,
+    SERIES_ITERS: tl.constexpr,
+    CF_ITERS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    a = tl.load(a_ptr + offsets, mask=mask, other=0.0)
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+
+    # Compute in float32 (Moore Threads hardware has no fp64).
+    a_f32 = a.to(tl.float32)
+    x_f32 = x.to(tl.float32)
+
+    valid = (a_f32 > 0.0) & (x_f32 >= 0.0)
+    x_pos = (a_f32 > 0.0) & (x_f32 > 0.0)
+
+    # Regularized lower incomplete gamma P(a, x).
+    #   For x < a + 1 use the series expansion:
+    #     P(a, x) = exp(-x) * x^a * sum_{n>=0} x^n / Gamma(a+n+1)
+    #             = exp(a*log(x) - x - lgamma(a)) * sum_{n>=0} x^n / ((a)_{n} * a)
+    #   where the inner sum starts at 1/a and uses the recurrence
+    #     t_n = t_{n-1} * x / (a + n).
+    #   For x >= a + 1 use Lentz's continued fraction for Q(a, x) = 1 - P(a, x):
+    #     Q(a, x) = exp(a*log(x) - x - lgamma(a)) / f, with P = 1 - Q.
+    use_series = x_f32 < (a_f32 + 1.0)
+    tiny = 1.0e-30
+
+    # --- Series expansion (large-x lanes are masked out, cheap) ---
+    series_term = 1.0 / a_f32
+    series_sum = series_term
+    converged_s = tl.zeros([BLOCK_SIZE], dtype=tl.int1)
+    for i in range(1, SERIES_ITERS):
+        series_term = tl.where(
+            converged_s, series_term, series_term * x_f32 / (a_f32 + i)
+        )
+        new_sum = series_sum + series_term
+        series_sum = tl.where(converged_s, series_sum, new_sum)
+        converged_s = converged_s | (tl.abs(series_term) < tl.abs(series_sum) * 1.0e-10)
+    log_pref = a_f32 * log(x_f32) - x_f32 - lgamma(a_f32)
+    series_result = exp(log_pref) * series_sum
+
+    # --- Lentz continued fraction for Q(a, x) (small-x lanes masked out) ---
+    b0 = x_f32 + 1.0 - a_f32
+    f_val = b0
+    C_val = b0
+    D_val = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for i in range(1, CF_ITERS):
+        an = i * (a_f32 - i)
+        bn = x_f32 + 2.0 * i + 1.0 - a_f32
+
+        D_val = bn + an * D_val
+        D_val = tl.where(tl.abs(D_val) < tiny, tiny, D_val)
+        D_val = 1.0 / D_val
+
+        C_val = bn + an / C_val
+        C_val = tl.where(tl.abs(C_val) < tiny, tiny, C_val)
+
+        delta = C_val * D_val
+        f_val = f_val * delta
+
+    q_val = exp(log_pref - log(f_val))
+    q_val = tl.where(q_val > 1.0, 1.0, tl.where(q_val < 0.0, 0.0, q_val))
+    frac_result = 1.0 - q_val
+
+    result = tl.where(use_series, series_result, frac_result)
+    # P(a, 0) = 0 for a > 0; NaN for a <= 0 or x < 0.
+    result = tl.where(
+        x_pos,
+        result,
+        tl.where(valid, 0.0, float("nan")),
+    )
+
+    tl.store(out_ptr + offsets, result, mask=mask)
+
+
+def _use_triton_kernel(a: torch.Tensor, x: torch.Tensor) -> Tuple[bool, int]:
+    if not isinstance(a, torch.Tensor) or not isinstance(x, torch.Tensor):
+        return False, 0
+    if a.device.type != "musa" or x.device.type != "musa":
+        return False, 0
+    if a.dtype not in _SUPPORTED_DTYPES or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if a.numel() != x.numel():
+        return False, 0
+    if a.numel() == 0 or not a.is_contiguous() or not x.is_contiguous():
+        return False, 0
+    return True, a.element_size()
+
+
+def _launch_gammainc(a: torch.Tensor, x: torch.Tensor, out: torch.Tensor):
+    a_flat = a.view(-1)
+    x_flat = x.view(-1)
+    out_flat = out.view(-1)
+    n_elements = out_flat.numel()
+    dtype_size = out_flat.element_size()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(out.device):
+        gammainc_kernel[grid](
+            a_flat,
+            x_flat,
+            out_flat,
+            n_elements,
+            dtype_size,
+            SERIES_ITERS=SERIES_ITERS,
+            CF_ITERS=CF_ITERS,
+        )
+    return out
+
+
+def special_gammainc(a: torch.Tensor, x: torch.Tensor, *, out: torch.Tensor = None):
+    logger.debug("GEMS_MTHREADS SPECIAL_GAMMAINC")
+    use_triton, _ = _use_triton_kernel(a, x)
+    if not use_triton:
+        return default_special_gammainc(a, x, out=out)
+
+    if a.shape != x.shape:
+        a, x = torch.broadcast_tensors(a, x)
+    out_in = out
+    out_t = out if out is not None else torch.empty_like(a)
+
+    a_c = a if a.is_contiguous() else a.contiguous()
+    x_c = x if x.is_contiguous() else x.contiguous()
+    out_c = out_t if out_t.is_contiguous() else out_t.contiguous()
+
+    # Promote both inputs to a common float dtype for the kernel.
+    common = torch.promote_types(a_c.dtype, x_c.dtype)
+    if common not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        common = torch.float32
+    if a_c.dtype != common:
+        a_c = a_c.to(common)
+    if x_c.dtype != common:
+        x_c = x_c.to(common)
+    if out_c.dtype != common:
+        out_c = torch.empty_like(a_c, dtype=common)
+
+    _launch_gammainc(a_c, x_c, out_c)
+
+    if out_c.dtype != out_t.dtype:
+        out_t.copy_(out_c)
+    elif out_c.data_ptr() != out_t.data_ptr():
+        out_t.copy_(out_c)
+    return out_t if out_in is not None else out_t

--- a/src/flag_gems/runtime/backend/_mthreads/ops/trunc.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/trunc.py
@@ -1,0 +1,100 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.trunc_ import trunc as default_trunc  # fallback
+from flag_gems.ops.trunc_ import trunc_ as default_trunc_  # fallback
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils.triton_lang_helper import tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_trunc = tl_extra_shim.trunc
+
+_SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=2),
+    ],
+    key=["n_elements", "dtype_size"],
+)
+@triton.jit
+def trunc_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    dtype_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    # Truncate toward zero in fp32 (mthreads hardware has no fp64).
+    y = _trunc(x.to(tl.float32))
+    tl.store(out_ptr + offsets, y.to(x.dtype), mask=mask)
+
+
+def _use_triton_kernel(x: torch.Tensor) -> Tuple[bool, int]:
+    if not isinstance(x, torch.Tensor):
+        return False, 0
+    if x.device.type != "musa" or x.dtype not in _SUPPORTED_DTYPES:
+        return False, 0
+    if x.numel() == 0 or not x.is_contiguous():
+        return False, 0
+    return True, x.element_size()
+
+
+def _launch_trunc(x: torch.Tensor, out: torch.Tensor, dtype_size: int):
+    n_elements = out.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(out.device):
+        trunc_kernel[grid](x, out, n_elements, dtype_size)
+    return out
+
+
+def trunc(A):
+    logger.debug("GEMS_MTHREADS TRUNC")
+    use_triton, dtype_size = _use_triton_kernel(A)
+    if not use_triton:
+        return default_trunc(A)
+
+    out = torch.empty_like(A)
+    return _launch_trunc(A, out, dtype_size)
+
+
+def trunc_(A):
+    logger.debug("GEMS_MTHREADS TRUNC_")
+    use_triton, dtype_size = _use_triton_kernel(A)
+    if not use_triton:
+        return default_trunc_(A)
+
+    _launch_trunc(A, A, dtype_size)
+    return A

--- a/tests/test_bucketize.py
+++ b/tests/test_bucketize.py
@@ -19,6 +19,12 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
+# Moore Threads (MUSA) has no native torch.bucketize with integer boundaries;
+# the reference call itself raises "Bucketize func unsupported!". Gate that one
+# parametrization for mthreads only (hardware limitation, not a kernel bug) so
+# other backends still exercise the int64-boundary path.
+_MTHREADS = flag_gems.vendor_name == "mthreads"
+
 
 def _reference_bucketize(inp, boundaries, **kwargs):
     ref_inp = utils.to_reference(inp, True)
@@ -76,7 +82,15 @@ def test_bucketize_int32(shape, dtype):
 @pytest.mark.parametrize(
     ("boundary_values", "boundary_dtype"),
     [
-        pytest.param([1, 3, 5, 7, 9], torch.int64, id="integer"),
+        pytest.param(
+            [1, 3, 5, 7, 9],
+            torch.int64,
+            id="integer",
+            marks=pytest.mark.skipif(
+                _MTHREADS,
+                reason="MUSA native torch.bucketize does not support integer boundaries",
+            ),
+        ),
         pytest.param([], torch.float32, id="empty"),
         pytest.param([5.0], torch.float32, id="single"),
         pytest.param([1.0, 3.0], torch.float32, id="two"),

--- a/tests/test_im2col.py
+++ b/tests/test_im2col.py
@@ -29,7 +29,10 @@ IM2COL_CONFIGS = [
 ]
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.skipif(
+    flag_gems.runtime.device.device_count == 0,
+    reason="No accelerator device is available",
+)
 @pytest.mark.im2col
 @pytest.mark.parametrize("shape", IM2COL_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)


### PR DESCRIPTION
## Summary

Add Moore Threads (MUSA) backend implementations for 20 operators that were previously
merged in [FlagGems-Experimental](https://github.com/flagos-ai/FlagGems-Experimental).
Generic-layer registrations for all 20 operators already exist in FlagGems `master`;
this PR only adds the vendor-specific implementations plus the device gating needed to
keep the shared tests green on hardware without fp64 / with MUSA-specific limitations.

## Operators (20)

`bucketize`, `erfinv`, `erfinv_`, `fmod_`, `histc`, `im2col`, `index_copy_`,
`linalg_cholesky`, `log_normal_`, `median`, `mish`, `nonzero_numpy`, `norm`,
`permute_copy`, `reflection_pad3d_backward`, `renorm_`, `round_`, `softplus_backward`,
`special_gammainc`, `trunc`

## Changes

**New vendor implementations (20 files)**
`src/flag_gems/runtime/backend/_mthreads/ops/<op>.py` — one file per operator.
No existing file is modified or renamed.

**Backend exports (1 file)**
`src/flag_gems/runtime/backend/_mthreads/ops/__init__.py` — addition-only.
The 20 new `from .<op> import ...` statements are merged into the existing import
block in alphabetical order, and the 55 new symbols are appended to `__all__`.
All 73 pre-existing top-level exports are preserved, and the
`get_device_capability(current_device())[0] >= 3` conditional block (8 further
exports) is byte-identical to `master`. Verified by symbol-set diff: 0 lost symbols,
`__all__` goes 73 → 128 entries.

**Device gating in shared tests (4 files)**
These files already exist on `master`; the changes are additive gating only, no
existing assertion or parametrization is removed:

- `tests/test_bucketize.py` — skip the `int64`-boundary parametrization on mthreads
  only. MUSA's native `torch.bucketize` raises `Bucketize func unsupported!` for
  integer boundaries, so the *reference* call fails; this is a hardware limitation,
  not a kernel bug. Other backends still exercise the int64 path.
- `tests/test_im2col.py` — replace `torch.cuda.is_available()` with
  `flag_gems.runtime.device.device_count == 0` so the skip condition is
  vendor-neutral rather than NVIDIA-specific.
- `benchmark/test_bucketize.py` — restrict dtypes to `float32` on mthreads.
- `benchmark/test_linalg_cholesky.py` — gate `float64` behind
  `flag_gems.runtime.device.support_fp64` (Moore Threads has no fp64).

## Provenance

Extracted from the head commit of each source PR in FlagGems-Experimental:
#114, #116, #117, #118, #119, #120, #121, #122, #127, #128, #129, #139,
#249, #250, #251, #259, #260, #261, #262, #263

Per-PR head SHAs were used rather than a branch diff, because the `infra-ci` branch
history has been rebuilt and diverged from the original merge commits, so the merged
files are no longer reachable from the current branch HEAD.

## Verification

Run on an NVIDIA H20 node, which cannot load the MUSA backend. What was checked:

- `flake8 --max-line-length=120 --ignore=F405,E731,W503,E203,E701,E704` — 0 issues
- `isort --profile black --project flag_gems --check-only` — clean
- `black --check` (26.5.1) — clean
- `python -m py_compile` on all 25 files — clean
- `__init__.py` symbol-set diff vs `master` — all 73 pre-existing top-level exports
  retained, 55 added, `__all__.extend` conditional block byte-identical
- No hardcoded `device="cuda"` in any test file; all use `flag_gems.device`

**Not verified:** correctness and performance on Moore Threads hardware. No MUSA
device was available, so no accuracy or benchmark numbers are reported here. These
kernels passed CI in FlagGems-Experimental at the time their source PRs were merged.
Review on real hardware is requested before merge.
