### PR TITLE
randperm/sort iluvatar

### DIFF
--- a/src/flag_gems/runtime/backend/_iluvatar/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/randperm.py
@@ -1,0 +1,522 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.ops.topk import argsort
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils.random_utils import philox_backend_seed_offset
+
+logger = logging.getLogger(__name__)
+device_ = device
+
+_MIN_INT8_VAL = tl.constexpr(torch.iinfo(torch.int8).min)
+_MAX_INT8_VAL = tl.constexpr(torch.iinfo(torch.int8).max)
+_MIN_INT16_VAL = tl.constexpr(torch.iinfo(torch.int16).min)
+_MAX_INT16_VAL = tl.constexpr(torch.iinfo(torch.int16).max)
+_MIN_INT32_VAL = tl.constexpr(torch.iinfo(torch.int32).min)
+_MAX_INT32_VAL = tl.constexpr(torch.iinfo(torch.int32).max)
+_MIN_INT64_VAL = tl.constexpr(torch.iinfo(torch.int64).min)
+_MAX_INT64_VAL = tl.constexpr(torch.iinfo(torch.int64).max)
+_MAX_UINT32_VAL = tl.constexpr((1 << 32) - 1)
+_MIN_UINT32_VAL = tl.constexpr(0)
+_MIN_INT24_VAL = tl.constexpr(-(2**23))
+_MAX_INT24_VAL = tl.constexpr(2**23 - 1)
+
+
+@triton.jit
+def _get_iinfo_val(
+    dtype,
+    return_max,
+):
+    if dtype is tl.int64:
+        if return_max:
+            return _MAX_INT64_VAL
+        else:
+            return _MIN_INT64_VAL
+    elif dtype is tl.int32:
+        if return_max:
+            return _MAX_INT32_VAL
+        else:
+            return _MIN_INT32_VAL
+    elif dtype is tl.int16:
+        if return_max:
+            return _MAX_INT16_VAL
+        else:
+            return _MIN_INT16_VAL
+    elif dtype is tl.int8:
+        if return_max:
+            return _MAX_INT8_VAL
+        else:
+            return _MIN_INT8_VAL
+    elif dtype is tl.uint32:
+        if return_max:
+            return _MAX_UINT32_VAL
+        else:
+            return _MIN_UINT32_VAL
+    else:
+        raise ValueError("Unknown dtype")
+
+
+@libentry()
+@triton.jit
+def bitonic_sortbykey_kernel(
+    y_ptr,
+    index_ptr,
+    chunk_x,
+    chunk_index,
+    N: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DESCENDING: tl.constexpr,
+):
+    cur_batch = tl.program_id(0)
+    chunk_x += cur_batch * N
+    chunk_index += cur_batch * N
+    index_ptr += cur_batch * N
+    y_ptr += cur_batch * N
+
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+
+    mask_val = _get_iinfo_val(chunk_x.dtype.element_ty, return_max=not DESCENDING)
+
+    chunk_x_val = tl.load(chunk_x + cols, mask=mask, other=mask_val)
+    chunk_index_val = tl.load(chunk_index + cols, mask=mask)
+
+    sorted_chunk_x, sorted_chunk_index = argsort(
+        chunk_x_val, chunk_index_val, 0, descending=DESCENDING
+    )
+    tl.store(y_ptr + cols, sorted_chunk_x, mask=cols < N)
+    tl.store(index_ptr + cols, sorted_chunk_index, mask=cols < N)
+
+
+@triton.jit
+def radix_type_convert(k):
+    ik = k.to(tl.int64)
+    if tl.constexpr(k.dtype == tl.int8):
+        mask = (ik >> 7) & 0x1
+        o = tl.where(mask, ik & 0x7F, ik | 0x80)
+    elif tl.constexpr(k.dtype == tl.int16):
+        mask = (ik >> 15) & 0x1
+        o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
+    elif tl.constexpr(k.dtype == tl.int32):
+        mask = (ik >> 31) & 0x1
+        o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
+    elif tl.constexpr(k.dtype == tl.int64):
+        mask = (ik >> 63) & 0x1
+        o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
+    else:
+        o = k
+    return o
+
+
+@libentry()
+@triton.jit
+def digit_hist_kernel(
+    digit_hist,
+    key,
+    n_elements,
+    bits_per_pass,
+    bins,
+    passes,
+    bit_mask,
+    bins_segment,
+    BLOCK_SIZE: tl.constexpr,
+):
+    bin_segid = tl.program_id(1)
+    pid0 = tl.program_id(0)
+    grid0 = tl.num_programs(0)
+
+    key_offset = pid0.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    key_mask = key_offset < n_elements
+    key_data = tl.load(key + key_offset, mask=key_mask)
+    ikey_data = radix_type_convert(key_data)
+    bit_offset = 0
+    for p in range(passes):
+        key_digit = (ikey_data >> bit_offset) & bit_mask
+        blk_bin_start = bin_segid * bins_segment
+        for s in range(bins_segment):
+            bin_id = s + blk_bin_start
+            digit_mask = tl.where(key_digit == bin_id and key_mask, 1, 0)
+            digit_sum = tl.sum(digit_mask)
+            # +1 for exclusive
+            bin_offset = p * (bins + 1) * grid0 + (bin_id + 1) * grid0 + pid0
+            # reduce rather than global atomic for perf issue
+            tl.store(digit_hist + bin_offset, digit_sum)
+        tl.store(digit_hist + p * (bins + 1) * grid0 + pid0, 0, mask=bin_segid == 0)
+        bit_offset += bits_per_pass
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("randperm"),
+    key=["n_elements"],
+)
+@triton.jit
+def radix_tile_hist_kernel(
+    tile_hist,
+    key_in,
+    n_elements,
+    bit_offset,
+    bit_mask,
+    bins_segment,
+    tiles_per_portion,
+    portion_size,
+    portion_id,
+    bins: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Pass 1: compute per-tile histogram for each bin."""
+    pid0 = tl.program_id(0)
+    portion_id_i64 = portion_id
+    portion_id_i64 = portion_id_i64.to(tl.int64)
+    key_offset = (
+        portion_id_i64 * portion_size
+        + pid0.to(tl.int64) * BLOCK_SIZE
+        + tl.arange(0, BLOCK_SIZE)
+    )
+    key_mask = key_offset < n_elements
+    key_data = tl.load(key_in + key_offset, mask=key_mask)
+    ikey_data = radix_type_convert(key_data)
+    key_digit = (ikey_data >> bit_offset) & bit_mask
+
+    blk_bin_start = tl.program_id(1) * bins_segment
+    for s in range(bins_segment):
+        bin_id = s + blk_bin_start
+        key_digit_mask = (key_digit == bin_id) & key_mask
+        count = tl.sum(tl.where(key_digit_mask, 1, 0))
+        # tile_hist: (bins, tiles_per_portion)
+        tl.store(tile_hist + bin_id * tiles_per_portion + pid0, count)
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("randperm"),
+    key=["n_elements"],
+)
+@triton.jit
+def radix_scatter_kernel(
+    key_out,
+    value_out,
+    key_in,
+    value_in,
+    digit_hist,
+    tile_offsets,
+    n_elements,
+    bit_offset,
+    passes,
+    p,
+    num_portions,
+    portion_size,
+    portion_id,
+    bit_mask,
+    bins_segment,
+    tiles_per_portion,
+    bins: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Pass 3: scatter using pre-computed tile offsets."""
+    pid0 = tl.program_id(0)
+    portion_id_i64 = portion_id
+    portion_id_i64 = portion_id_i64.to(tl.int64)
+    key_offset = (
+        portion_id_i64 * portion_size
+        + pid0.to(tl.int64) * BLOCK_SIZE
+        + tl.arange(0, BLOCK_SIZE)
+    )
+
+    key_mask = key_offset < n_elements
+    value_data = tl.load(value_in + key_offset, mask=key_mask)
+    key_data = tl.load(key_in + key_offset, mask=key_mask)
+
+    ikey_data = radix_type_convert(key_data)
+    key_digit = (ikey_data >> bit_offset) & bit_mask
+
+    blk_bin_start = tl.program_id(1) * bins_segment
+    last_block = pid0 == tiles_per_portion - 1
+    for s in range(bins_segment):
+        bin_id = s + blk_bin_start
+        key_digit_mask = (key_digit == bin_id) & key_mask
+        key_elem_mask = tl.where(key_digit_mask, 1, 0)
+        key_block_rank = tl.cumsum(key_elem_mask)
+        key_block_rank = tl.where(key_digit_mask, key_block_rank - 1, 0)
+
+        # Load pre-computed tile offset (exclusive prefix sum of tile counts)
+        tile_offset = tl.load(tile_offsets + bin_id * tiles_per_portion + pid0)
+
+        # Load global bin offset
+        bin_offset = p * (bins + 1) + bin_id
+        prefix_offsets = tl.load(
+            digit_hist + bin_offset + portion_id * passes * (bins + 1)
+        )
+
+        # Compute inclusive sum for portion boundary propagation
+        bin_of_bucket = tl.sum(key_elem_mask)
+        if last_block and portion_id < num_portions - 1:
+            inc_bucket_offset = (
+                prefix_offsets.to(tl.int64)
+                + tile_offset.to(tl.int64)
+                + bin_of_bucket.to(tl.int64)
+            )
+            tl.store(
+                digit_hist + bin_offset + (portion_id + 1) * passes * (bins + 1),
+                inc_bucket_offset,
+            )
+
+        global_offsets = (
+            prefix_offsets.to(tl.int64)
+            + tile_offset.to(tl.int64)
+            + key_block_rank.to(tl.int64)
+        )
+        tl.store(key_out + global_offsets, key_data, mask=key_digit_mask)
+        tl.store(value_out + global_offsets, value_data, mask=key_digit_mask)
+
+
+# for parallelization, randomly shuffle the entire block rather than adjacent equal elements as pytorch GPU backend
+@libentry()
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset"])
+def duplicate_keys_shuffle_kernel(
+    value_in, n_elements, philox_seed, philox_offset, BLOCK_SIZE: tl.constexpr
+):
+    pid0 = tl.program_id(0)
+    offset_range = tl.arange(0, BLOCK_SIZE)
+    value_offset = pid0.to(tl.int64) * BLOCK_SIZE + offset_range
+    value_mask = value_offset < n_elements
+    value_data = tl.load(value_in + value_offset, mask=value_mask)
+
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+    i4 = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    c0 += i4
+    _O = c0 * 0
+    r0, _, _, _ = tl.philox(philox_seed, c0, c1, _O, _O)
+
+    _block_size = BLOCK_SIZE
+    r1 = r0 % _block_size.to(tl.uint32)
+    mask_val = _get_iinfo_val(tl.uint32, True)
+    r1 = tl.where(value_offset < n_elements, r1, mask_val)
+    _, sorted_chunk_index = argsort(r1, offset_range, 0, descending=False)
+    store_offset = pid0.to(tl.int64) * BLOCK_SIZE + sorted_chunk_index.to(tl.int64)
+    tl.store(value_in + store_offset, value_data, mask=store_offset < n_elements)
+
+
+def sort_by_key(key, value, valid_bits, generator=None):
+    n_elements = key.numel()
+    if n_elements > 2 * 1024:
+        # radix method - 3-pass approach (no cross-CTA dependencies)
+        BLOCK_SIZE = 1024
+        bits_per_pass = 4
+        bits_per_segment = 3
+        passes = triton.cdiv(valid_bits, bits_per_pass)
+        bins = 2**bits_per_pass
+        bins_per_sgement = 2**bits_per_segment
+        bit_mask = bins - 1
+
+        portion_size = 2**30  # 2 bits reserved for mask
+        num_portions = triton.cdiv(n_elements, portion_size)
+        max_portion_items = portion_size if num_portions > 1 else n_elements
+        max_tiles_per_portion = triton.cdiv(max_portion_items, BLOCK_SIZE)
+
+        hist_dtype = torch.int64 if num_portions > 1 else torch.int32
+        grid_hist = (triton.cdiv(n_elements, BLOCK_SIZE), bins // bins_per_sgement)
+
+        digit_hist_slice = torch.empty(
+            (passes, bins + 1, grid_hist[0]), dtype=hist_dtype, device=key.device
+        )
+
+        digit_hist = torch.empty(
+            (num_portions, passes, bins + 1), dtype=hist_dtype, device=key.device
+        )
+
+        key_out_p = torch.empty_like(key)
+        key_out_q = torch.empty_like(key)
+        value_out_p = torch.empty_like(value)
+        value_out_q = torch.empty_like(value)
+
+        # step1: global histogram
+        with torch_device_fn.device(key.device):
+            digit_hist_kernel[grid_hist](
+                digit_hist_slice,
+                key,
+                n_elements,
+                bits_per_pass,
+                bins,
+                passes,
+                bit_mask,
+                bins_per_sgement,
+                BLOCK_SIZE,
+            )
+
+        # step2: prefix sum to get global bin offsets
+        digit_hist_slice = torch.sum(digit_hist_slice, dim=2, keepdim=False)
+        digit_hist_slice = digit_hist_slice.cumsum(dim=1)  # shape of [passes, bins + 1]
+        digit_hist.copy_(digit_hist_slice)
+
+        bit_offset = 0
+        for p in range(passes):
+            k_in = (key if p == 0 else key_out_p) if p % 2 == 0 else key_out_q
+            v_in = (value if p == 0 else value_out_p) if p % 2 == 0 else value_out_q
+            k_out = key_out_q if p % 2 == 0 else key_out_p
+            v_out = value_out_q if p % 2 == 0 else value_out_p
+            # step3: 3-pass per portion
+            for portion_id in range(num_portions):
+                portion_items = min(
+                    n_elements - portion_id * portion_size, portion_size
+                )
+                tiles_per_portion = triton.cdiv(portion_items, BLOCK_SIZE)
+                grid_portion = (tiles_per_portion, grid_hist[1])
+
+                # Allocate per-tile histogram: (bins, tiles_per_portion)
+                tile_hist = torch.empty(
+                    (bins, tiles_per_portion),
+                    dtype=torch.int32,
+                    device=key.device,
+                )
+
+                # Pass 1: per-tile histogram
+                with torch_device_fn.device(key.device):
+                    radix_tile_hist_kernel[grid_portion](
+                        tile_hist,
+                        k_in,
+                        n_elements,
+                        bit_offset,
+                        bit_mask,
+                        bins_per_sgement,
+                        tiles_per_portion,
+                        portion_size,
+                        portion_id,
+                        bins,
+                        BLOCK_SIZE,
+                    )
+
+                # Pass 2: exclusive prefix sum along tile dimension
+                # tile_hist: (bins, tiles_per_portion) -> tile_offsets
+                tile_offsets = torch.cumsum(tile_hist, dim=-1) - tile_hist
+
+                # Pass 3: scatter
+                with torch_device_fn.device(key.device):
+                    radix_scatter_kernel[grid_portion](
+                        k_out,
+                        v_out,
+                        k_in,
+                        v_in,
+                        digit_hist,
+                        tile_offsets,
+                        n_elements,
+                        bit_offset,
+                        passes,
+                        p,
+                        num_portions,
+                        portion_size,
+                        portion_id,
+                        bit_mask,
+                        bins_per_sgement,
+                        tiles_per_portion,
+                        bins,
+                        BLOCK_SIZE,
+                    )
+            bit_offset += bits_per_pass
+
+        # last step, shuffle inner-block data
+        BLOCK_SIZE_SHUFFLE = 512
+        grid_shuffle = (triton.cdiv(n_elements, BLOCK_SIZE_SHUFFLE),)
+        philox_seed, philox_offset = philox_backend_seed_offset(
+            n_elements, generator=generator
+        )
+        with torch_device_fn.device(key.device):
+            duplicate_keys_shuffle_kernel[grid_shuffle](
+                v_out,
+                n_elements,
+                philox_seed,
+                philox_offset,
+                BLOCK_SIZE_SHUFFLE,
+                num_warps=4,
+            )
+        return v_out
+    else:
+        # bitonic method
+        BLOCK_SIZE = triton.next_power_of_2(n_elements)
+        grid = (1,)
+        k_out = torch.empty_like(key)
+        v_out = torch.empty_like(value)
+        with torch_device_fn.device(key.device):
+            bitonic_sortbykey_kernel[grid](
+                k_out, v_out, key, value, n_elements, BLOCK_SIZE, False
+            )
+        return v_out
+
+
+def randperm(
+    n,
+    *,
+    generator=None,
+    out=None,
+    dtype=torch.int64,
+    layout=torch.strided,
+    device=None,
+    requires_grad=False,
+    pin_memory=False,
+):
+    logger.debug("GEMS RANDPERM")
+    assert dtype == torch.int16 or dtype == torch.int32 or dtype == torch.int64
+    assert n <= _MAX_INT64_VAL, "n exceeds maximum int64"
+
+    if device is None:
+        device = torch.device(device_.name)
+    in_range = torch.arange(n, dtype=dtype, device=device)
+
+    u8max = 2**8
+    u16max = 2**16
+    u24max = 2**24
+    u32max = 2**32
+
+    if n <= u8max:
+        valid_bits = 8
+        key_dtype = torch.int8
+        keymin = _MIN_INT8_VAL
+        keymax = _MAX_INT8_VAL
+    elif n <= u16max:
+        valid_bits = 16
+        key_dtype = torch.int16
+        keymin = _MIN_INT16_VAL
+        keymax = _MAX_INT16_VAL
+    elif n <= u24max:
+        valid_bits = 24
+        key_dtype = torch.int32
+        keymin = _MIN_INT24_VAL
+        keymax = _MAX_INT24_VAL
+    elif n <= u32max:
+        valid_bits = 32
+        key_dtype = torch.int32
+        keymin = _MIN_INT32_VAL
+        keymax = _MAX_INT32_VAL
+    else:
+        valid_bits = 64
+        key_dtype = torch.int64
+        keymin = _MIN_INT64_VAL
+        keymax = _MAX_INT64_VAL
+
+    rand_key = torch.randint(
+        low=keymin, high=keymax, size=[n], dtype=key_dtype, device=device
+    )
+    perm_range = sort_by_key(rand_key, in_range, valid_bits, generator=generator)
+    return perm_range

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/sort.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/sort.py
@@ -1,0 +1,433 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.topk import _get_finfo_val, _get_iinfo_val, argsort
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def unwrap_if_constexpr(o):
+    return o.value if isinstance(o, tl.constexpr) else o
+
+
+@tl.constexpr
+def get_int_t(num_bits: tl.constexpr, signed: tl.constexpr) -> tl.dtype:
+    num_bits = unwrap_if_constexpr(num_bits)
+    signed = unwrap_if_constexpr(signed)
+    return tl.core.get_int_dtype(num_bits, signed)
+
+
+@tl.constexpr
+def one_zeros(num_bits: tl.constexpr) -> int:
+    num_bits = unwrap_if_constexpr(num_bits)
+    return 1 << (num_bits - 1)
+
+
+@tl.constexpr
+def zero_ones(num_bits: tl.constexpr) -> int:
+    num_bits = unwrap_if_constexpr(num_bits)
+    return (1 << (num_bits - 1)) - 1
+
+
+@triton.jit
+def uint_to_uint(x, descending: tl.constexpr = False):
+    out = ~x if descending else x
+    return out
+
+
+@triton.jit
+def int_to_uint(x, descending: tl.constexpr = False):
+    num_bits: tl.constexpr = x.dtype.primitive_bitwidth
+    udtype = get_int_t(num_bits, False)
+    ux = tl.cast(x, udtype, bitcast=True)
+    if descending:
+        # 0111111....1
+        bit_mask: tl.constexpr = zero_ones(num_bits)
+        bit_mask_tensor = tl.full((), value=bit_mask, dtype=udtype)
+        out = ux ^ bit_mask_tensor
+    else:
+        # 1000000...0
+        sign_bit_mask: tl.constexpr = one_zeros(num_bits)
+        sign_bit_mask_tensor = tl.full((), value=sign_bit_mask, dtype=udtype)
+        out = ux ^ sign_bit_mask_tensor
+    return out
+
+
+@triton.jit
+def floating_to_uint(x, descending: tl.constexpr = False):
+    num_bits: tl.constexpr = x.dtype.primitive_bitwidth
+    sdtype = get_int_t(num_bits, True)
+    udtype = get_int_t(num_bits, False)
+    sx = x.to(sdtype, bitcast=True)
+    ux = x.to(udtype, bitcast=True)
+
+    sign_bit_mask_v: tl.constexpr = one_zeros(num_bits)
+    sign_bit_mask = tl.full((), value=sign_bit_mask_v, dtype=udtype)
+    # mind the dtype, right_shift for signed is arithmetic right shift
+    # Fix for triton 3.1 or else `sx >> rshift_bits` is promoted to int32
+    rshift_bits = tl.full((), value=num_bits - 1, dtype=sdtype)
+    mask = sign_bit_mask | (sx >> rshift_bits).to(udtype, bitcast=True)
+    tl.static_assert(mask.dtype == udtype, "type mismatch")
+    # 1000000000...0 for positive
+    # 1111111111...1 for negative
+    if descending:
+        out = ux ^ (~mask)
+    else:
+        out = ux ^ mask
+    return out.to(udtype, bitcast=True)
+
+
+@triton.jit
+def convert_to_uint_preverse_order(x: tl.tensor, descending: tl.constexpr = False):
+    if x.dtype.is_floating():
+        out = floating_to_uint(x, descending)
+    elif x.dtype.is_int_signed():
+        out = int_to_uint(x, descending)
+    elif x.dtype.is_int_unsigned():
+        out = uint_to_uint(x, descending)
+    return out
+
+
+@triton.jit
+def compute_global_hist_kernel(
+    arr_ptr,
+    out_ptr,
+    num_passes,
+    m,
+    n,
+    tiles_n_per_cta,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    num_bits_per_pass: tl.constexpr,
+    descending: tl.constexpr,
+):
+    # arr_ptr: (m, n)
+    # out_ptr: (m, n_passes, r), where r = 2 ** k_bits is the number of bins
+    pid = tl.program_id(0)
+    pid_n = pid // m
+    pid_m = pid % m
+
+    r: tl.constexpr = 2**num_bits_per_pass
+    bfe_mask: tl.constexpr = (1 << num_bits_per_pass) - 1  # a.k.a. 2 ** k_bits - 1
+    CTA_TILE_N: tl.constexpr = TILE_N * tiles_n_per_cta
+    cta_n_start = CTA_TILE_N * pid_n
+    cta_n_end = tl.minimum(cta_n_start + CTA_TILE_N, n)
+
+    for p in range(0, num_passes):  # parallel
+        bit_offset = p * num_bits_per_pass
+        for r_start in range(0, r, TILE_R):  # parallel
+            bin_indices = r_start + tl.arange(0, TILE_R)
+            acc = tl.zeros((TILE_R, TILE_N), dtype=tl.int64)
+            for n_start in range(cta_n_start, cta_n_end, TILE_N):  # sequantial
+                n_offsets = n_start + tl.arange(0, TILE_N)  # (TILE_N, )
+                mask = n_offsets < cta_n_end
+                arr = tl.load(arr_ptr + pid_m * n + n_offsets, mask=mask)
+                arr = convert_to_uint_preverse_order(arr, descending)
+                key = (arr >> bit_offset) & bfe_mask  # (TILE_N, )
+                matches = tl.where(
+                    mask, (bin_indices[:, None] == key), False
+                )  # (TILE_R, TILE_N)
+                acc += matches
+            local_sum = tl.sum(acc, axis=1)
+            tl.atomic_add(
+                out_ptr + pid_m * num_passes * r + p * r + bin_indices,
+                local_sum,
+                sem="relaxed",
+            )
+
+
+@triton.jit
+def tile_histogram_kernel(
+    arr_ptr,
+    tile_hist_ptr,  # output: (m, r, grid_n) - per-tile count for each bin
+    bit_offset,
+    m,
+    N,
+    grid_n,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    # Grid: (m * grid_n, grid_r)
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+        count = tl.sum(matches.to(tl.uint32), axis=0)
+        # tile_hist: (m, r, grid_n)
+        tl.store(
+            tile_hist_ptr + pid_m * (r * grid_n) + bin_index * grid_n + pid_n,
+            count,
+        )
+
+
+@triton.jit
+def scatter_kernel(
+    arr_ptr,
+    associate_arr_ptr,
+    out_ptr,
+    associate_out_ptr,
+    excumsum_bins_ptr,  # (m, n_passes, r) - global exclusive prefix per bin
+    tile_offsets_ptr,  # (m, r, grid_n) - exclusive prefix of tile counts per bin
+    n_passes,
+    pass_id,
+    bit_offset,
+    m,
+    N,
+    grid_n,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    # Grid: (m * grid_n, grid_r)
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+    if associate_arr_ptr is not None:
+        associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+
+        # Intra-tile exclusive cumsum for this bin
+        local_ex_cumsum = tl.cumsum(matches.to(tl.uint32), axis=0) - matches
+
+        # Load pre-computed offset for this tile+bin
+        tile_offset = tl.load(
+            tile_offsets_ptr + pid_m * (r * grid_n) + bin_index * grid_n + pid_n
+        )
+
+        # Global bin offset
+        ex_cumsum_bins = tl.load(
+            excumsum_bins_ptr + pid_m * (n_passes * r) + pass_id * r + bin_index
+        )
+
+        pos = ex_cumsum_bins + tile_offset + local_ex_cumsum
+
+        # scatter
+        tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
+        if associate_arr_ptr is not None:
+            tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
+
+
+def radix_sort(arr, k_bits=8, descending=False):
+    n = arr.shape[-1]
+    m = arr.numel() // n
+    assert n < (1 << 30), "we have not implemented 2**30 per launch"
+    dtype = arr.dtype
+    num_bits = 1 if dtype == torch.bool else (arr.itemsize * 8)
+
+    TILE_N = 1024
+    tiles_n_per_cta = 8
+    CTA_TILE_N = tiles_n_per_cta * TILE_N
+
+    num_bins = 2**k_bits
+    n_passes = triton.cdiv(num_bits, k_bits)
+    TILE_R = 16
+
+    grid_n = triton.cdiv(n, CTA_TILE_N)
+    grid_for_global_hist = (m * grid_n, 1, 1)
+
+    with torch_device_fn.device(arr.device):
+        global_hist = torch.zeros(
+            (m, n_passes, num_bins), device=arr.device, dtype=torch.int32
+        )
+        compute_global_hist_kernel[grid_for_global_hist](
+            arr,
+            global_hist,
+            n_passes,
+            m,
+            n,
+            tiles_n_per_cta,
+            TILE_N,
+            TILE_R,
+            k_bits,
+            descending,
+        )
+        ex_cumsum_bins = torch.cumsum(global_hist, -1) - global_hist
+        ex_cumsum_bins = ex_cumsum_bins.to(torch.uint32)
+
+        # sort
+        arr_in = torch.clone(arr)
+        indices_in = (
+            torch.arange(0, n, dtype=torch.int64, device=arr_in.device)
+            .broadcast_to(arr.shape)
+            .contiguous()
+        )
+        arr_out = torch.empty_like(arr)
+        indices_out = torch.empty_like(indices_in)
+
+        TILE_R = 8
+        grid_r = triton.cdiv(num_bins, TILE_R)
+        TILE_N = 2048
+        grid_n = triton.cdiv(n, TILE_N)
+
+        # 3-pass radix sort: no cross-CTA dependencies, fully parallel,
+        # no deadlock risk regardless of SM count or occupancy.
+        grid_sweep = (m * grid_n, grid_r)
+
+        # Allocate tile histogram buffer: (m, num_bins, grid_n)
+        tile_hist = torch.empty(
+            (m, num_bins, grid_n), device=arr.device, dtype=torch.uint32
+        )
+
+        for i in range(0, n_passes):
+            bit_offset = i * k_bits
+
+            # Pass 1: compute per-tile histogram
+            tile_histogram_kernel[grid_sweep](
+                arr_in,
+                tile_hist,
+                bit_offset,
+                m,
+                n,
+                grid_n,
+                TILE_N,
+                TILE_R,
+                k_bits,
+                descending,
+            )
+
+            # Pass 2: exclusive prefix sum along tile dimension (host-side)
+            # tile_hist shape: (m, num_bins, grid_n)
+            # We want exclusive cumsum along dim=-1 for each (m, bin)
+            tile_offsets = torch.cumsum(tile_hist, dim=-1) - tile_hist
+
+            # Pass 3: scatter using pre-computed offsets
+            scatter_kernel[grid_sweep](
+                arr_in,
+                indices_in,
+                arr_out,
+                indices_out,
+                ex_cumsum_bins,
+                tile_offsets,
+                n_passes,
+                i,
+                bit_offset,
+                m,
+                n,
+                grid_n,
+                TILE_N,
+                TILE_R,
+                k_bits,
+                descending,
+            )
+
+            arr_in, arr_out = arr_out, arr_in
+            indices_in, indices_out = indices_out, indices_in
+
+    return arr_in, indices_in
+
+
+@libentry()
+@triton.jit()
+def sort_kernel(
+    in_ptr,
+    out_ptr,
+    out_index_ptr,
+    N: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DESCENDING: tl.constexpr,
+    IS_FLOAT: tl.constexpr,
+):
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < N
+    offset = tl.program_id(0) * N + cols
+    in_ptr += offset
+    out_ptr += offset
+    out_index_ptr += offset
+
+    if IS_FLOAT:
+        mask_val = _get_finfo_val(in_ptr.dtype.element_ty, return_max=not DESCENDING)
+        in_val = tl.load(in_ptr, mask=mask, other=mask_val)
+    else:
+        mask_val = _get_iinfo_val(in_ptr.dtype.element_ty, return_max=not DESCENDING)
+        in_val = tl.load(in_ptr, mask=mask, other=mask_val)
+
+    index_val = tl.arange(0, BLOCK_SIZE)
+
+    sorted_in_val, sorted_index_val = argsort(
+        in_val, index_val, 0, descending=DESCENDING
+    )
+    tl.store(out_ptr, sorted_in_val, mask=mask)
+    tl.store(out_index_ptr, sorted_index_val, mask=mask)
+
+
+def sort(inp, dim=-1, descending=False):
+    # We only implement stable radix sort here
+    logger.debug("GEMS SORT")
+    return sort_stable(inp, stable=False, dim=dim, descending=descending)
+
+
+def sort_stable(inp, *, stable, dim=-1, descending=False):
+    logger.debug("GEMS SORT.STABLE")
+    # We only implement stable radix sort here
+    _ = stable
+    sort_elem_cnt = inp.shape[dim]
+    if sort_elem_cnt == 1:
+        return inp, torch.zeros_like(inp, dtype=torch.int64)
+
+    if dim < 0:
+        dim = dim + inp.ndim
+    if dim != inp.ndim - 1:
+        inp = torch.movedim(inp, dim, -1).contiguous()
+    else:
+        inp = inp.contiguous()
+
+    dtype = inp.dtype
+    num_bits_per_pass = 1 if dtype == torch.bool else 4
+    out, out_index = radix_sort(inp, num_bits_per_pass, descending)
+
+    if dim != inp.ndim - 1:
+        out = torch.movedim(out, -1, dim)
+        out_index = torch.movedim(out_index, -1, dim)
+    return out, out_index


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
decoupled lookback（解耦回看）前缀和算法，这种算法要求 CTAs 严格按 pid 递增顺序执行（或至少保证 pid=k 执行前，pid<k 的 CTA 必须已经写入 status）。在Iluvatar BI-V150 上只有 16 个 SM。当 grid 大小超过 16 时，GPU 不能保证 CTA 的调度顺序。如果 pid=5 的CTA 先被调度，它会在 while pack1 == 0 处死等 pid=4 的结果，但 pid=4 可能还没被调度到——死锁。
用 3-pass 替代 decoupled lookback，天数后端单独适配，损失一定性能

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
