### PR TITLE
[metax] Fix upsample_linear1d autotune key mismatch (unblock metax CI)

### DIFF
--- a/src/flag_gems/runtime/backend/_metax/ops/upsample_linear1d.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/upsample_linear1d.py
@@ -38,7 +38,7 @@ device = device.name
 
 @triton.autotune(
     configs=runtime.get_tuned_config("upsample_linear1d"),
-    key=["N", "C", "W_in", "W_out"],
+    key=["NC", "W_in", "W_out"],
 )
 @triton.heuristics(
     values={


### PR DESCRIPTION
## Problem

Metax backend CI is failing at `import flag_gems` with:

```
RuntimeError: Failed to import vendor extra lib: 'N' is not in list
```

This breaks **every** metax backend test run, regardless of which operator is
under test (e.g. PR #4954's `masked_scatter_backward` run fails with this same
error).

## Root Cause

`_metax/ops/upsample_linear1d.py` declares:

```python
@triton.autotune(
    configs=runtime.get_tuned_config("upsample_linear1d"),
    key=["N", "C", "W_in", "W_out"],   # ❌
)
def upsample_linear1d_metax_kernel(
    input_ptr, output_ptr,
    NC,          # ✅ single flattened arg, not separate N and C
    W_in, W_out, scale, bias,
    BLOCK_SIZE: tl.constexpr,
):
```

The autotune `key` references `N` and `C`, but the kernel signature only has
the flattened `NC = N * C`. On triton versions that resolve autotune keys
eagerly (during `Autotuner.__init__`), `arg_names.index("N")` raises
`ValueError: 'N' is not in list`, which the vendor-lib loader wraps as the
`RuntimeError` above.

## Fix

```python
key=["NC", "W_in", "W_out"],
```

matching the actual kernel parameters.

## Verification (MetaX C550)

- `get_tuned_config("upsample_linear1d")` returns 12 configs (added in #5576)
- op runs correctly; max abs diff vs `torch.nn.functional.interpolate` = 0.0
- full test suite: `tests/test_upsample_linear1d.py` → 1107 passed, 120 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
