### PR TITLE
fix(metax): add Triton cache race protection for full and index ops

### DIFF
--- a/src/flag_gems/runtime/backend/_metax/ops/full.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/full.py
@@ -14,6 +14,7 @@
 
 import logging
 import math
+import time
 
 import torch
 import triton
@@ -105,21 +106,41 @@ def full_(out, N, dtype, device, fill_value):
         is_scale = True
 
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+    
+    # Retry mechanism for Triton cache race conditions
+    max_retries = 3
+    retry_delay = 0.01  # 10ms
+    
     with torch_device_fn.device(device):
-        if is_scale:
-            full_kernel_scale[grid_fn](
-                out,
-                N,
-                fill_value,
-            )
-        else:
-            full_kernel[grid_fn](
-                out,
-                N,
-                fill_value,
-                FILL_VALUE_IS_PTR=FILL_VALUE_IS_PTR,
-                BLOCK_SIZE=1024,
-            )
+        for attempt in range(max_retries):
+            try:
+                if is_scale:
+                    full_kernel_scale[grid_fn](
+                        out,
+                        N,
+                        fill_value,
+                    )
+                else:
+                    full_kernel[grid_fn](
+                        out,
+                        N,
+                        fill_value,
+                        FILL_VALUE_IS_PTR=FILL_VALUE_IS_PTR,
+                        BLOCK_SIZE=1024,
+                    )
+                break  # Success, exit retry loop
+            except FileNotFoundError as e:
+                if attempt < max_retries - 1:
+                    # Transient Triton cache issue, retry
+                    logger.warning(
+                        f"Triton cache FileNotFoundError (attempt {attempt + 1}/{max_retries}): {e}"
+                    )
+                    time.sleep(retry_delay)
+                    retry_delay *= 2  # Exponential backoff
+                else:
+                    # Final attempt failed, re-raise
+                    logger.error(f"Triton cache FileNotFoundError after {max_retries} attempts")
+                    raise
     return out
 
 

--- a/src/flag_gems/runtime/backend/_metax/ops/index.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index.py
@@ -49,6 +49,7 @@ def broadcast_indices(indices, target_shape):
 
 
 def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
+    code.writeline("import time")
     code.writeline("import triton")
     code.writeline("import triton.language as tl")
     code.newline()
@@ -56,6 +57,9 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
+    code.writeline("import logging")
+    code.newline()
+    code.writeline("logger = logging.getLogger(__name__)")
 
     code.newline()
     code.newline()
@@ -180,23 +184,50 @@ def generate_index_wrapper(
             code.writeline("triton.cdiv(N, meta['BLOCK_SIZE1']), ")
         code.writeline(")")
         code.newline()
-        code.writeline(f"{kernel_name}[grid](")
+        
+        # Add retry mechanism for Triton cache race conditions
+        code.writeline("# Retry mechanism for Triton cache race conditions")
+        code.writeline("max_retries = 3")
+        code.writeline("retry_delay = 0.01  # 10ms")
+        code.newline()
+        code.writeline("for attempt in range(max_retries):")
         with code.indent():
-            args = ["input,"]
-            args += [f"indices[{i}]," for i in range(indices_len)]
-            args += ["out,"]
-            args += [f"input_shape[{i}]," for i in range(inp_rank)]
-            for i in range(indices_len):
-                args += [f"indices{i}_shape[{j}]," for j in range(index_rank)]
-            args += [f"input_stride[{i}]," for i in range(inp_rank)]
-            for i in range(indices_len):
-                args += [f"indices{i}_stride[{j}]," for j in range(index_rank)]
-            args += [
-                f"out_stride[{i}]," for i in range(index_rank + inp_rank - indices_len)
-            ]
-            args += ["M,", "N,"]
-            code.writelines(args)
-        code.writeline(")")
+            code.writeline("try:")
+            with code.indent():
+                code.writeline(f"{kernel_name}[grid](")
+                with code.indent():
+                    args = ["input,"]
+                    args += [f"indices[{i}]," for i in range(indices_len)]
+                    args += ["out,"]
+                    args += [f"input_shape[{i}]," for i in range(inp_rank)]
+                    for i in range(indices_len):
+                        args += [f"indices{i}_shape[{j}]," for j in range(index_rank)]
+                    args += [f"input_stride[{i}]," for i in range(inp_rank)]
+                    for i in range(indices_len):
+                        args += [f"indices{i}_stride[{j}]," for j in range(index_rank)]
+                    args += [
+                        f"out_stride[{i}]," for i in range(index_rank + inp_rank - indices_len)
+                    ]
+                    args += ["M,", "N,"]
+                    code.writelines(args)
+                code.writeline(")")
+                code.writeline("break  # Success, exit retry loop")
+            code.writeline("except FileNotFoundError as e:")
+            with code.indent():
+                code.writeline("if attempt < max_retries - 1:")
+                with code.indent():
+                    code.writeline("# Transient Triton cache issue, retry")
+                    code.writeline('logger.warning(')
+                    with code.indent():
+                        code.writeline('f"Triton cache FileNotFoundError in index (attempt {attempt + 1}/{max_retries}): {e}"')
+                    code.writeline(")")
+                    code.writeline("time.sleep(retry_delay)")
+                    code.writeline("retry_delay *= 2  # Exponential backoff")
+                code.writeline("else:")
+                with code.indent():
+                    code.writeline("# Final attempt failed, re-raise")
+                    code.writeline('logger.error(f"Triton cache FileNotFoundError in index after {max_retries} attempts")')
+                    code.writeline("raise")
         code.writeline("return input")
     code.newline()
     code.newline()


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

Add retry mechanism with exponential backoff to handle transient `FileNotFoundError` caused by Triton cache race conditions on MACA backend.

**Problem**: Under concurrent execution on MACA hardware, Triton's JIT compilation cache can encounter race conditions where a cached kernel file is temporarily unavailable, resulting in `FileNotFoundError` that crashes the operator.

**Solution**: Wrap kernel launches in `full.py` and `index.py` with a retry loop (max 3 attempts, 10ms initial delay with exponential backoff). If the error persists after all retries, it is re-raised with proper logging.

**Changed files**:
- `src/flag_gems/runtime/backend/_metax/ops/full.py`: Add retry around `full_kernel` / `full_kernel_scale` launches
- `src/flag_gems/runtime/backend/_metax/ops/index.py`: Add retry in generated index kernel wrapper code

### Issue

Resolves transient `FileNotFoundError` during Triton kernel launch on MACA backend under concurrent workloads.

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

No performance impact in normal execution path (retry only triggers on transient cache failures). The 10ms backoff only activates when `FileNotFoundError` is caught, which does not occur in healthy conditions.
