### PR TITLE
[XCoreSigma] Add swiglu op on ascend backend

### DIFF
--- a/benchmark/test_swiglu.py
+++ b/benchmark/test_swiglu.py
@@ -13,10 +13,19 @@
 # limitations under the License.
 
 import pytest
+import torch
 
 import flag_gems
 
 from . import base, consts
+
+try:
+    import torch_npu
+
+    NPU_SWIGLU = getattr(torch_npu, "npu_swiglu", None)
+except ImportError:
+    torch_npu = None
+    NPU_SWIGLU = None
 
 # Note: Importing transformer_engine (especially in some versions like py 3.10) may automatically
 # configure the Root Logger (adding handlers). This may cause subsequent `logging.basicConfig`
@@ -44,5 +53,59 @@ def test_swiglu():
         torch_op=TE_OP,
         gems_op=GEMS_OP,
         dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+# (M, H) of the 2D input; the kernel splits the last dim in half, H must be even.
+# Mirrors the accuracy cases in tests/test_swiglu.py.
+SWIGLU_SHAPES = [
+    (4, 32),
+    (256, 128),
+    (8192, 128),
+    (15000, 128),
+    (2560, 2048),
+    (15000, 2048),
+]
+
+
+def npu_swiglu_golden(
+    input_tensor: torch.Tensor, scalarValue: float = 1.0
+) -> torch.Tensor:
+    return torch_npu.npu_swiglu(input_tensor, dim=-1)
+
+
+def swiglu_input_fn(shape, dtype, device):
+    M, H = shape
+    input_tensor = torch.randn((M, H), dtype=dtype, device=device)
+    yield (input_tensor, 1.0)
+
+
+class SwigluBenchmark(base.GenericBenchmark):
+    """swiglu uses its own (M, H) configs instead of the generic shape list."""
+
+    def set_more_shapes(self):
+        return []
+
+    def get_input_iter(self, dtype):
+        for shape in SWIGLU_SHAPES:
+            yield from self.input_fn(shape, dtype, self.device)
+
+
+@pytest.mark.swiglu
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "ascend",
+    reason="swiglu is only specialized on the ascend backend",
+)
+@pytest.mark.skipif(
+    NPU_SWIGLU is None, reason="golden torch_npu.npu_swiglu is unavailable"
+)
+def test_swiglu_ascend():
+    bench = SwigluBenchmark(
+        op_name="swiglu",
+        input_fn=swiglu_input_fn,
+        torch_op=npu_swiglu_golden,
+        gems_op=flag_gems.swiglu,
+        dtypes=[torch.float16],
     )
     bench.run()

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -107,6 +107,7 @@ from .softmax import softmax, softmax_backward, softmax_backward_out, softmax_ou
 from .sort import sort
 from .sparse_sampled_addmm import sparse_sampled_addmm, sparse_sampled_addmm_out
 from .stack import stack
+from .swiglu import swiglu
 from .threshold import threshold, threshold_backward
 from .triu import triu
 from .unique import _unique2
