### PR TITLE
[MTHREADS] optimize baddbmm with SQMMA

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -203,7 +203,7 @@ __all__ = [
 
 if get_device_capability(current_device())[0] >= 3:
     from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
-    from .baddbmm import baddbmm  # noqa: F401
+    from .baddbmm import baddbmm, baddbmm_out  # noqa: F401
     from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
     from .mm import mm  # noqa: F401
@@ -216,6 +216,7 @@ if get_device_capability(current_device())[0] >= 3:
             "addmm_dtype_out",
             "addmm_out",
             "baddbmm",
+            "baddbmm_out",
             "bmm",
             "gelu",
             "mm",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/baddbmm.py
@@ -20,7 +20,7 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
-from flag_gems.ops.add import add
+from flag_gems.ops.add import add, add_func
 from flag_gems.ops.mul import mul
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
@@ -292,7 +292,11 @@ def baddbmm_out(bias, A, B, *, beta=1.0, alpha=1.0, out):
         out.shape == (batch, M, N) and out.dtype == A.dtype
     ), "Incompatible output shape or dtype for baddbmm.out"
     if _use_sqmma(A, B, N, K):
-        return out.copy_(_baddbmm_sqmma(bias, A, B, beta, alpha))
+        A, B = A.contiguous(), B.contiguous()
+        product = bmm_sqmma(A, B, A.dtype, batch, M, N, K)
+        scaled = mul(product, alpha)
+        add_func(scaled, torch.broadcast_to(bias, (batch, M, N)), beta, out0=out)
+        return out
     _baddbmm_launch(
         bias.contiguous(),
         A.contiguous(),

--- a/src/flag_gems/runtime/backend/_mthreads/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/baddbmm.py
@@ -20,12 +20,13 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
+from flag_gems.ops.add import add
 from flag_gems.ops.mul import mul
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
 
-from .bmm import bmm
+from .bmm import bmm, bmm_sqmma, is_sqmma_compatible
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ def _baddbmm_launch(bias, A, B, beta, alpha, out):
     _, _, N = B.shape
     A = A.contiguous()
     B = B.contiguous()
-    bbias = torch.broadcast_to(bias, (batch, M, N)).contiguous()
+    bbias = torch.broadcast_to(bias, (batch, M, N))
     bias_batch_stride = bbias.stride(0)
     bias_M_stride = bbias.stride(1)
     bias_N_stride = bbias.stride(-1)
@@ -188,6 +189,26 @@ def _baddbmm_launch(bias, A, B, beta, alpha, out):
         )
 
 
+def _baddbmm_sqmma(bias, A, B, beta, alpha):
+    batch, M, K = A.shape
+    A, B = A.contiguous(), B.contiguous()
+    product = bmm_sqmma(A, B, A.dtype, batch, M, B.shape[2], K)
+    return add(
+        mul(product, alpha), mul(torch.broadcast_to(bias, (batch, M, B.shape[2])), beta)
+    )
+
+
+# sqmma has a fixed launch/memory floor; measured crossover on MTT S5000 is ~3.2 GFLOPs.
+_SQMMA_MIN_FLOPS = 3.2e9
+
+
+def _use_sqmma(A, B, N, K):
+    return (
+        is_sqmma_compatible(A, B, N, K)
+        and A.shape[0] * A.shape[1] * N * K * 2 >= _SQMMA_MIN_FLOPS
+    )
+
+
 class BaddbmmFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, bias, A, B, beta, alpha):
@@ -199,6 +220,8 @@ class BaddbmmFunction(torch.autograd.Function):
 
         batch, M, K = A.shape
         _, _, N = B.shape
+        if _use_sqmma(A, B, N, K):
+            return _baddbmm_sqmma(bias, A, B, beta, alpha)
         out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)
         _baddbmm_launch(bias, A, B, beta, alpha, out)
         return out
@@ -268,6 +291,8 @@ def baddbmm_out(bias, A, B, *, beta=1.0, alpha=1.0, out):
     assert (
         out.shape == (batch, M, N) and out.dtype == A.dtype
     ), "Incompatible output shape or dtype for baddbmm.out"
