### PR TITLE
fix(i0): avoid unnecessary x.to() temporary tensor

### DIFF
--- a/src/flag_gems/ops/i0.py
+++ b/src/flag_gems/ops/i0.py
@@ -120,7 +120,7 @@ def i0(x: torch.Tensor):
         raise ValueError(f"i0: input tensor must be on {flag_gems.device} device")
     # Result dtype follows PyTorch's floating type behavior
     out_dtype = x.dtype if x.is_floating_point() else torch.get_default_dtype()
-    out = torch.empty_like(x.to(dtype=out_dtype), dtype=out_dtype, device=x.device)
+    out = torch.empty_like(x, dtype=out_dtype)
     _launch_i0(out, x)
     return out
 


### PR DESCRIPTION
torch.empty_like accepts a dtype parameter directly, so there is no need to convert x via x.to(dtype=out_dtype) just to obtain shape info. The converted tensor was immediately discarded after empty_like read its shape — the original x (unconverted) is passed to the kernel.

Migrated from f57177d71 ("fix(special_i0): avoid unnecessary x.to() temporary tensor") which targeted the since-removed special_i0.py; the equivalent code lives in ops/i0.py on this branch.

Origin PR：https://github.com/flagos-ai/FlagGems-Experimental/pull/83
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
