### PR TITLE
fix iluvatar bmm/conv2d

### DIFF
--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -15,7 +15,10 @@
 from ._native_batch_norm_legit_functional import _native_batch_norm_legit_functional
 from .addmm import addmm, addmm_out
 from .arccosh_ import arccosh_
+from .baddbmm import baddbmm, baddbmm_out
+from .bmm import bmm, bmm_out
 from .cholesky_solve import cholesky_solve, cholesky_solve_out
+from .conv2d import conv2d
 from .conv_depthwise2d import _conv_depthwise2d
 from .conv_transpose1d import conv_transpose1d
 from .div import div_mode, div_mode_
@@ -44,9 +47,14 @@ __all__ = [
     "addmm",
     "addmm_out",
     "arccosh_",
+    "baddbmm",
+    "baddbmm_out",
+    "bmm",
+    "bmm_out",
     "cholesky_solve",
     "cholesky_solve_out",
     "conv_transpose1d",
+    "conv2d",
     "div_mode",
     "div_mode_",
     "hadamard_transform",

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/baddbmm.py
@@ -1,0 +1,255 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Iluvatar-specific baddbmm implementation that adds padding for small dimensions.
+
+The Iluvatar Triton compiler requires:
+1. All dimensions (M, N, K) >= 32
+2. K must be a multiple of 128 (EVEN_K=False crashes the compiler)
+
+This implementation pads matrices before calling the baddbmm kernel and slices
+the result back to the original size, similar to the mm/addmm fix #5466.
+"""
+
+import logging
+
+import torch
+
+from flag_gems.ops.baddbmm import baddbmm_kernel
+from flag_gems.ops.mul import mul
+from flag_gems.runtime import torch_device_fn
+from flag_gems.runtime.backend._iluvatar.ops.bmm import bmm as bmm_iluvatar
+
+logger = logging.getLogger(__name__)
+
+# Iluvatar compiler constraints (from mm.py fix #5466)
+_MIN_TRITON_DIM = 32
+_MAX_BLOCK_K = 128
+
+
+def _baddbmm_launch_padded(bias, A, B, beta, alpha, out):
+    """Launch baddbmm kernel with padding for Iluvatar compiler constraints."""
+    batch, M, K = A.shape
+    _, _, N = B.shape
+
+    # Check if padding is needed
+    need_pad = (
+        M < _MIN_TRITON_DIM
+        or N < _MIN_TRITON_DIM
+        or K < _MIN_TRITON_DIM
+        or K % _MAX_BLOCK_K != 0
+    )
+
+    if not need_pad:
+        # No padding needed, use default kernel directly
+        A = A.contiguous()
+        B = B.contiguous()
+        bbias = torch.broadcast_to(bias, (batch, M, N)).contiguous()
+        bias_batch_stride = bbias.stride(0)
+        bias_M_stride = bbias.stride(1)
+        bias_N_stride = bbias.stride(-1)
+
+        grid = lambda meta: (
+            triton.cdiv(meta["M"], meta["TILE_M"]),
+            triton.cdiv(meta["N"], meta["TILE_N"]),
+            batch,
+        )
+
+        import triton
+
+        with torch_device_fn.device(A.device):
+            baddbmm_kernel[grid](
+                A,
+                B,
+                out,
+                bbias,
+                alpha,
+                beta,
+                M,
+                N,
+                K,
+                bias_batch_stride=bias_batch_stride,
+                bias_M_stride=bias_M_stride,
+                bias_N_stride=bias_N_stride,
+            )
+        return
+
+    # Padding is needed - calculate padding amounts
+    pad_M = max(_MIN_TRITON_DIM - M, 0)
+    pad_N = max(_MIN_TRITON_DIM - N, 0)
+    new_K = K + max(_MIN_TRITON_DIM - K, 0)
+    remainder = new_K % _MAX_BLOCK_K
+    if remainder:
+        new_K += _MAX_BLOCK_K - remainder
+    pad_K = new_K - K
+
+    # Pad inputs
+    if pad_M or pad_K:
+        A_padded = torch.nn.functional.pad(A, (0, pad_K, 0, pad_M))
+    else:
+        A_padded = A
+
+    if pad_K or pad_N:
+        B_padded = torch.nn.functional.pad(B, (0, pad_N, 0, pad_K))
+    else:
+        B_padded = B
+
+    # Pad bias
+    bias_expanded = torch.broadcast_to(bias, (batch, M, N))
+    if pad_M or pad_N:
+        bias_padded = torch.nn.functional.pad(bias_expanded, (0, pad_N, 0, pad_M))
+    else:
+        bias_padded = bias_expanded
+
+    # Make everything contiguous
+    A_padded = A_padded.contiguous()
+    B_padded = B_padded.contiguous()
+    bias_padded = bias_padded.contiguous()
+
+    pM, pN, pK = M + pad_M, N + pad_N, new_K
+
+    # Create padded output
+    out_padded = torch.empty((batch, pM, pN), dtype=A.dtype, device=A.device)
+
+    # Launch kernel on padded inputs
+    import triton
+
+    bias_batch_stride = bias_padded.stride(0)
+    bias_M_stride = bias_padded.stride(1)
+    bias_N_stride = bias_padded.stride(-1)
+
+    grid = lambda meta: (
+        triton.cdiv(meta["M"], meta["TILE_M"]),
+        triton.cdiv(meta["N"], meta["TILE_N"]),
+        batch,
+    )
+
+    with torch_device_fn.device(A.device):
+        baddbmm_kernel[grid](
+            A_padded,
+            B_padded,
+            out_padded,
+            bias_padded,
+            alpha,
+            beta,
+            pM,
+            pN,
+            pK,
+            bias_batch_stride=bias_batch_stride,
+            bias_M_stride=bias_M_stride,
+            bias_N_stride=bias_N_stride,
+        )
+
+    # Slice back to original size
+    out.copy_(out_padded[:, :M, :N])
+
+
+def compute_A_grad(d_output, B, alpha):
+    """Compute gradient for A using iluvatar-specialized bmm."""
+    B_T = B.transpose(1, 2)
+    if B.dtype == torch.float16:
+        Bcopy = B_T.to(torch.float32)
+        dcopye = d_output.to(torch.float32)
+        mul1 = bmm_iluvatar(dcopye, Bcopy)
+        grad_A = mul(mul1, alpha)
+        grad_A = grad_A.to(torch.float16)
+    else:
+        mul1 = bmm_iluvatar(d_output, B_T)
+        grad_A = mul(mul1, alpha)
+    return grad_A
+
+
+def compute_B_grad(A, d_output, alpha):
+    """Compute gradient for B using iluvatar-specialized bmm."""
+    A_T = A.transpose(1, 2)
+    if A.dtype == torch.float16:
+        Acopy = A_T.to(torch.float32)
+        dcopye = d_output.to(torch.float32)
+        mul2 = bmm_iluvatar(Acopy, dcopye)
+        grad_B = mul(mul2, alpha)
+        grad_B = grad_B.to(torch.float16)
+    else:
+        mul2 = bmm_iluvatar(A_T, d_output)
+        grad_B = mul(mul2, alpha)
+    return grad_B
+
+
+def compute_bias_grad(d_output, beta, bias):
+    """Compute gradient for bias (copied from ops.baddbmm)."""
+    grad_bias = mul(d_output, beta)
+    if grad_bias.shape != bias.shape:
+        # Sum over broadcasted dimensions
+        while grad_bias.dim() > bias.dim():
+            grad_bias = grad_bias.sum(dim=0)
+        for i in range(bias.dim()):
+            if bias.shape[i] == 1 and grad_bias.shape[i] > 1:
+                grad_bias = grad_bias.sum(dim=i, keepdim=True)
+    return grad_bias
+
+
+class BaddbmmFunction(torch.autograd.Function):
+    """Iluvatar-specific BaddbmmFunction with padding and specialized bmm."""
+
+    @staticmethod
+    def forward(ctx, bias, A, B, beta, alpha):
+        logger.debug("GEMS_ILUVATAR BADDBMM FORWARD")
+
+        ctx.save_for_backward(A, B, bias)
+        ctx.alpha = alpha
+        ctx.beta = beta
+
+        batch, M, K = A.shape
+        _, _, N = B.shape
+        out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)
+        _baddbmm_launch_padded(bias, A, B, beta, alpha, out)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logger.debug("GEMS_ILUVATAR BADDBMM BACKWARD")
+        A, B, bias = ctx.saved_tensors
+
+        grad_A = None
+        grad_B = None
+        grad_bias = None
+        if ctx.needs_input_grad[0]:
+            grad_bias = compute_bias_grad(grad_output, ctx.beta, bias)
+        if ctx.needs_input_grad[1]:
+            grad_A = compute_A_grad(grad_output, B, ctx.alpha)
+        if ctx.needs_input_grad[2]:
+            grad_B = compute_B_grad(A, grad_output, ctx.alpha)
+
+        return grad_bias, grad_A, grad_B, None, None
+
+
+def baddbmm(bias, a, b, beta=1.0, alpha=1.0):
+    """Batch matrix multiply-add with Iluvatar-specific padding for small dimensions.
+
+    Computes: out = beta * bias + alpha * (a @ b)
+    Uses BaddbmmFunction.apply which has specialized backward.
+    """
+    logger.debug("GEMS_ILUVATAR BADDBMM")
+    return BaddbmmFunction.apply(
+        bias.contiguous(), a.contiguous(), b.contiguous(), beta, alpha
+    )
+
+
+def baddbmm_out(bias, a, b, *, beta=1.0, alpha=1.0, out):
+    """Batch matrix multiply-add with output tensor, using Iluvatar-specific padding."""
+    logger.debug("GEMS_ILUVATAR BADDBMM_OUT")
+
+    result = baddbmm(bias, a, b, beta=beta, alpha=alpha)
+    out.copy_(result)
+    return out

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
@@ -1,0 +1,87 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Iluvatar-specific bmm implementation that adds padding for small dimensions.
+
+The Iluvatar Triton compiler requires:
+1. All dimensions (M, N, K) >= 32
+2. K must be a multiple of 128 (EVEN_K=False crashes the compiler)
+"""
+
+import logging
+
+import torch
+
+from flag_gems.ops.bmm import bmm as bmm_default
+
+logger = logging.getLogger(__name__)
+
+# Iluvatar compiler constraints (from mm.py fix #5466)
+_MIN_TRITON_DIM = 32
+_MAX_BLOCK_K = 128
+
+
+def bmm(a, b):
+    """Batch matrix multiply with Iluvatar-specific padding for small dimensions."""
+    logger.debug("GEMS_ILUVATAR BMM")
+
+    batch, M, K = a.shape
+    _, K2, N = b.shape
+    assert K == K2, f"incompatible dimensions: K={K} vs K2={K2}"
+
+    # Check if padding is needed
+    need_pad = (
+        M < _MIN_TRITON_DIM
+        or N < _MIN_TRITON_DIM
+        or K < _MIN_TRITON_DIM
+        or K % _MAX_BLOCK_K != 0
+    )
+
+    if not need_pad:
+        # No padding needed, use default implementation
+        return bmm_default(a, b)
+
+    # Calculate padding amounts
+    pad_M = max(_MIN_TRITON_DIM - M, 0)
+    pad_N = max(_MIN_TRITON_DIM - N, 0)
+    new_K = K + max(_MIN_TRITON_DIM - K, 0)
+    remainder = new_K % _MAX_BLOCK_K
+    if remainder:
+        new_K += _MAX_BLOCK_K - remainder
+    pad_K = new_K - K
+
+    # Pad inputs
+    if pad_M or pad_K:
+        # Pad a: (batch, M, K) -> (batch, M+pad_M, K+pad_K)
+        a = torch.nn.functional.pad(a, (0, pad_K, 0, pad_M))
+    if pad_K or pad_N:
+        # Pad b: (batch, K, N) -> (batch, K+pad_K, N+pad_N)
+        b = torch.nn.functional.pad(b, (0, pad_N, 0, pad_K))
+
+    # Run bmm on padded inputs
+    out_padded = bmm_default(a, b)
+
+    # Slice back to original size
+    out = out_padded[:, :M, :N]
+    return out
+
+
+def bmm_out(a, b, *, out):
+    """Batch matrix multiply with output tensor, using Iluvatar-specific padding."""
+    logger.debug("GEMS_ILUVATAR BMM_OUT")
+
+    result = bmm(a, b)
+    out.copy_(result)
+    return out

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/conv2d.py
@@ -1,0 +1,857 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def conv2d_output_size(
+    in_size: int,
+    kernel_size: int,
+    stride: int,
+    padding: int,
+    dilation: int,
+) -> int:
+    """
+    Determines the output size of a 2D convolution operation.
+
+    Args:
+        in_size: Input size.
+        kernel_size: Kernel size.
+        stride: Stride.
+        padding: Padding.
+        dilation: Dilation.
+
+    Returns:
+        Output size of 2D convolution.
+    """
+    return (in_size + 2 * padding - dilation * (kernel_size - 1) - 1) // stride + 1
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("conv2d_forward"),
+    key=[
+        "in_n",
+        "weight_c",
+        "input_height",
+        "input_width",
+        "out_c",
+        "out_height",
+        "out_width",
+        "weight_height",
+        "weight_width",
+        "stride_height",
+        "stride_width",
+        "padding_height",
+        "padding_width",
+        "groups",
+    ],
+)
+@triton.jit
+def conv2d_forward_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    groups: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_ni_ho_wo = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_group = tl.program_id(2)
+
+    # caculate in_n out_height out_weight value in kernel
+    ni_ho_wo_offset = pid_ni_ho_wo * BLOCK_NI_HO_WO + tl.arange(0, BLOCK_NI_HO_WO)
+    ni_ho_offset = ni_ho_wo_offset // out_width
+    in_n_point_value = ni_ho_offset // out_height
+    output_height_point_value = ni_ho_offset % out_height
+    output_width_point_value = ni_ho_wo_offset % out_width
+
+    # Load the input and weight pointers. input and weight are of shape
+    # [in_n, groups, in_c, input_height, input_width] and [groups, out_c, in_c, weight_height, weight_width]
+    out_per_group_c = out_c // groups
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    input_pointer += (
+        input_n_stride * in_n_point_value + input_c_stride * pid_group * weight_c
+    )[:, None]
+    weight_pointer += (
+        weight_n_stride * output_c_offset
+        + weight_n_stride * pid_group * out_per_group_c
+    )[None, :]
+
+    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
+    BLOCK_CI_COUNT = (weight_c + BLOCK_CI - 1) // BLOCK_CI
+    for hwc in range(weight_height * weight_width * BLOCK_CI_COUNT):
+        c = (hwc % BLOCK_CI_COUNT) * BLOCK_CI
+        hw = hwc // BLOCK_CI_COUNT
+        h = hw // weight_width
+        w = hw % weight_width
+
+        input_c_offset = c + tl.arange(0, BLOCK_CI)
+        input_height_offset = (
+            h * dilation_height
+            - padding_height
+            + stride_height * output_height_point_value
+        )
+        input_width_offset = (
+            w * dilation_width - padding_width + stride_width * output_width_point_value
+        )
+
+        curr_input_pointer = (
+            input_pointer
+            + (input_c_stride * input_c_offset)[None, :]
+            + (input_height_stride * input_height_offset)[:, None]
+            + (input_width_stride * input_width_offset)[:, None]
+        )
+        curr_weight_pointer = (
+            weight_pointer
+            + (weight_c_stride * input_c_offset)[:, None]
+            + (weight_height_stride * h)
+            + (weight_width_stride * w)
+        )
+
+        input_mask = (
+            (in_n_point_value < in_n)[:, None]
+            & (input_c_offset < weight_c)[None, :]
+            & (0 <= input_height_offset)[:, None]
+            & (input_height_offset < input_height)[:, None]
+            & (0 <= input_width_offset)[:, None]
+            & (input_width_offset < input_width)[:, None]
+        )
+        weight_mask = (input_c_offset < weight_c)[:, None] & (
+            output_c_offset < out_per_group_c
+        )[None, :]
+
+        input_block = tl.load(curr_input_pointer, mask=input_mask)
+        weight_block = tl.load(curr_weight_pointer, mask=weight_mask)
+
+        accum += tl.dot(input_block, weight_block, allow_tf32=False)
+    bias_pointer += (pid_group[None] * out_per_group_c)[None, :] + output_c_offset[
+        None, :
+    ]
+    mask_bias = (output_c_offset < out_per_group_c)[None, :]
+    bias = tl.load(bias_pointer, mask_bias).to(tl.float32)
+    accum += bias
+    output_pointer += (
+        (output_n_stride * in_n_point_value)[:, None]
+        + (output_c_stride * (pid_group * out_per_group_c + output_c_offset))[None, :]
+        + (output_height_stride * output_height_point_value)[:, None]
+        + (output_width_stride * output_width_point_value)[:, None]
+    )
+    output_mask = (
+        (in_n_point_value < in_n)[:, None]
+        & (output_c_offset < out_per_group_c)[None, :]
+        & (output_height_point_value < out_height)[:, None]
+        & (output_width_point_value < out_width)[:, None]
+    )
+
+    tl.store(output_pointer, accum, mask=output_mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("conv2d_backward_weight"),
+    key=[
+        "in_n",
+        "input_height",
+        "input_width",
+        "weight_height",
+        "weight_width",
+        "input_c",
+        "stride_height",
+        "stride_width",
+        "out_height",
+        "out_width",
+        "out_c",
+        "padding_height",
+        "padding_width",
+    ],
+)
+@triton.jit
+def conv2d_backward_kernel_weight(
+    input_pointer,
+    out_grad_pointer,
+    weight_pointer,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    input_height,
+    input_width,
+    weight_height,
+    weight_width,
+    input_c,
+    in_n,
+    stride_height,
+    stride_width,
+    out_height,
+    out_width,
+    out_c,
+    padding_height,
+    padding_width,
+    dilation_height,
+    dilation_width,
+    BLOCK_NO: tl.constexpr,
+    BLOCK_CI_HK_WK: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    # load out_grad n (groups out_c)  ho wo
+    # load weight (groups out_c) ci h w
+    # load input n (groups ci)  hi wi
+
+    # init pid and offset 0 for ci*hk*wk, 1 for groups, 2 for co.
+    pid_ci_hk_wk = tl.program_id(0)
+    pid_groups = tl.program_id(1)
+    pid_co = tl.program_id(2)
+
+    # caculate ci weight_height weight_weight value in kernel
+    ci_hk_wk_offset = pid_ci_hk_wk * BLOCK_CI_HK_WK + tl.arange(0, BLOCK_CI_HK_WK)
+    ci_hk_offset = ci_hk_wk_offset // weight_width
+    ci_point_value = ci_hk_offset // weight_height
+    weight_height_point_value = ci_hk_offset % weight_height
+    weight_width_point_value = ci_hk_wk_offset % weight_width
+
+    # caculate init pointer info of tensors
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    out_grad_pointer += (output_c_offset * output_c_stride)[None, :] + (
+        pid_groups[None] * output_c_stride * out_c
+    )[:, None]
+
+    weight_pointer += (
+        pid_groups * weight_n_stride * out_c + output_c_offset * weight_n_stride
+    )[None, :] + (
+        ci_point_value * weight_c_stride
+        + weight_height_point_value * weight_height_stride
+        + weight_width_point_value * weight_width_stride
+    )[
+        :, None
+    ]
+
+    input_pointer += (ci_point_value * input_c_stride[None])[:, None] + (
+        pid_groups[None] * input_c_stride * input_c
+    )[None, :]
+
+    # calculate the values of the input based on the width and height of the output by looping
+    accum = tl.zeros((BLOCK_CI_HK_WK, BLOCK_CO), dtype=tl.float32)
+    for h in range(0, out_height):
+        for w in range(0, out_width):
+            for n in range(0, in_n, BLOCK_NO):
+                output_n_offset = n + tl.arange(0, BLOCK_NO)
+
+                # caculate input pointer to [cin*kh*kw, *] out_grad pointer to [*, out_c], N*hout*wout as reduce dim
+                curr_out_grad_pointer = (
+                    out_grad_pointer
+                    + (
+                        output_n_offset * output_n_stride
+                        + h * output_height_stride
+                        + w * output_width_stride
+                    )[:, None]
+                )
+                out_grad_mask = (output_n_offset < in_n)[:, None] & (
+                    output_c_offset < out_c
+                )[None, :]
+
+                curr_out_grad = tl.load(curr_out_grad_pointer, mask=out_grad_mask)
+
+                input_height_offset = (
+                    weight_height_point_value * dilation_height
+                    - padding_height
+                    + stride_height * h
+                )
+
+                input_width_offset = (
+                    weight_width_point_value * dilation_width
+                    - padding_width
+                    + stride_width * w
+                )
+
+                curr_input_pointer = (
+                    input_pointer
+                    + (input_n_stride * output_n_offset)[None, :]
+                    + (input_height_stride * input_height_offset)[:, None]
+                    + (input_width_stride * input_width_offset)[:, None]
+                )
+                input_mask = (
+                    (output_n_offset < in_n)[None, :]
+                    & (ci_point_value < input_c)[:, None]
+                    & (0 <= input_height_offset)[:, None]
+                    & (input_height_offset < input_height)[:, None]
+                    & (0 <= input_width_offset)[:, None]
+                    & (input_width_offset < input_width)[:, None]
+                )
+
+                curr_input = tl.load(curr_input_pointer, mask=input_mask)
+                accum += tl.dot(curr_input, curr_out_grad, allow_tf32=False)
+
+    weight_mask = (
+        (ci_point_value < input_c)[:, None]
+        & (output_c_offset < out_c)[None, :]
+        & (weight_height_point_value < weight_height)[:, None]
+        & (weight_width_point_value < weight_width)[:, None]
+    )
+    tl.store(weight_pointer, accum, weight_mask)
+
+
+class Conv2d(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, weight, bias, stride, padding, dilation, groups):
+        logger.debug("GEMS CONV2D")
+        assert weight.ndim == 4, "Weights must be 4D, received shape {weight.shape}"
+        assert (
+            bias is None or bias.ndim == 1
+        ), "Bias must be 1D, received shape {bias.shape}"
+
+        assert (
+            input.shape[1] == groups * weight.shape[1]
+        ), "Incompatible input ({input.shape}) and weights ({weight.shape}) shape with {groups} groups"
+        assert (
+            bias is None or weight.shape[0] == bias.shape[0]
+        ), "Incompatible weights ({weight.shape}) and bias ({bias.shape}) shape"
+
+        if isinstance(stride, (list, tuple)):
+            stride_height, stride_width = stride
+        else:
+            stride_height = stride_width = stride
+
+        if isinstance(padding, (list, tuple)):
+            padding_height, padding_width = padding
+        else:
+            padding_height = padding_width = padding
+
+        if isinstance(dilation, (list, tuple)):
+            dilation_height, dilation_width = dilation
+        else:
+            dilation_height = dilation_width = dilation
+
+        in_n, _, input_height, input_width = input.shape
+        out_c, weight_c, weight_height, weight_width = weight.shape
+        orig_weight_c = weight_c  # Save original before potential padding
+
+        # Save original tensors for backward BEFORE padding
+        orig_input = input
+        orig_weight = weight
+
+        # Triton tl.dot requires K >= 16. The K dimension in conv2d im2col matmul
+        # is BLOCK_CI which tiles over weight_c. When weight_c < 16, AABS
+        # (Auto-Adjusted Block Size) shrinks BLOCK_CI to next_power_of_2(weight_c)
+        # which violates the K >= 16 constraint. Pad input/weight channels to 16.
+        _MIN_DOT_K = 16
+        if weight_c < _MIN_DOT_K:
+            pad_c = _MIN_DOT_K - weight_c
+            if groups == 1:
+                # Simple case: pad channel dim at the end
+                input = torch.nn.functional.pad(input, (0, 0, 0, 0, 0, pad_c))
+            else:
+                # For grouped conv, must pad each group's channels independently.
+                # Reshape to (N, groups, weight_c, H, W), pad weight_c dim, reshape back.
+                N, C, H, W = input.shape
+                input = input.reshape(N, groups, weight_c, H, W)
+                input = torch.nn.functional.pad(input, (0, 0, 0, 0, 0, pad_c))
+                input = input.reshape(N, groups * (weight_c + pad_c), H, W)
+            # Pad weight: (out_c, weight_c, kH, kW) -> (out_c, weight_c+pad_c, kH, kW)
+            weight = torch.nn.functional.pad(weight, (0, 0, 0, 0, 0, pad_c))
+            weight_c = weight_c + pad_c
+
+        # Pad out_c (N dim of dot) when out_c per group is too small.
+        # The compiler may specialize on out_per_group_c causing pipeline failures.
+        fwd_out_c = out_c
+        out_per_group_c = out_c // groups
+        if out_per_group_c < _MIN_DOT_K:
+            pad_oc = _MIN_DOT_K - out_per_group_c
+            # weight shape: (out_c, weight_c, kH, kW) -> pad dim 0 per group
+            if groups == 1:
+                weight = torch.nn.functional.pad(weight, (0, 0, 0, 0, 0, 0, 0, pad_oc))
+            else:
+                weight = weight.reshape(groups, out_per_group_c, weight_c, weight_height, weight_width)
+                weight = torch.nn.functional.pad(weight, (0, 0, 0, 0, 0, 0, 0, pad_oc))
+                weight = weight.reshape(groups * (out_per_group_c + pad_oc), weight_c, weight_height, weight_width)
+            fwd_out_c = groups * (out_per_group_c + pad_oc)
+
+        # Pad batch dimension (in_n) when small. AABS may shrink BLOCK_NI_HO_WO
+        # based on in_n, causing the dot M dimension to fall below what the
+        # pipeline pass can handle (especially with float32).
+        fwd_in_n = in_n
+        if fwd_in_n < _MIN_DOT_K:
+            pad_n = _MIN_DOT_K - fwd_in_n
+            input = torch.nn.functional.pad(input, (0, 0, 0, 0, 0, 0, 0, pad_n))
+            fwd_in_n = fwd_in_n + pad_n
+
+        out_height = conv2d_output_size(
+            input_height, weight_height, stride_height, padding_height, dilation_height
+        )
+        out_width = conv2d_output_size(
+            input_width, weight_width, stride_width, padding_width, dilation_width
+        )
+
+        output_dtype = input.dtype
+        output = torch.empty(
+            (fwd_in_n, fwd_out_c, out_height, out_width),
+            device=input.device,
+            dtype=output_dtype,
+        )
+
+        # BLOCK_NI_HO_WO along the in_n, out_height, and out_width dimensions,
+        # BLOCK_CO along the out_c,
+        # one group per cat
+        grid = lambda META: (
+            triton.cdiv(fwd_in_n * out_height * out_width, META["BLOCK_NI_HO_WO"]),
+            triton.cdiv(int(fwd_out_c // groups), META["BLOCK_CO"]),
+            groups,
+        )
+
+        if bias is None:
+            bias_pointer = torch.zeros(fwd_out_c, device=input.device, dtype=output_dtype)
+        else:
+            # Pad bias if out_c was padded
+            if fwd_out_c != out_c:
+                bias_pointer = torch.nn.functional.pad(bias, (0, fwd_out_c - out_c))
+            else:
+                bias_pointer = bias
+        conv2d_forward_kernel[grid](
+            input,
+            weight,
+            output,
+            bias_pointer,
+            fwd_in_n,
+            input_height,
+            input_width,
+            fwd_out_c,
+            out_height,
+            out_width,
+            *input.stride(),
+            *weight.stride(),
+            *output.stride(),
+            weight_c,
+            weight_height,
+            weight_width,
+            stride_height,
+            stride_width,
+            padding_height,
+            padding_width,
+            dilation_height,
+            dilation_width,
+            groups=groups,
+        )
+
+        # Slice output back to original dimensions if padded
+        if fwd_in_n != in_n or fwd_out_c != out_c:
+            output = output[:in_n, :out_c, :, :].contiguous()
+
+        # Save ORIGINAL (unpadded) tensors for backward
+        ctx.save_for_backward(orig_weight, orig_input, bias)
+
+        ctx.stride = (stride_height, stride_width)
+        ctx.padding = (padding_height, padding_width)
+        ctx.dilation = (dilation_height, dilation_width)
+
+        ctx.weight_info = (
+            int(out_c / groups),
+            orig_weight_c,
+            weight_height,
+            weight_width,
+        )
+        ctx.input_info = (in_n, input_height, input_width)
+        ctx.out_info = (out_height, out_width)
+
+        ctx.device = input.device
+        ctx.groups = groups
+
+        return output
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        logger.debug("GEMS CONV2D VJP")
+        weight, input, bias = ctx.saved_tensors
+        # (out_c equals origin cout divide groups)
+        out_c, weight_c, weight_height, weight_width = ctx.weight_info
+        in_n, input_height, input_width = ctx.input_info
+        out_height, out_width = ctx.out_info
+
+        device = ctx.device
+        groups = ctx.groups
+
+        stride_height, stride_width = ctx.stride
+        dilation_height, dilation_width = ctx.dilation
+        padding_height, padding_width = ctx.padding
+
+        revert_padding_height = dilation_height * (weight_height - 1) - padding_height
+        revert_padding_width = dilation_width * (weight_width - 1) - padding_width
+        revert_weight = weight.clone()
+        revert_weight = torch.flip(revert_weight, dims=[2, 3]).contiguous()
+
+        if groups != 1:
+            revert_weight = revert_weight.reshape(
+                groups, out_c, weight_c, weight_height, weight_width
+            )
+            revert_weight = revert_weight.transpose(1, 2)
+            revert_weight = revert_weight.reshape(
+                groups * weight_c, out_c, weight_height, weight_width
+            ).contiguous()
+        else:
+            revert_weight = revert_weight.transpose(0, 1).contiguous()
+
+        new_out_height = out_grad.shape[2] + (stride_height - 1) * (
+            out_grad.shape[2] - 1
+        )
+        new_out_width = out_grad.shape[3] + (stride_width - 1) * (out_grad.shape[3] - 1)
+
+        new_out = torch.zeros(
+            out_grad.shape[0],
+            out_grad.shape[1],
+            new_out_height,
+            new_out_width,
+            device=device,
+            dtype=out_grad.dtype,
+        )
+
+        # copy out_grad to new_out
+        if stride_height > 1 or stride_width > 1:
+            for i in range(out_grad.shape[2]):
+                for j in range(out_grad.shape[3]):
+                    new_out[:, :, i * (stride_height), j * (stride_width)] = out_grad[
+                        :, :, i, j
+                    ]
+        else:
+            new_out = out_grad
+
+        # Backward input gradient: reuse conv2d_forward_kernel with transposed weight.
+        # The kernel's out_c param = groups * weight_c, and K dim = out_c (per group).
+        # Iluvatar compiler requires dot dimensions >= 16. Pad both K dim (bwd_weight_c)
+        # and M dim (bwd_out_c, i.e. weight_c per group) when they are too small.
+        _MIN_DOT_K = 16
+        bwd_weight_c = out_c  # becomes kernel's weight_c constexpr (K dim of dot)
+        bwd_out_c = weight_c  # becomes kernel's out_c param (M dim of dot per group)
+
+        # Pad K dimension (out_c per group in revert_weight dim=1, new_out channel)
+        if bwd_weight_c < _MIN_DOT_K:
+            pad_k = _MIN_DOT_K - bwd_weight_c
+            # revert_weight shape: [groups*weight_c, out_c, kH, kW] -> pad dim=1
+            revert_weight = torch.nn.functional.pad(
+                revert_weight, (0, 0, 0, 0, 0, pad_k)
+            )
+            # new_out shape: [N, groups*out_c, H, W] -> pad each group's channels
+            if groups == 1:
+                new_out = torch.nn.functional.pad(new_out, (0, 0, 0, 0, 0, pad_k))
+            else:
+                N_bwd, C_bwd, H_bwd, W_bwd = new_out.shape
+                new_out = new_out.reshape(N_bwd, groups, out_c, H_bwd, W_bwd)
+                new_out = torch.nn.functional.pad(new_out, (0, 0, 0, 0, 0, pad_k))
+                new_out = new_out.reshape(
+                    N_bwd, groups * (out_c + pad_k), H_bwd, W_bwd
+                )
+            bwd_weight_c = bwd_weight_c + pad_k
+
+        # Pad M dimension (weight_c per group as kernel's out_per_group_c)
+        if bwd_out_c < _MIN_DOT_K:
+            pad_m = _MIN_DOT_K - bwd_out_c
+            # revert_weight shape: [groups*weight_c, bwd_weight_c, kH, kW] -> pad dim=0
+            # Each group has weight_c output channels; pad each group to _MIN_DOT_K
+            if groups == 1:
+                revert_weight = torch.nn.functional.pad(
+                    revert_weight, (0, 0, 0, 0, 0, 0, 0, pad_m)
+                )
+            else:
+                rw_co, rw_ci, rw_kh, rw_kw = revert_weight.shape
+                revert_weight = revert_weight.reshape(
+                    groups, bwd_out_c, rw_ci, rw_kh, rw_kw
+                )
+                revert_weight = torch.nn.functional.pad(
+                    revert_weight, (0, 0, 0, 0, 0, 0, 0, pad_m)
+                )
+                revert_weight = revert_weight.reshape(
+                    groups * (bwd_out_c + pad_m), rw_ci, rw_kh, rw_kw
+                )
+            bwd_out_c = bwd_out_c + pad_m
+
+        bwd_fwd_in_n = in_n
+        bwd_fwd_new_out = new_out
+        # Pad batch dimension for the forward kernel used in backward input grad.
+        # The iluvatar compiler's pipeline pass may fail when in_n is small and
+        # specialized, especially with float32.
+        if bwd_fwd_in_n < _MIN_DOT_K:
+            pad_n = _MIN_DOT_K - bwd_fwd_in_n
+            bwd_fwd_new_out = torch.nn.functional.pad(
+                new_out, (0, 0, 0, 0, 0, 0, 0, pad_n)
+            )
+            bwd_fwd_in_n = bwd_fwd_in_n + pad_n
+
+        input_back = torch.zeros(
+            bwd_fwd_in_n,
+            bwd_out_c * groups,
+            input_height,
+            input_width,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        grid = lambda META: (
+            triton.cdiv(
+                bwd_fwd_in_n * input_height * input_width, META["BLOCK_NI_HO_WO"]
+            ),
+            triton.cdiv(int(bwd_out_c), META["BLOCK_CO"]),
+            groups,
+        )
+        bias_zero = torch.zeros(
+            groups * bwd_out_c, device=device, dtype=out_grad.dtype
+        )
+
+        conv2d_forward_kernel[grid](
+            bwd_fwd_new_out,
+            revert_weight,
+            input_back,
+            bias_zero,
+            bwd_fwd_in_n,
+            new_out_height,
+            new_out_width,
+            groups * bwd_out_c,
+            input_height,
+            input_width,
+            *bwd_fwd_new_out.stride(),
+            *revert_weight.stride(),
+            *input_back.stride(),
+            bwd_weight_c,
+            weight_height,
+            weight_width,
+            1,
+            1,
+            revert_padding_height,
+            revert_padding_width,
+            dilation_height,
+            dilation_width,
+            groups=groups,
+        )
+
+        # Slice batch dimension back to original in_n if padded
+        if bwd_fwd_in_n != in_n:
+            input_back = input_back[:in_n, :, :, :].contiguous()
+
+        # Slice back to original weight_c channels if we padded M dimension
+        if bwd_out_c != weight_c:
+            if groups == 1:
+                input_back = input_back[:, :weight_c, :, :].contiguous()
+            else:
+                input_back = input_back.reshape(
+                    in_n, groups, bwd_out_c, input_height, input_width
+                )
+                input_back = input_back[:, :, :weight_c, :, :].contiguous()
+                input_back = input_back.reshape(
+                    in_n, groups * weight_c, input_height, input_width
+                )
+
+        # Backward weight kernel: tl.dot(curr_input, curr_out_grad) with shapes
+        # (BLOCK_CI_HK_WK, BLOCK_NO) x (BLOCK_NO, BLOCK_CO).
+        # BLOCK_CI_HK_WK tiles over weight_c * weight_height * weight_width.
+        # Iluvatar compiler requires dot K dim >= 16. The K dim here is BLOCK_NO
+        # which tiles over in_n. When in_n is specialized to < 16, the compiler
+        # may reduce the effective K dim causing "K >= 16" errors.
+        # Also pad weight_c and out_c to avoid layout issues.
+        bwd_wt_weight_c = weight_c
+        bwd_wt_out_c = out_c
+        bwd_wt_in_n = in_n
+        bwd_wt_input = input
+        bwd_wt_out_grad = out_grad
+
+        # Pad batch dimension (N) so in_n >= _MIN_DOT_K for K dim of dot
+        if bwd_wt_in_n < _MIN_DOT_K:
+            pad_n = _MIN_DOT_K - bwd_wt_in_n
+            bwd_wt_input = torch.nn.functional.pad(
+                input, (0, 0, 0, 0, 0, 0, 0, pad_n)
+            )
+            bwd_wt_out_grad = torch.nn.functional.pad(
+                out_grad, (0, 0, 0, 0, 0, 0, 0, pad_n)
+            )
+            bwd_wt_in_n = bwd_wt_in_n + pad_n
+
+        if bwd_wt_weight_c < _MIN_DOT_K:
+            pad_wc = _MIN_DOT_K - bwd_wt_weight_c
+            # Pad input channel dim: (N, groups*weight_c, H, W)
+            if groups == 1:
+                bwd_wt_input = torch.nn.functional.pad(
+                    bwd_wt_input, (0, 0, 0, 0, 0, pad_wc)
+                )
+            else:
+                N_i, C_i, H_i, W_i = bwd_wt_input.shape
+                bwd_wt_input = bwd_wt_input.reshape(N_i, groups, weight_c, H_i, W_i)
+                bwd_wt_input = torch.nn.functional.pad(
+                    bwd_wt_input, (0, 0, 0, 0, 0, pad_wc)
+                )
+                bwd_wt_input = bwd_wt_input.reshape(
+                    N_i, groups * (bwd_wt_weight_c + pad_wc), H_i, W_i
+                )
+            bwd_wt_weight_c = bwd_wt_weight_c + pad_wc
+
+        if bwd_wt_out_c < _MIN_DOT_K:
+            pad_oc = _MIN_DOT_K - bwd_wt_out_c
+            # Pad out_grad channel dim: (N, groups*out_c, H, W)
+            if groups == 1:
+                bwd_wt_out_grad = torch.nn.functional.pad(
+                    bwd_wt_out_grad, (0, 0, 0, 0, 0, pad_oc)
+                )
+            else:
+                N_o, C_o, H_o, W_o = bwd_wt_out_grad.shape
+                bwd_wt_out_grad = bwd_wt_out_grad.reshape(N_o, groups, out_c, H_o, W_o)
+                bwd_wt_out_grad = torch.nn.functional.pad(
+                    bwd_wt_out_grad, (0, 0, 0, 0, 0, pad_oc)
+                )
+                bwd_wt_out_grad = bwd_wt_out_grad.reshape(
+                    N_o, groups * (bwd_wt_out_c + pad_oc), H_o, W_o
+                )
+            bwd_wt_out_c = bwd_wt_out_c + pad_oc
+
+        weight_back = torch.zeros(
+            bwd_wt_out_c * groups,
+            bwd_wt_weight_c,
+            weight_height,
+            weight_width,
+            dtype=weight.dtype,
+            device=device,
+        )
+
+        grid_weight = lambda meta: (
+            triton.cdiv(
+                bwd_wt_weight_c * weight_height * weight_width, meta["BLOCK_CI_HK_WK"]
+            ),
+            groups,
+            triton.cdiv(bwd_wt_out_c, meta["BLOCK_CO"]),
+        )
+        conv2d_backward_kernel_weight[grid_weight](
+            bwd_wt_input,
+            bwd_wt_out_grad,
+            weight_back,
+            *bwd_wt_input.stride(),
+            *weight_back.stride(),
+            *bwd_wt_out_grad.stride(),
+            input_height,
+            input_width,
+            weight_height,
+            weight_width,
+            bwd_wt_weight_c,
+            bwd_wt_in_n,
+            stride_height,
+            stride_width,
+            out_height,
+            out_width,
+            bwd_wt_out_c,
+            padding_height,
+            padding_width,
+            dilation_height,
+            dilation_width,
+        )
+
+        # Slice weight_back back to original dimensions if padded
+        if bwd_wt_out_c != out_c or bwd_wt_weight_c != weight_c:
+            weight_back = weight_back[: out_c * groups, :weight_c, :, :].contiguous()
+        if bias is not None:
+            bias_grad = out_grad.sum(dim=(0, 2, 3))
+        else:
+            bias_grad = None
+        return (
+            input_back,
+            weight_back,
+            bias_grad,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+# todo test SymInt[2] of stride or padding
+def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    if isinstance(padding, str):
+        if padding == "same":
+            assert stride == 1, "Doesn't support any stride values other than 1 \
+                in padding = 'same' mode, received stride value {stride}"
+            ih = input.shape[-2]
+            iw = input.shape[-1]
+            kernel_size_h = weight.shape[-2]
+            kernel_size_w = weight.shape[-1]
+            padding_h = int(
+                math.ceil(
+                    (stride * (ih - 1) + 1 + dilation * (kernel_size_h - 1) - ih) / 2
+                )
+            )
+            padding_w = int(
+                math.ceil(
+                    (stride * (iw - 1) + 1 + dilation * (kernel_size_w - 1) - iw) / 2
+                )
+            )
+            oh = int(
+                (ih + 2 * padding_h - dilation * (kernel_size_h - 1) - 1) / stride + 1
+            )
+            ow = int(
+                (iw + 2 * padding_w - dilation * (kernel_size_w - 1) - 1) / stride + 1
+            )
+            # Use per-dimension padding so asymmetric kernels (kh != kw) pad each
+            # spatial axis independently; the trailing slice trims the extra pad
+            # that ceil() introduces on the bottom/right, matching torch's "same".
+            padding = (padding_h, padding_w)
+            return Conv2d.apply(input, weight, bias, stride, padding, dilation, groups)[
+                ..., (oh - ih) :, (ow - iw) :
+            ]
+        elif padding == "valid":
+            return Conv2d.apply(input, weight, bias, stride, 0, dilation, groups)
+        else:
+            raise ValueError(
+                f"Unsupported padding string: {padding}, only'valild'/'same' are allowed."
+            )
+    else:
+        return Conv2d.apply(input, weight, bias, stride, padding, dilation, groups)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
conv2d:
Iluvatar Triton's AABS (Auto-Adjusted Block Size) mechanism automatically shrinks the block size based on runtime parameters. When in_n=2, AABS reduces BLOCK_NI_HO_WO from 16 to 2, causing the M dimension of tl.dot to become 2. This falls below the pipeline pass's minimum threshold (16) for float32 matrix multiplication, triggering a direct compiler error during PassManager::run.

bmm:
Small-dimension padding (_MIN_TRITON_DIM = 32)
When any matrix dimension (M, N, or K) is smaller than 32, Triton's tl.multiple_of / tl.max_contiguous hints become invalid, causing the Iluvatar compiler to crash or produce wrong results. We automatically pad inputs to the minimum tile size and slice the result back to the original shape.
Force EVEN_K=True (_MAX_BLOCK_K = 128)
The Iluvatar Triton compiler generates incorrect results in the EVEN_K=False code path (when K is not divisible by the block size). We pad K to a multiple of 128, ensuring EVEN_K=True regardless of which autotuner config is selected.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
