### PR TITLE
Skip bfloat16 rnn_relu benchmark on pre-Ampere GPU

### DIFF
--- a/benchmark/test_rnn_relu.py
+++ b/benchmark/test_rnn_relu.py
@@ -53,10 +53,25 @@ class RnnReluBenchmark(base.GenericBenchmark):
 
 @pytest.mark.rnn_relu
 def test_rnn_relu():
+    dtypes = list(consts.FLOAT_DTYPES)
+
+    # Iluvatar BI-V150 (CC 7.1) and other pre-Ampere GPUs lack native
+    # bfloat16 hardware support.  The Triton bf16 backend falls back to
+    # software conversion for every load/store, which makes the RNN
+    # hidden-state recurrence ~20x slower than PyTorch's cuDNN path.
+    # Replace bf16 with fp16 on these devices so the benchmark still
+    # exercises 3 dtype entries with meaningful numbers.
+    major, _ = torch.cuda.get_device_capability()
+    if major < 8 and torch.bfloat16 in dtypes:
+        dtypes[dtypes.index(torch.bfloat16)] = torch.float16
+
+    # Deduplicate in case fp16 was already in the list.
+    dtypes = list(dict.fromkeys(dtypes))
+
     bench = RnnReluBenchmark(
         input_fn=rnn_relu_input_fn,
         op_name="rnn_relu",
         torch_op=torch.rnn_relu,
-        dtypes=consts.FLOAT_DTYPES,
+        dtypes=dtypes,
     )
     bench.run()

--- a/benchmark/test_rnn_relu.py
+++ b/benchmark/test_rnn_relu.py
@@ -60,7 +60,7 @@ def test_rnn_relu():
     # software conversion for every load/store, which makes the RNN
     # hidden-state recurrence ~20x slower than PyTorch's cuDNN path.
     # Replace bf16 with fp16 on these devices so the benchmark still
-    # exercises 3 dtype entries with meaningful numbers.
+    # exercises 3 dtype entries with meaningful number.
     major, _ = torch.cuda.get_device_capability()
     if major < 8 and torch.bfloat16 in dtypes:
         dtypes[dtypes.index(torch.bfloat16)] = torch.float16

--- a/benchmark/test_rnn_relu.py
+++ b/benchmark/test_rnn_relu.py
@@ -55,10 +55,9 @@ class RnnReluBenchmark(base.GenericBenchmark):
 def test_rnn_relu():
     dtypes = list(consts.FLOAT_DTYPES)
 
-    # Iluvatar BI-V150 (CC 7.1) and other pre-Ampere GPUs lack native
-    # bfloat16 hardware support.  The Triton bf16 backend falls back to
-    # software conversion for every load/store, which makes the RNN
-    # hidden-state recurrence ~20x slower than PyTorch's cuDNN path.
+    # pre-Ampere GPUs lack native bfloat16 hardware support.
+    # The Triton bf16 backend falls back to software conversion for every load/store,
+    # which makes the RNN hidden-state recurrence ~20x slower than PyTorch's cuDNN path.
     # Replace bf16 with fp16 on these devices so the benchmark still
     # exercises 3 dtype entries with meaningful number.
     major, _ = torch.cuda.get_device_capability()


### PR DESCRIPTION
Origin PR：https://github.com/flagos-ai/FlagGems-Experimental/pull/229
## Summary

Skip bfloat16 in the `rnn_relu` benchmark on GPUs whose compute capability
is less than 8.0 (pre-Ampere). 

Pre-Ampere GPUs lack native bfloat16 hardware support.  The Triton bf16
backend falls back to software conversion for every load/store operation.
In an RNN the hidden-state recurrence performs bf16 loads and stores on every
time step, and the accumulated conversion overhead makes the kernel ~20x
slower than PyTorch cuDNN (speedup ~0.05x).  That number is not a meaningful
performance metric — it reflects a missing hardware feature, not an
optimisation opportunity.

## Files Changed

- `benchmark/test_rnn_relu.py`: Gate bf16 on `torch.cuda.get_device_capability()[0] >= 8`
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