@@ -249,6 +250,7 @@ __all__ = [
     "sparse_sampled_addmm",
     "sparse_sampled_addmm_out",
     "stack",
+    "swiglu",
     "threshold",
     "threshold_backward",
     "triu",

--- a/src/flag_gems/runtime/backend/_ascend/ops/swiglu.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/swiglu.py
@@ -1,0 +1,114 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import torch
+import triton
+import triton.experimental.tle as tle
+import triton.language as tl
+import triton.language.math as math
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def swiglu_kernel(
+    input_a_ptr,
+    input_b_ptr,
+    output_ptr,
+    M: tl.constexpr,
+    H: tl.constexpr,
+    input_stride_m,
+    output_stride_m,
+    beta: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    TILE_SIZE_M: tl.constexpr,
+    TILE_SIZE_H: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    m_start = pid_m * BLOCK_SIZE_M
+    for tile_m_idx in range(0, BLOCK_SIZE_M, TILE_SIZE_M):
+        m_idx = m_start + tile_m_idx
+        for tile_h_idx in range(0, H, TILE_SIZE_H):
+            offs_m = m_idx + tl.arange(0, TILE_SIZE_M)
+            offs_h = tile_h_idx + tl.arange(0, TILE_SIZE_H)
+            mask_m = offs_m < M
+            mask_h = offs_h < H
+            mask = mask_m[:, None] & mask_h[None, :]
+            input_offset = offs_m[:, None] * input_stride_m + offs_h[None, :]
+            x_a = tl.load(input_a_ptr + input_offset, mask=mask, other=0.0)
+            x_b = tl.load(input_b_ptr + input_offset, mask=mask, other=0.0)
+
+            tmp = x_a * x_b
+            sig = 1.0 / (1.0 + math.exp(-1 * x_a * beta))
+            out = tmp * sig.to(tl.float16)
+
+            output_offset = offs_m[:, None] * output_stride_m + offs_h[None, :]
+            out_buf = tle.dsa.to_buffer(out, space=tle.dsa.ascend.UB)
+            with tle.dsa.hint(inter_no_alias=True):
+                tle.dsa.copy(
+                    out_buf, output_ptr + output_offset, [TILE_SIZE_M, TILE_SIZE_H]
+                )
+
+
+def swiglu(input_tensor: torch.Tensor, scalarValue: float) -> torch.Tensor:
+    logger.debug("GEMS SWIGLU")
+    assert (
+        input_tensor.shape[-1] % 2 == 0
+    ), "The last dimension of the input tensor must be even."
+
+    shape = input_tensor.shape
+    H = shape[-1] // 2
+    M = input_tensor.numel() // (2 * H)
+    if len(input_tensor.shape) > 2:
+        input_2d = input_tensor.contiguous().view(-1, 2 * H)
+    else:
+        input_2d = input_tensor.contiguous()
+
+    input_a, input_b = torch.split(input_2d, H, dim=1)
+    output_2d = torch.empty(M, H, device=input_a.device, dtype=input_a.dtype)
+
+    def get_core_num():
+        try:
+            current_device = torch.npu.current_device()
+            torch.npu.set_device(current_device)
+            cores_dict = torch.npu.get_device_limit(current_device)
+            return cores_dict["vector_core_num"]
+        except (AttributeError, KeyError, TypeError):
+            return None
+
+    num_cores = 24 if get_core_num() is None else get_core_num()
+
+    TILE_SIZE_M = min(M, 32)
+    TILE_SIZE_H = min(H, 256)
+    if M * H < 256 * 64:
+        num_cores = 1
+    BLOCK_SIZE_M = int((M + num_cores - 1) // num_cores)
+    swiglu_kernel[(num_cores,)](
+        input_a,
+        input_b,
+        output_2d,
+        M,
+        H,
+        input_a.stride(0),
+        output_2d.stride(0),
+        beta=scalarValue,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        TILE_SIZE_M=TILE_SIZE_M,
+        TILE_SIZE_H=TILE_SIZE_H,
+        multibuffer=True,
+        limit_auto_multi_buffer_of_local_buffer="no-limit",
+    )
+    return output_2d

--- a/tests/test_swiglu.py
+++ b/tests/test_swiglu.py
@@ -18,6 +18,7 @@ import torch
 import flag_gems
 
 from . import accuracy_utils as utils
+from .conftest import QUICK_MODE
 
 try:
     from transformer_engine.pytorch import cpp_extensions as tex
@@ -25,6 +26,14 @@ try:
     TE_OP = getattr(tex, "swiglu", None)
 except ImportError:
     TE_OP = None
+
+try:
+    import torch_npu
+
+    NPU_SWIGLU = getattr(torch_npu, "npu_swiglu", None)
+except ImportError:
+    torch_npu = None
+    NPU_SWIGLU = None
 
 
 def generate_input(
@@ -63,3 +72,40 @@ def test_swiglu(shape: tuple[int, ...], dtype: torch.dtype):
         fg_forward = flag_gems.swiglu(input_tensor, quantizer=None)
 
     utils.gems_assert_close(fg_forward, te_forward, dtype)
+
+
+# (M, H) of the 2D input; the kernel splits the last dim in half, H must be even.
+if QUICK_MODE:
+    CASES = [(4, 32), (256, 128)]
+else:
+    CASES = [
+        (4, 32),
+        (256, 128),
+        (8192, 128),
+        (15000, 128),
+        (2560, 2048),
+        (15000, 2048),
+    ]
+
+
+@pytest.mark.swiglu
+@pytest.mark.parametrize("M,H", CASES)
+@pytest.mark.skipif(
+    flag_gems.vendor_name != "ascend",
+    reason="swiglu is only specialized on the ascend backend",
+)
+@pytest.mark.skipif(
+    NPU_SWIGLU is None, reason="golden torch_npu.npu_swiglu is unavailable"
+)
+def test_swiglu_ascend(M: int, H: int):
+    torch.manual_seed(20)
+    input_tensor = torch.empty(
+        (M, H), dtype=torch.float16, device=flag_gems.device
+    ).normal_(mean=0.0, std=0.5)
+
+    fg_forward = flag_gems.swiglu(input_tensor, 1.0)
+    npu_forward = torch_npu.npu_swiglu(input_tensor, dim=-1)
+
+    torch.testing.assert_close(
+        fg_forward, npu_forward, rtol=1e-3, atol=1e-3, equal_nan=True
+    )


### PR DESCRIPTION
精度测试通过；
性能测试数据：
Operator: swiglu  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail

SUCCESS               0.004586            0.002267               2.023          [torch.Size([4, 32]), 1.0]
SUCCESS               0.003613            0.005753               0.628          [torch.Size([256, 128]), 1.0]
SUCCESS               0.012172            0.007111               1.712          [torch.Size([8192, 128]), 1.0]
SUCCESS               0.012809            0.008499               1.507          [torch.Size([15000, 128]), 1.0]
SUCCESS               0.017289            0.012413               1.393          [torch.Size([2560, 2048]), 1.0]
SUCCESS               0.048735            0.039705               1.227          [torch.Size([15000, 2048]), 1.0]
