### PR TITLE
Fix automatic docs rebuild when docs changes are merged

### DIFF
--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -17,7 +17,7 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -37,5 +37,7 @@ jobs:
 
       - id: rebase
         run: |
-          git rebase master
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rebase origin/master
           git push -u origin gh-pages -f

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -35,9 +35,15 @@ jobs:
       pr_id: ${{ steps.get-pr-id.outputs.PR_ID }}
       labels: ${{ fromJSON(steps.get-labels.outputs.result) }}
       backend_matrix: ${{ steps.build-backend-matrix.outputs.matrix }}
+      docs_changed: ${{ steps.docs-changed.outputs.any_changed }}
     steps:
       - id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
+      - id: docs-changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
+        with:
+          files: |
+            docs/**
       - id: wait-for-triage
         uses: ArcticLampyrid/action-wait-for-workflow@ff297b23789206858260877c4b83026d90c6db8c  # v1.3.0
         with:
@@ -100,8 +106,8 @@ jobs:
 
   build-doc:
     needs: preprocess
-    if: (contains(needs.preprocess.outputs.labels, 'documentation') &&
-      github.event.pull_request.merged == true)
+    if: needs.preprocess.outputs.docs_changed == 'true' &&
+      (github.event_name == 'push' || github.event.pull_request.merged == true)
     uses: ./.github/workflows/sync-docs.yaml
 
   cpp-op:


### PR DESCRIPTION
Fixes #2278

## Summary

The docs site was never rebuilt automatically when `/docs` content
changed, because the `build-doc` job in `unittest.yaml` could never
trigger:

- its condition required `github.event.pull_request.merged == true`, but
  the workflow's `pull_request` trigger only listens to
  `opened/synchronize/reopened/labeled/unlabeled` (not `closed`), so the
  merged event never fired;
- on `push` events (which is what a merge actually produces),
  `github.event.pull_request` is `null`, so the condition was false.

The `gh-pages` branch was therefore never rebased onto `master`, and
docs changes were not published.

## Changes

- `unittest.yaml`: the `preprocess` job now detects whether any file
  under `docs/` changed (via `tj-actions/changed-files` with
  `files: docs/**`) and exposes a `docs_changed` output. The `build-doc`
  job now runs `sync-docs` whenever docs changed **and** the change was
  merged (`push` to `master`, or a merged pull request), instead of
  relying on the `documentation` label + a condition that never fired.
- `sync-docs.yaml`: fixed the rebase step so it can actually complete
  when triggered:
  - bumped `permissions` to `contents: write` (the job force-pushes the
    `gh-pages` branch);
  - rebase against `origin/master` instead of `master`, because the
    checkout of `gh-pages` only creates a local `gh-pages` branch;
  - configure a git identity so the rebase can create commits.

## Resulting flow

1. A PR touching `docs/` is merged to `master`.
2. The `push` to `master` runs `unittest.yaml`; `preprocess` sees
   `docs_changed == 'true'`.
3. `build-doc` calls `sync-docs`, which rebases `gh-pages` onto
   `origin/master` and force-pushes it.
4. The `gh-pages` push triggers the existing `hugo-site` workflow, which
   rebuilds and deploys the site.

## Verification

- Both workflow files parse as valid YAML.
- `preprocess` exposes `docs_changed` from a `docs/**` change detection
  step; the `build-doc` job condition reads that output.
- Note: the rebase replays gh-pages-only commits (coverage/benchmark
  data) on top of `master`; if that ever hits a conflict it fails
  loudly in CI rather than silently skipping the sync.
