### PR TITLE
fix(metax): add MACA backend specialization for K>=16 constraint

### DIFF
--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -3,7 +3,9 @@ from ._nested_view_from_buffer_copy import _nested_view_from_buffer_copy
 from .addmm import addmm
 from .amax import amax
 from .arange import arange, arange_start
+from .baddbmm import baddbmm
 from .bmm import bmm
+from .conv2d import conv2d
 from .cholesky_solve import cholesky_solve, cholesky_solve_out
 from .exponential_ import exponential_
 from .full import full
@@ -53,7 +55,9 @@ __all__ = [
     "amax",
     "arange",
     "arange_start",
+    "baddbmm",
     "bmm",
+    "conv2d",
     "cholesky_solve",
     "cholesky_solve_out",
     "exponential_",

--- a/src/flag_gems/runtime/backend/_metax/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/baddbmm.py
@@ -1,0 +1,151 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MetaX (MACA) backend specialization for baddbmm.
+
+The original baddbmm backward calls ``bmm()`` from ``flag_gems/ops/bmm.py``
+directly. That path lacks the K>=16 padding required by the MACA compiler.
+
+This module re-exports the unchanged forward kernel but overrides the backward
+helpers to pad K<16 before calling the triton bmm kernel (without the M/N<32
+fallback that the dispatch-level metax bmm uses, since the triton kernel can
+handle small M/N fine).
+"""
+
+import logging
+
+import torch
+import triton
+
+from flag_gems.runtime import torch_device_fn
+
+# Reuse the original forward kernel, launch helper, and bias grad computation
+from flag_gems.ops.baddbmm import (
+    _baddbmm_launch,
+    compute_bias_grad,
+)
+from flag_gems.ops.mul import mul
+
+# Import the metax bmm kernel (triton kernel) directly for backward use
+from .bmm import bmm_kernel
+
+logger = logging.getLogger(__name__)
+
+_MIN_DOT_K = 16
+
+
+def _bmm_for_backward(A, B):
+    """BMM specialized for baddbmm backward: only pads K<16, no M/N fallback.
+
+    The triton bmm kernel handles small M/N correctly. We only need to ensure
+    K >= 16 for the tl.dot constraint on MACA backend.
+    """
+    batch, M, K = A.shape
+    _, _, N = B.shape
+
+    # MACA backend K dimension constraint: tl.dot requires K >= 16
+    if K < _MIN_DOT_K:
+        pad_k = _MIN_DOT_K - K
+        logger.debug(
+            "GEMS_METAX BADDBMM backward bmm padding K: %s -> %s", K, _MIN_DOT_K
+        )
+        A = torch.nn.functional.pad(A, (0, pad_k), mode="constant", value=0)
+        B = torch.nn.functional.pad(B, (0, 0, 0, pad_k), mode="constant", value=0)
+        K = _MIN_DOT_K
+
+    A = A.contiguous()
+    B = B.contiguous()
+    out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)
+
+    grid_fn = lambda meta: (
+        triton.cdiv(meta["M"], meta["TILE_M"]),
+        triton.cdiv(meta["N"], meta["TILE_N"]),
+        batch,
+    )
+    with torch_device_fn.device(A.device):
+        bmm_kernel[grid_fn](A, B, out, M, N, K, batch)
+    return out
+
+
+def compute_A_grad(d_output, B, alpha):
+    """Compute grad w.r.t. A: alpha * d_output @ B^T"""
+    B_T = B.transpose(1, 2)
+    if B.dtype == torch.float16:
+        Bcopy = B_T.to(torch.float32)
+        dcopye = d_output.to(torch.float32)
+        mul1 = _bmm_for_backward(dcopye, Bcopy)
+        grad_A = mul(mul1, alpha)
+        grad_A = grad_A.to(torch.float16)
+    else:
+        mul1 = _bmm_for_backward(d_output, B_T)
+        grad_A = mul(mul1, alpha)
+    return grad_A
+
+
+def compute_B_grad(A, d_output, alpha):
+    """Compute grad w.r.t. B: alpha * A^T @ d_output"""
+    A_T = A.transpose(1, 2)
+    if A.dtype == torch.float16:
+        Acopy = A_T.to(torch.float32)
+        dcopye = d_output.to(torch.float32)
+        mul2 = _bmm_for_backward(Acopy, dcopye)
+        grad_B = mul(mul2, alpha)
+        grad_B = grad_B.to(torch.float16)
+    else:
+        mul2 = _bmm_for_backward(A_T, d_output)
+        grad_B = mul(mul2, alpha)
+    return grad_B
+
+
+class BaddbmmFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, bias, A, B, beta, alpha):
+        logger.debug("GEMS_METAX BADDBMM FORWARD")
+
+        ctx.save_for_backward(A, B, bias)
+        ctx.alpha = alpha
+        ctx.beta = beta
+
+        batch, M, K = A.shape
+        _, _, N = B.shape
+        out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)
+        _baddbmm_launch(bias, A, B, beta, alpha, out)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logger.debug("GEMS_METAX BADDBMM BACKWARD")
+        A, B, bias = ctx.saved_tensors
+
+        grad_A = None
+        grad_B = None
+        grad_bias = None
+        if ctx.needs_input_grad[0]:
+            grad_bias = compute_bias_grad(grad_output, ctx.beta, bias)
+        if ctx.needs_input_grad[1]:
+            grad_A = compute_A_grad(grad_output, B, ctx.alpha)
+        if ctx.needs_input_grad[2]:
+            grad_B = compute_B_grad(A, grad_output, ctx.alpha)
+
+        return grad_bias, grad_A, grad_B, None, None
+
+
+def baddbmm(bias, A, B, beta=1.0, alpha=1.0):
+    return BaddbmmFunction.apply(
+        bias.contiguous(),
+        A.contiguous(),
+        B.contiguous(),
+        beta,
+        alpha,
+    )

--- a/src/flag_gems/runtime/backend/_metax/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/bmm.py
@@ -180,6 +180,24 @@ def bmm(A, B):
             _FALLBACK_KEYSET, A.contiguous(), B.contiguous()
         )
 
+    # MACA backend K dimension constraint: tl.dot requires K >= 16
+    # Pad K dimension with zeros if necessary
+    _MIN_DOT_K = 16
+    original_K = K
+    if K < _MIN_DOT_K:
+        pad_k = _MIN_DOT_K - K
+        logger.debug(
+            "GEMS_METAX BMM padding K dimension: %s -> %s (pad_k=%s)",
+            K,
+            _MIN_DOT_K,
+            pad_k,
+        )
+        # Pad A: [batch, M, K] -> [batch, M, _MIN_DOT_K]
+        A = torch.nn.functional.pad(A, (0, pad_k), mode="constant", value=0)
+        # Pad B: [batch, K, N] -> [batch, _MIN_DOT_K, N]
+        B = torch.nn.functional.pad(B, (0, 0, 0, pad_k), mode="constant", value=0)
+        K = _MIN_DOT_K
+
     A = A.contiguous()
     B = B.contiguous()
     out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)

--- a/src/flag_gems/runtime/backend/_metax/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/conv2d.py
@@ -1,0 +1,742 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+MACA backend specialization for conv2d operator.
+
+This module addresses two MACA-specific tl.dot K>=16 constraints:
+
+1. Forward pass: When weight_c (input channels per group) < 16, the BLOCK_CI
+   tile dimension becomes the K dimension for tl.dot, violating K>=16.
+   Solution: Pad input/weight channels to 16.
+
+2. Backward weight pass: The original triple-nested loop (N, H, W) uses BLOCK_NO
+   as the K dimension for tl.dot. When in_n (batch size) < 16, BLOCK_NO can be
+   smaller than 16. Solution: Flatten (N, H, W) into a single reduction dimension
+   so BLOCK_NO always satisfies the K>=16 constraint via autotuner configs.
+
+3. Backward input pass: When out_c < 16, it becomes the K dimension in the
+   reversed convolution. Solution: Pad revert_weight and new_out channels to 16.
+"""
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def conv2d_output_size(
+    in_size: int,
+    kernel_size: int,
+    stride: int,
+    padding: int,
+    dilation: int,
+) -> int:
+    """
+    Determines the output size of a 2D convolution operation.
+
+    Args:
+        in_size: Input size.
+        kernel_size: Kernel size.
+        stride: Stride.
+        padding: Padding.
+        dilation: Dilation.
+
+    Returns:
+        Output size of 2D convolution.
+    """
+    return (in_size + 2 * padding - dilation * (kernel_size - 1) - 1) // stride + 1
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("conv2d_forward"),
+    key=[
+        "in_n",
+        "weight_c",
+        "input_height",
+        "input_width",
+        "out_c",
+        "out_height",
+        "out_width",
+        "weight_height",
+        "weight_width",
+        "stride_height",
+        "stride_width",
+        "padding_height",
+        "padding_width",
+        "groups",
+    ],
+)
+@triton.jit
+def conv2d_forward_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    groups: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_ni_ho_wo = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_group = tl.program_id(2)
+
+    # caculate in_n out_height out_weight value in kernel
+    ni_ho_wo_offset = pid_ni_ho_wo * BLOCK_NI_HO_WO + tl.arange(0, BLOCK_NI_HO_WO)
+    ni_ho_offset = ni_ho_wo_offset // out_width
+    in_n_point_value = ni_ho_offset // out_height
+    output_height_point_value = ni_ho_offset % out_height
+    output_width_point_value = ni_ho_wo_offset % out_width
+
+    # Load the input and weight pointers. input and weight are of shape
+    # [in_n, groups, in_c, input_height, input_width] and [groups, out_c, in_c, weight_height, weight_width]
+    out_per_group_c = out_c // groups
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    input_pointer += (
+        input_n_stride * in_n_point_value + input_c_stride * pid_group * weight_c
+    )[:, None]
+    weight_pointer += (
+        weight_n_stride * output_c_offset
+        + weight_n_stride * pid_group * out_per_group_c
+    )[None, :]
+
+    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
+    BLOCK_CI_COUNT = (weight_c + BLOCK_CI - 1) // BLOCK_CI
+    for hwc in range(weight_height * weight_width * BLOCK_CI_COUNT):
+        c = (hwc % BLOCK_CI_COUNT) * BLOCK_CI
+        hw = hwc // BLOCK_CI_COUNT
+        h = hw // weight_width
+        w = hw % weight_width
+
+        input_c_offset = c + tl.arange(0, BLOCK_CI)
+        input_height_offset = (
+            h * dilation_height
+            - padding_height
+            + stride_height * output_height_point_value
+        )
+        input_width_offset = (
+            w * dilation_width - padding_width + stride_width * output_width_point_value
+        )
+
+        curr_input_pointer = (
+            input_pointer
+            + (input_c_stride * input_c_offset)[None, :]
+            + (input_height_stride * input_height_offset)[:, None]
+            + (input_width_stride * input_width_offset)[:, None]
+        )
+        curr_weight_pointer = (
+            weight_pointer
+            + (weight_c_stride * input_c_offset)[:, None]
+            + (weight_height_stride * h)
+            + (weight_width_stride * w)
+        )
+
+        input_mask = (
+            (in_n_point_value < in_n)[:, None]
+            & (input_c_offset < weight_c)[None, :]
+            & (0 <= input_height_offset)[:, None]
+            & (input_height_offset < input_height)[:, None]
+            & (0 <= input_width_offset)[:, None]
+            & (input_width_offset < input_width)[:, None]
+        )
+        weight_mask = (input_c_offset < weight_c)[:, None] & (
+            output_c_offset < out_per_group_c
+        )[None, :]
+
+        curr_input = tl.load(curr_input_pointer, mask=input_mask)
+        curr_weight = tl.load(curr_weight_pointer, mask=weight_mask)
+        accum += tl.dot(curr_input, curr_weight, allow_tf32=False)
+
+    if bias_pointer is not None:
+        bias_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+        bias_offset += pid_group * out_per_group_c
+        bias = tl.load(bias_pointer + bias_offset, mask=(bias_offset < out_c))
+        accum += bias[None, :]
+
+    output_pointer += (
+        (output_n_stride * in_n_point_value)[:, None]
+        + (output_c_stride * (pid_group * out_per_group_c + output_c_offset))[None, :]
+        + (output_height_stride * output_height_point_value)[:, None]
+        + (output_width_stride * output_width_point_value)[:, None]
+    )
+
+    output_mask = (
+        (in_n_point_value < in_n)[:, None]
+        & (output_c_offset < out_per_group_c)[None, :]
+        & (output_height_point_value < out_height)[:, None]
+        & (output_width_point_value < out_width)[:, None]
+    )
+
+    tl.store(output_pointer, accum, mask=output_mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("conv2d_backward_weight"),
+    key=[
+        "in_n",
+        "input_height",
+        "input_width",
+        "weight_height",
+        "weight_width",
+        "input_c",
+        "stride_height",
+        "stride_width",
+        "out_height",
+        "out_width",
+        "out_c",
+        "padding_height",
+        "padding_width",
+    ],
+)
+@triton.jit
+def conv2d_backward_kernel_weight(
+    input_pointer,
+    out_grad_pointer,
+    weight_pointer,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    input_height,
+    input_width,
+    weight_height,
+    weight_width,
+    input_c,
+    in_n,
+    stride_height,
+    stride_width,
+    out_height,
+    out_width,
+    out_c,
+    padding_height,
+    padding_width,
+    dilation_height,
+    dilation_width,
+    BLOCK_NO: tl.constexpr,
+    BLOCK_CI_HK_WK: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    # MACA specialization: Compute weight gradient by reducing over
+    # N * out_height * out_width. The reduction dimension is flattened into
+    # a single loop to ensure the K dimension of tl.dot (BLOCK_NO) is always
+    # >= 16, even when in_n is small (e.g., 1 or 2).
+    #
+    # Layout:
+    #   out_grad: [N, groups*out_c, out_height, out_width]
+    #   input:    [N, groups*input_c, input_height, input_width]
+    #   weight:   [groups*out_c, input_c, weight_height, weight_width]
+    #
+    # For each block of the flattened index k in [0, in_n * out_height * out_width):
+    #   n = k // (out_height * out_width)
+    #   hw = k % (out_height * out_width)
+    #   h = hw // out_width
+    #   w = hw % out_width
+
+    # init pid and offset: 0 for ci*hk*wk, 1 for groups, 2 for co.
+    pid_ci_hk_wk = tl.program_id(0)
+    pid_groups = tl.program_id(1)
+    pid_co = tl.program_id(2)
+
+    # calculate ci, weight_height, weight_width indices from flattened ci_hk_wk
+    ci_hk_wk_offset = pid_ci_hk_wk * BLOCK_CI_HK_WK + tl.arange(0, BLOCK_CI_HK_WK)
+    ci_hk_offset = ci_hk_wk_offset // weight_width
+    ci_point_value = ci_hk_offset // weight_height
+    weight_height_point_value = ci_hk_offset % weight_height
+    weight_width_point_value = ci_hk_wk_offset % weight_width
+
+    # calculate init pointer info of tensors
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    out_grad_pointer += (output_c_offset * output_c_stride)[None, :] + (
+        pid_groups[None] * output_c_stride * out_c
+    )[:, None]
+
+    weight_pointer += (
+        pid_groups * weight_n_stride * out_c + output_c_offset * weight_n_stride
+    )[None, :] + (
+        ci_point_value * weight_c_stride
+        + weight_height_point_value * weight_height_stride
+        + weight_width_point_value * weight_width_stride
+    )[
+        :, None
+    ]
+
+    input_pointer += (ci_point_value * input_c_stride[None])[:, None] + (
+        pid_groups[None] * input_c_stride * input_c
+    )[None, :]
+
+    # Flatten the reduction space: total_k = in_n * out_height * out_width
+    # Iterate with BLOCK_NO steps (guaranteed >= 16 by autotuner config)
+    hw_size = out_height * out_width
+    total_k = in_n * hw_size
+
+    accum = tl.zeros((BLOCK_CI_HK_WK, BLOCK_CO), dtype=tl.float32)
+    for k_start in range(0, total_k, BLOCK_NO):
+        k_offset = k_start + tl.arange(0, BLOCK_NO)
+        k_mask = k_offset < total_k
+
+        # Decompose flattened index back to (n, h, w)
+        n_idx = k_offset // hw_size
+        hw_idx = k_offset % hw_size
+        h_idx = hw_idx // out_width
+        w_idx = hw_idx % out_width
+
+        # Load out_grad block: shape [BLOCK_NO, BLOCK_CO]
+        curr_out_grad_pointer = (
+            out_grad_pointer
+            + (
+                n_idx * output_n_stride
+                + h_idx * output_height_stride
+                + w_idx * output_width_stride
+            )[:, None]
+        )
+        out_grad_mask = k_mask[:, None] & (output_c_offset < out_c)[None, :]
+        curr_out_grad = tl.load(curr_out_grad_pointer, mask=out_grad_mask)
+
+        # Calculate input spatial offsets based on kernel position and output position
+        # weight_height_point_value: [BLOCK_CI_HK_WK], h_idx: [BLOCK_NO]
+        # Result: input_height_offset [BLOCK_CI_HK_WK, BLOCK_NO]
+        input_height_offset = (
+            weight_height_point_value[:, None] * dilation_height
+            - padding_height
+            + stride_height * h_idx[None, :]
+        )
+
+        input_width_offset = (
+            weight_width_point_value[:, None] * dilation_width
+            - padding_width
+            + stride_width * w_idx[None, :]
+        )
+
+        # Load input block: shape [BLOCK_CI_HK_WK, BLOCK_NO]
+        curr_input_pointer = (
+            input_pointer
+            + (input_n_stride * n_idx)[None, :]
+            + input_height_stride * input_height_offset
+            + input_width_stride * input_width_offset
+        )
+        input_mask = (
+            k_mask[None, :]
+            & (ci_point_value < input_c)[:, None]
+            & (0 <= input_height_offset)
+            & (input_height_offset < input_height)
+            & (0 <= input_width_offset)
+            & (input_width_offset < input_width)
+        )
+
+        curr_input = tl.load(curr_input_pointer, mask=input_mask)
+        accum += tl.dot(curr_input, curr_out_grad, allow_tf32=False)
+
+    weight_mask = (
+        (ci_point_value < input_c)[:, None]
+        & (output_c_offset < out_c)[None, :]
+        & (weight_height_point_value < weight_height)[:, None]
+        & (weight_width_point_value < weight_width)[:, None]
+    )
+    tl.store(weight_pointer, accum, weight_mask)
+
+
+class Conv2d(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, weight, bias, stride, padding, dilation, groups):
+        logger.debug("GEMS_METAX CONV2D")
+        assert weight.ndim == 4, "Weights must be 4D, received shape {weight.shape}"
+        assert (
+            bias is None or bias.ndim == 1
+        ), "Bias must be 1D, received shape {bias.shape}"
+
+        assert (
+            input.shape[1] == groups * weight.shape[1]
+        ), "Incompatible input ({input.shape}) and weights ({weight.shape}) shape with {groups} groups"
+        assert (
+            bias is None or weight.shape[0] == bias.shape[0]
+        ), "Incompatible weights ({weight.shape}) and bias ({bias.shape}) shape"
+
+        if isinstance(stride, (list, tuple)):
+            stride_height, stride_width = stride
+        else:
+            stride_height = stride_width = stride
+
+        if isinstance(padding, (list, tuple)):
+            padding_height, padding_width = padding
+        else:
+            padding_height = padding_width = padding
+
+        if isinstance(dilation, (list, tuple)):
+            dilation_height, dilation_width = dilation
+        else:
+            dilation_height = dilation_width = dilation
+
+        in_n, _, input_height, input_width = input.shape
+        out_c, weight_c, weight_height, weight_width = weight.shape
+        orig_weight_c = weight_c  # Save original before potential padding
+
+        # Save original tensors for backward BEFORE padding
+        orig_input = input
+        orig_weight = weight
+
+        # MACA constraint: Triton tl.dot requires K >= 16. The K dimension in
+        # conv2d im2col matmul is BLOCK_CI which tiles over weight_c. When
+        # weight_c < 16, AABS shrinks BLOCK_CI to next_power_of_2(weight_c)
+        # which violates the K >= 16 constraint. Pad input/weight channels to 16.
+        _MIN_DOT_K = 16
+        if weight_c < _MIN_DOT_K:
+            pad_c = _MIN_DOT_K - weight_c
+            if groups == 1:
+                # Simple case: pad channel dim at the end
+                input = torch.nn.functional.pad(input, (0, 0, 0, 0, 0, pad_c))
+            else:
+                # For grouped conv, must pad each group's channels independently.
+                # Reshape to (N, groups, weight_c, H, W), pad weight_c dim, reshape back.
+                N, C, H, W = input.shape
+                input = input.reshape(N, groups, weight_c, H, W)
+                input = torch.nn.functional.pad(input, (0, 0, 0, 0, 0, pad_c))
+                input = input.reshape(N, groups * (weight_c + pad_c), H, W)
+            # Pad weight: (out_c, weight_c, kH, kW) -> (out_c, weight_c+pad_c, kH, kW)
+            weight = torch.nn.functional.pad(weight, (0, 0, 0, 0, 0, pad_c))
+            weight_c = weight_c + pad_c
+
+        out_height = conv2d_output_size(
+            input_height, weight_height, stride_height, padding_height, dilation_height
+        )
+        out_width = conv2d_output_size(
+            input_width, weight_width, stride_width, padding_width, dilation_width
+        )
+
+        output_dtype = input.dtype
+        output = torch.empty(
+            (in_n, out_c, out_height, out_width),
+            device=input.device,
+            dtype=output_dtype,
+        )
+
+        # BLOCK_NI_HO_WO along the in_n, out_height, and out_width dimensions,
+        # BLOCK_CO along the out_c,
+        # one group per cat
+        grid = lambda META: (
+            triton.cdiv(in_n * out_height * out_width, META["BLOCK_NI_HO_WO"]),
+            triton.cdiv(int(out_c / groups), META["BLOCK_CO"]),
+            groups,
+        )
+
+        conv2d_forward_kernel[grid](
+            input,
+            weight,
+            output,
+            bias,
+            in_n,
+            input_height,
+            input_width,
+            out_c,
+            out_height,
+            out_width,
+            *input.stride(),
+            *weight.stride(),
+            *output.stride(),
+            weight_c,
+            weight_height,
+            weight_width,
+            stride_height,
+            stride_width,
+            padding_height,
+            padding_width,
+            dilation_height,
+            dilation_width,
+            groups=groups,
+        )
+
+        # Save ORIGINAL (unpadded) tensors for backward
+        ctx.save_for_backward(orig_weight, orig_input, bias)
+
+        ctx.stride = (stride_height, stride_width)
+        ctx.padding = (padding_height, padding_width)
+        ctx.dilation = (dilation_height, dilation_width)
+
+        ctx.weight_info = (
+            int(out_c / groups),
+            orig_weight_c,
+            weight_height,
+            weight_width,
+        )
+        ctx.input_info = (in_n, input_height, input_width)
+        ctx.out_info = (out_height, out_width)
+
+        ctx.device = input.device
+        ctx.groups = groups
+
+        return output
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        logger.debug("GEMS_METAX CONV2D VJP")
+        weight, input, bias = ctx.saved_tensors
+        # (out_c equals origin cout divide groups)
+        out_c, weight_c, weight_height, weight_width = ctx.weight_info
+        in_n, input_height, input_width = ctx.input_info
+        out_height, out_width = ctx.out_info
+
+        device = ctx.device
+        groups = ctx.groups
+
+        stride_height, stride_width = ctx.stride
+        dilation_height, dilation_width = ctx.dilation
+        padding_height, padding_width = ctx.padding
+
+        revert_padding_height = dilation_height * (weight_height - 1) - padding_height
+        revert_padding_width = dilation_width * (weight_width - 1) - padding_width
+        revert_weight = weight.clone()
+        revert_weight = torch.flip(revert_weight, dims=[2, 3]).contiguous()
+
+        if groups != 1:
+            revert_weight = revert_weight.reshape(
+                groups, out_c, weight_c, weight_height, weight_width
+            )
+            revert_weight = revert_weight.transpose(1, 2)
+            revert_weight = revert_weight.reshape(
+                groups * weight_c, out_c, weight_height, weight_width
+            ).contiguous()
+        else:
+            revert_weight = revert_weight.transpose(0, 1).contiguous()
+
+        new_out_height = out_grad.shape[2] + (stride_height - 1) * (
+            out_grad.shape[2] - 1
+        )
+        new_out_width = out_grad.shape[3] + (stride_width - 1) * (out_grad.shape[3] - 1)
+
+        new_out = torch.zeros(
+            out_grad.shape[0],
+            out_grad.shape[1],
+            new_out_height,
+            new_out_width,
+            device=device,
+            dtype=out_grad.dtype,
+        )
+
+        # copy out_grad to new_out
+        if stride_height > 1 or stride_width > 1:
+            for i in range(out_grad.shape[2]):
+                for j in range(out_grad.shape[3]):
+                    new_out[:, :, i * (stride_height), j * (stride_width)] = out_grad[
+                        :, :, i, j
+                    ]
+        else:
+            new_out = out_grad
+
+        input_back = torch.zeros(
+            in_n,
+            weight_c * groups,
+            input_height,
+            input_width,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        grid = lambda META: (
+            triton.cdiv(
+                out_grad.shape[0] * input_height * input_width, META["BLOCK_NI_HO_WO"]
+            ),
+            triton.cdiv(int(weight_c), META["BLOCK_CO"]),
+            groups,
+        )
+        bias_zero = torch.zeros(groups * weight_c, device=device, dtype=out_grad.dtype)
+
+        # MACA constraint: Backward input path uses out_c as the kernel's weight_c
+        # (constexpr K dim). When out_c < 16, AABS shrinks BLOCK_CI below 16,
+        # violating tl.dot K>=16. Pad revert_weight and new_out channels to 16.
+        _MIN_DOT_K = 16
+        bwd_weight_c = out_c  # This becomes the kernel's weight_c constexpr
+        if bwd_weight_c < _MIN_DOT_K:
+            pad_c = _MIN_DOT_K - bwd_weight_c
+            # Pad revert_weight on dim=1 (the out_c/group dimension)
+            # revert_weight shape: [groups*weight_c, out_c, kH, kW]
+            revert_weight = torch.nn.functional.pad(
+                revert_weight, (0, 0, 0, 0, 0, pad_c)
+            )
+            # Pad new_out on channel dim (dim=1).
+            # new_out shape: [N, groups*out_c, H, W]
+            # Each group has out_c channels, need to pad each group to _MIN_DOT_K.
+            if groups == 1:
+                new_out = torch.nn.functional.pad(new_out, (0, 0, 0, 0, 0, pad_c))
+            else:
+                N_bwd, C_bwd, H_bwd, W_bwd = new_out.shape
+                new_out = new_out.reshape(N_bwd, groups, out_c, H_bwd, W_bwd)
+                new_out = torch.nn.functional.pad(new_out, (0, 0, 0, 0, 0, pad_c))
+                new_out = new_out.reshape(N_bwd, groups * (out_c + pad_c), H_bwd, W_bwd)
+            bwd_weight_c = bwd_weight_c + pad_c
+
+        conv2d_forward_kernel[grid](
+            new_out,
+            revert_weight,
+            input_back,
+            bias_zero,
+            out_grad.shape[0],
+            new_out_height,
+            new_out_width,
+            groups * weight_c,
+            input_height,
+            input_width,
+            *new_out.stride(),
+            *revert_weight.stride(),
+            *input_back.stride(),
+            bwd_weight_c,
+            weight_height,
+            weight_width,
+            1,
+            1,
+            revert_padding_height,
+            revert_padding_width,
+            dilation_height,
+            dilation_width,
+            groups=groups,
+        )
+
+        weight_back = torch.zeros(
+            out_c * groups,
+            weight_c,
+            weight_height,
+            weight_width,
+            dtype=weight.dtype,
+            device=device,
+        )
+
+        grid_weight = lambda meta: (
+            triton.cdiv(
+                weight_c * weight_height * weight_width, meta["BLOCK_CI_HK_WK"]
+            ),
+            groups,
+            triton.cdiv(out_c, meta["BLOCK_CO"]),
+        )
+        conv2d_backward_kernel_weight[grid_weight](
+            input,
+            out_grad,
+            weight_back,
+            *input.stride(),
+            *weight.stride(),
+            *out_grad.stride(),
+            input_height,
+            input_width,
+            weight_height,
+            weight_width,
+            weight_c,
+            in_n,
+            stride_height,
+            stride_width,
+            out_height,
+            out_width,
+            out_c,
+            padding_height,
+            padding_width,
+            dilation_height,
+            dilation_width,
+        )
+        if bias is not None:
+            bias_grad = out_grad.sum(dim=(0, 2, 3))
+        else:
+            bias_grad = None
+        return (
+            input_back,
+            weight_back,
+            bias_grad,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+# todo test SymInt[2] of stride or padding
+def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    if isinstance(padding, str):
+        if padding == "same":
+            assert stride == 1, "Doesn't support any stride values other than 1 \
+                in padding = 'same' mode, received stride value {stride}"
+            ih = input.shape[-2]
+            iw = input.shape[-1]
+            kernel_size_h = weight.shape[-2]
+            kernel_size_w = weight.shape[-1]
+            padding_h = int(
+                math.ceil(
+                    (stride * (ih - 1) + 1 + dilation * (kernel_size_h - 1) - ih) / 2
+                )
+            )
+            padding_w = int(
+                math.ceil(
+                    (stride * (iw - 1) + 1 + dilation * (kernel_size_w - 1) - iw) / 2
+                )
+            )
+            oh = int(
+                (ih + 2 * padding_h - dilation * (kernel_size_h - 1) - 1) / stride + 1
+            )
+            ow = int(
+                (iw + 2 * padding_w - dilation * (kernel_size_w - 1) - 1) / stride + 1
+            )
+            # Use per-dimension padding so asymmetric kernels (kh != kw) pad each
+            # spatial axis independently; the trailing slice trims the extra pad
+            # that ceil() introduces on the bottom/right, matching torch's "same".
+            padding = (padding_h, padding_w)
+            return Conv2d.apply(input, weight, bias, stride, padding, dilation, groups)[
+                ..., (oh - ih) :, (ow - iw) :
+            ]
+        elif padding == "valid":
+            return Conv2d.apply(input, weight, bias, stride, 0, dilation, groups)
+        else:
+            raise ValueError(
+                f"Unsupported padding string: {padding}, only'valild'/'same' are allowed."
+            )
+    else:
+        return Conv2d.apply(input, weight, bias, stride, padding, dilation, groups)


### PR DESCRIPTION
## Summary

MACA backend's `tl.dot` requires K dimension >= 16, which causes runtime failures when batch size or channel count is small. This PR adds backend-specific operator implementations to handle the K>=16 constraint.

## Changes

### Modified
- `src/flag_gems/runtime/backend/_metax/ops/bmm.py`: Add K dimension padding (pad to 16 when K < 16)
- `src/flag_gems/runtime/backend/_metax/ops/__init__.py`: Register conv2d and baddbmm exports

### New Files
- `src/flag_gems/runtime/backend/_metax/ops/conv2d.py`: MACA-specialized conv2d with flattened backward weight kernel loop (N×H×W → single loop) to ensure BLOCK_NO >= 16, plus channel padding for forward/backward
- `src/flag_gems/runtime/backend/_metax/ops/baddbmm.py`: MACA-specialized baddbmm with K dimension padding

## Technical Details

### conv2d backward weight kernel
- **Problem**: Triple-nested loop (N, H, W) uses BLOCK_NO (batch dim) as K in `tl.dot`, violates K>=16 when batch is small
- **Solution**: Flatten (N×H×W) into single reduction loop with index decomposition, autotuner guarantees BLOCK_NO >= 16

### bmm / baddbmm
- **Problem**: When matrix K dimension < 16, `tl.dot` fails
- **Solution**: Pad A and B matrices along K dimension to 16

## Impact
- **conv1d**: Automatically benefits (internally calls conv2d)
- **conv3d**: Not affected (independent kernel implementation)
- **NVIDIA backend**: No impact (changes are MACA-specific backend specializations)
