### PR TITLE
[KMCompiler] fix linalg_vecdot: exclude fp64 benchmark for iluvatar and ascend platforms

### DIFF
--- a/benchmark/test_linalg_vecdot.py
+++ b/benchmark/test_linalg_vecdot.py
@@ -5,6 +5,12 @@ import flag_gems
 
 from . import base
 
+VECDOT_DTYPES = (
+    [torch.float32]
+    if flag_gems.vendor_name in ["iluvatar", "ascend"]
+    else [torch.float32, torch.float64]
+)
+
 VECDOT_SHAPES = [
     (10,),
     (100,),
@@ -44,7 +50,7 @@ def test_linalg_vecdot_benchmark():
     bench = VecdotBenchmark(
         op_name="linalg_vecdot",
         torch_op=torch.linalg.vecdot,
-        dtypes=[torch.float32, torch.float64],
+        dtypes=VECDOT_DTYPES,
     )
     bench.gems_op = flag_gems.linalg_vecdot
     bench.run()
@@ -55,7 +61,7 @@ def test_linalg_vecdot_out_benchmark():
     bench = VecdotBenchmark(
         op_name="linalg_vecdot_out",
         torch_op=torch.linalg.vecdot,
-        dtypes=[torch.float32, torch.float64],
+        dtypes=VECDOT_DTYPES,
     )
     bench.gems_op = flag_gems.linalg_vecdot_out
     bench.run()


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
On Ascend and Iluvatar backends, linalg_vecdot cannot handle float64 inputs. Exclude float64 from benchmark dtypes for Iluvatar and Ascend platforms.
### Issue


### Progress


### Performance