+    if _use_sqmma(A, B, N, K):
+        return out.copy_(_baddbmm_sqmma(bias, A, B, beta, alpha))
     _baddbmm_launch(
         bias.contiguous(),
         A.contiguous(),


### PR DESCRIPTION
### Description

Add a MTHREADS baddbmm override that routes fp16/bfloat16 compatible layouts through a TensorDescriptor SQMMA batched matmul, then applies alpha/beta scaling and bias via pointwise mul/add. The dispatch uses a workload-size threshold (batch\*M\*N\*K\*2 >= 3.2 GFLOPs, measured crossover on MTT S5000) because SQMMA has a fixed launch floor and only wins on large workloads; below the crossover the FMA kernel is faster, which would otherwise regress small shapes like [2,384,384].

The FMA fallback remains for fp32 and non-SQMMA fp16/bfloat16 shapes, and no longer materializes the broadcast bias before launch.

### Performence

#### 1. fp16
| Status | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | TFLOPS | Size Detail | 
|---|---|---|---|---|---|
| SUCCESS | 0.023120 | 0.019120 | 1.209 | 11.861 | [torch.Size([2, 384, 384]), torch.Size([2, 384, 384]), torch.Size([2, 384, 384])] |
| SUCCESS | 0.814200 | 1.886040 | 0.432 | 145.761 | [torch.Size([2, 4096, 4096]), torch.Size([2, 4096, 4096]), torch.Size([2, 4096, 4096])] |
| SUCCESS | 0.190480 | 0.417340 | 0.456 | 82.371 | [torch.Size([16, 1024, 1024]), torch.Size([16, 1024, 1024]), torch.Size([16, 1024, 1024])] |
| SUCCESS | 0.974360 | 2.300760 | 0.423 | 119.502 | [torch.Size([16, 2048, 2048]), torch.Size([16, 2048, 2048]), torch.Size([16, 2048, 2048])] |
| SUCCESS | 6.626760 | 14.871300 | 0.446 | 147.888 | [torch.Size([16, 4096, 4096]), torch.Size([16, 4096, 4096]), torch.Size([16, 4096, 4096])] |

#### 2. bf16
| Status | Torch Latency (ms) | Gems Latency (ms) | Gems Speedup | TFLOPS | Size Detail |
|---|---|---|---|---|---|
| SUCCESS | 0.017920 | 0.019160 | 0.935 | 11.837 | [torch.Size([2, 384, 384]), torch.Size([2, 384, 384]), torch.Size([2, 384, 384])] |
| SUCCESS | 0.811860 | 1.934280 | 0.420 | 142.126 | [torch.Size([2, 4096, 4096]), torch.Size([2, 4096, 4096]), torch.Size([2, 4096, 4096])] |
| SUCCESS | 0.185380 | 0.437100 | 0.424 | 78.647 | [torch.Size([16, 1024, 1024]), torch.Size([16, 1024, 1024]), torch.Size([16, 1024, 1024])] |
| SUCCESS | 0.960600 | 2.402140 | 0.400 | 114.458 | [torch.Size([16, 2048, 2048]), torch.Size([16, 2048, 2048]), torch.Size([16, 2048, 2048])] |
| SUCCESS | 6.507640 | 15.477200 | 0.420 | 142.099 | [torch.Size([16, 4096, 4096]), torch.Size([16, 4096, 4096]), torch.Size([16, 4096, 4096])] |

Key improvements (Gems latency, before -> after):

- fp16 16x4096x4096: 73.825 ms -> 14.871 ms (~4.96x)
- fp16 16x2048x2048: 9.290 ms -> 2.301 ms (~4.04x)
- fp16 16x1024x1024: 1.184 ms -> 0.417 ms (~2.84x)
- fp16 2x4096x4096: 9.267 ms -> 1.886 ms (~4.91x)
- bf16 16x4096x4096: 73.829 ms -> 15.477 ms (~4.77x)
- bf16 16x2048x2048: 9.290 ms -> 2.402 ms (~3.87x)
- bf16 16x1024x1024: 1.184 ms -> 0.437 ms (~2.71x)
- bf16 2x4096x4096: 9.268 ms -> 1.934 ms (~4.79x)
