### PR TITLE
[KMCompiler][Ascend][Thead][Hygon][Metax][iluvatar]Add unsafe_index_put with triton

### DIFF
--- a/benchmark/test_unsafe_index_put.py
+++ b/benchmark/test_unsafe_index_put.py
@@ -1,0 +1,188 @@
+import numpy as np
+import pytest
+import torch
+
+import flag_gems
+
+from . import base
+
+# Comprehensive shapes covering all usage patterns
+# Format: (input_shape, [index_shapes], values_shape, accumulate)
+_SHAPES_ACC_FALSE = (
+    # --- 1D input with 1 index ---
+    ((256,), ((64,),), (64,), False),
+    ((4096,), ((1024,),), (1024,), False),
+    ((2**28,), ((2**16,),), (2**16,), False),
+    # --- 2D input, 1 index ---
+    ((32, 32), ((2, 8),), (32,), False),
+    # Replace=False: index elements must be ≤ input dim size
+    # so max index elements = input_shape[i]
+    ((256, 256), ((16, 16),), (256,), False),  # 256 ≤ 256
+    ((1024, 1024), ((64,),), (1024,), False),
+    ((1024, 1024), ((4, 64),), (1024,), False),
+    ((4096, 4096), ((256,),), (4096,), False),
+    # --- 2D input, 2 indices ---
+    ((32, 32), ((8,), (8,)), (8,), False),
+    ((32, 32), ((8,), (2, 8)), (8,), False),
+    ((1024, 1024), ((64,), (64,)), (64,), False),
+    ((1024, 1024), ((64,), (4, 64)), (64,), False),
+    ((4096, 4096), ((256,), (256,)), (256,), False),
+    # --- 3D input (various index configs) ---
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), False),
+    ((512, 512, 512), ((128,), (128,), (128,)), (128,), False),
+    ((512, 512, 512), ((2, 128), (128,), (128,)), (128,), False),
+    ((512, 512, 512), ((2, 128),), (512,), False),
+    ((256, 256, 256), ((64,), (64,), (64,)), (64,), False),
+    # --- 4D input ---
+    ((64, 64, 64, 64), ((8, 8), (8, 8), (8, 8), (8, 8)), (8, 8), False),
+)
+
+_SHAPES_ACC_TRUE = (
+    # 1D input, 1 index, no suffix
+    ((100,), ((100,),), (100,), True),
+    ((10000,), ((10000,),), (10000,), True),
+    # 2D input, 2 indices (both dims indexed), no suffix
+    # values_shape = broadcast_index_shape
+    ((32, 32), ((8,), (8,)), (8,), True),
+    ((512, 512), ((512,), (512,)), (512,), True),
+    ((1024, 1024), ((1024,), (1024,)), (1024,), True),
+    # 3D input, 3 indices, no suffix
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), True),
+    ((512, 512, 512), ((128,), (128,), (128,)), (128,), True),
+    ((512, 512, 512), ((2, 128), (2, 128), (2, 128)), (2, 128), True),
+)
+
+
+def _gen_indices(input_shape, indices_shapes, accumulate):
+    """Generate index tensors for benchmarking."""
+    indices = []
+    for i, shape in enumerate(indices_shapes):
+        index = np.random.choice(
+            np.arange(input_shape[i]), size=shape, replace=accumulate
+        )
+        indices.append(torch.tensor(index, device=flag_gems.device))
+    return indices
+
+
+def _is_float_dtype(dtype):
+    return dtype in (torch.float32, torch.float64, torch.float16, torch.bfloat16)
+
+
+def _make_tensor(shape, dtype, device):
+    if dtype == torch.bool:
+        return torch.randint(0, 2, shape, device=device).to(torch.bool)
+    elif _is_float_dtype(dtype):
+        return torch.randn(shape, dtype=dtype, device=device)
+    else:
+        return torch.randint(1, 10, shape, device=device).to(dtype)
+
+
+def unsafe_index_put_input_fn(shapes, dtype, device):
+    """Input generator for _unsafe_index_put benchmark."""
+    input_shape, indices_shapes, values_shape, accumulate = shapes
+    inp = _make_tensor(input_shape, dtype, device)
+    indices = _gen_indices(input_shape, indices_shapes, accumulate)
+    values = _make_tensor(values_shape, dtype, device)
+    yield inp, indices, values, accumulate
+
+
+class UnsafeIndexPutBenchmark(base.Benchmark):
+    """Dedicated benchmark for _unsafe_index_put with 4-tuple shapes."""
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            yield from unsafe_index_put_input_fn(shape, cur_dtype, self.device)
+
+    def get_gbps(self, args, latency):
+        """Compute GB/s: input + output + values + indices."""
+        inp = args[0]
+        indices = args[1]
+        values = args[2]
+        io_amount = sum(
+            flag_gems.utils.shape_utils.size_in_bytes(t)
+            for t in [inp, inp]  # read + write
+        )
+        io_amount += flag_gems.utils.shape_utils.size_in_bytes(values)
+        for idx in indices:
+            io_amount += flag_gems.utils.shape_utils.size_in_bytes(idx)
+        return io_amount * 1e-9 / (latency * 1e-3)
+
+    def set_shapes(self, shape_file_path=None):
+        """Override to use only our shapes, not DEFAULT_SHAPES."""
+        # Skip the default shape loading; call set_more_shapes directly
+        if hasattr(self, "set_more_shapes") and callable(
+            getattr(self, "set_more_shapes")
+        ):
+            self.shapes = list(self.set_more_shapes() or [])
+        if not self.shapes:
+            self.shapes = base.Benchmark.DEFAULT_SHAPES
+
+
+class UnsafeIndexPutAccFalseBenchmark(UnsafeIndexPutBenchmark):
+    def set_more_shapes(self):
+        return list(_SHAPES_ACC_FALSE)
+
+
+class UnsafeIndexPutAccTrueBenchmark(UnsafeIndexPutBenchmark):
+    def set_more_shapes(self):
+        return list(_SHAPES_ACC_TRUE)
+
+
+BENCH_FLOAT_DTYPES = [torch.float16, torch.float32, torch.float64, torch.bfloat16]
+BENCH_INT_DTYPES = [torch.int32, torch.int64]
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_false_floats():
+    bench = UnsafeIndexPutAccFalseBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_false_ints():
+    bench = UnsafeIndexPutAccFalseBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_INT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_true_floats():
+    bench = UnsafeIndexPutAccTrueBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_true_ints():
+    bench = UnsafeIndexPutAccTrueBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_INT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_unsafe_index_put.py
+++ b/benchmark/test_unsafe_index_put.py
@@ -133,9 +133,6 @@ BENCH_INT_DTYPES = [torch.int32, torch.int64]
 
 
 @pytest.mark.unsafe_index_put
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
-)
 def test_unsafe_index_put_acc_false_floats():
     bench = UnsafeIndexPutAccFalseBenchmark(
         op_name="_unsafe_index_put",
@@ -147,9 +144,6 @@ def test_unsafe_index_put_acc_false_floats():
 
 
 @pytest.mark.unsafe_index_put
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
-)
 def test_unsafe_index_put_acc_false_ints():
     bench = UnsafeIndexPutAccFalseBenchmark(
         op_name="_unsafe_index_put",
@@ -161,9 +155,6 @@ def test_unsafe_index_put_acc_false_ints():
 
 
 @pytest.mark.unsafe_index_put
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
-)
 def test_unsafe_index_put_acc_true_floats():
     bench = UnsafeIndexPutAccTrueBenchmark(
         op_name="_unsafe_index_put",
@@ -175,9 +166,6 @@ def test_unsafe_index_put_acc_true_floats():
 
 
 @pytest.mark.unsafe_index_put
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
-)
 def test_unsafe_index_put_acc_true_ints():
     bench = UnsafeIndexPutAccTrueBenchmark(
         op_name="_unsafe_index_put",

--- a/benchmark/test_unsafe_index_put.py
+++ b/benchmark/test_unsafe_index_put.py
@@ -129,6 +129,9 @@ class UnsafeIndexPutAccTrueBenchmark(UnsafeIndexPutBenchmark):
 
 
 BENCH_FLOAT_DTYPES = [torch.float16, torch.float32, torch.float64, torch.bfloat16]
+if not flag_gems.runtime.device.support_fp64:
+    # The Ascend Triton backend has no fp64 support (fp64_enabled=False).
+    BENCH_FLOAT_DTYPES = [d for d in BENCH_FLOAT_DTYPES if d != torch.float64]
 BENCH_INT_DTYPES = [torch.int32, torch.int64]
 
 
@@ -155,6 +158,10 @@ def test_unsafe_index_put_acc_false_ints():
 
 
 @pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "iluvatar" and torch.float64 in BENCH_FLOAT_DTYPES,
+    reason="skip when vendor is iluvatar and dtypes include f64",
+)
 def test_unsafe_index_put_acc_true_floats():
     bench = UnsafeIndexPutAccTrueBenchmark(
         op_name="_unsafe_index_put",

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -12074,7 +12074,6 @@ ops:
       - _unsafe_index_put
     labels:
       - aten
-      - KernelGen
     kind:
       - Math
     stages:

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -12064,6 +12064,21 @@ ops:
       - Tensor
     stages:
       - alpha: '5.4'
+  - id: unsafe_index_put
+    description: |
+      Functional advanced indexing scatter: returns a new tensor with `values`
+      put at the positions given by `indices`; with accumulate=True, sums into
+      the existing values via atomic_add (widened fp32/int32 scratch for
+      dtypes without native atomics).
+    for:
+      - _unsafe_index_put
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: unsafe_masked_index
     description: Gathers elements from self at given indices where mask is True, filling unmasked positions with a scalar value.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -240,6 +240,7 @@ _FULL_CONFIG = (
         lambda: version.parse(torch.__version__) >= version.parse("2.4"),
     ),
     ("_unique2", _unique2),
+    ("_unsafe_index_put", _unsafe_index_put),
     ("_unsafe_masked_index", _unsafe_masked_index),
     ("_unsafe_masked_index_put_accumulate", _unsafe_masked_index_put_accumulate),
     ("_unsafe_view", _unsafe_view),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -125,6 +125,7 @@ from flag_gems.ops._thnn_fused_lstm_cell import _thnn_fused_lstm_cell
 from flag_gems.ops._thnn_fused_lstm_cell_backward_impl import (
     _thnn_fused_lstm_cell_backward_impl,
 )
+from flag_gems.ops._unsafe_index_put import _unsafe_index_put
 from flag_gems.ops._unsafe_masked_index import _unsafe_masked_index
 from flag_gems.ops._unsafe_masked_index_put_accumulate import (
     _unsafe_masked_index_put_accumulate,
@@ -972,6 +973,7 @@ __all__ = [
     "_thnn_fused_lstm_cell",
     "_thnn_fused_lstm_cell_backward_impl",
     "_unique2",
+    "_unsafe_index_put",
     "_unsafe_masked_index",
     "_unsafe_masked_index_put_accumulate",
     "_unsafe_view",

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -1260,12 +1260,12 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
     idx_numel = _volume(idx_shape)
     suffix_numel = _volume(suffix_shape)
 
-    if inp.device.type != "cuda":
-        # Non-CUDA fallback: native implementation (bypasses flag_gems' own
-        # _index_put_impl_ patch which only applies to the CUDA dispatch key).
-        out = inp.clone()
-        torch._index_put_impl_(out, processed, values, accumulate, unsafe=True)
-        return out
+    # if inp.device.type != "cuda":
+    #     # Non-CUDA fallback: native implementation (bypasses flag_gems' own
+    #     # _index_put_impl_ patch which only applies to the CUDA dispatch key).
+    #     out = inp.clone()
+    #     torch._index_put_impl_(out, processed, values, accumulate, unsafe=True)
+    #     return out
 
     # Functional contract: the input is never modified. empty_like + Triton
     # copy avoids the patched aten::clone dispatch under use_gems.

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -54,7 +54,17 @@ from functools import lru_cache
 import torch
 import triton
 import triton.language as tl
-from triton import knobs
+
+try:
+    from triton import knobs
+except ImportError:
+    # old Triton：create virtual knobs object，hook set None
+    class _Knobs:
+        class runtime:
+            launch_enter_hook = None
+            launch_exit_hook = None
+
+    knobs = _Knobs()
 from triton.runtime import driver
 
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -31,12 +31,21 @@ without any C++ involvement:
   arbitrary GPU scheduling (same tolerance class as PyTorch's own CPU-vs-CUDA
   divergence); integer accumulation is exact.
 
-All host-side stride/divisor scalars are packed into one small cached int64
-``meta`` tensor per call. Besides keeping the kernel signatures short, this
-sidesteps Triton's per-argument specialization cost in the Python launcher
-(~80 scalar arguments would otherwise be type-specialized on every launch).
-The meta tensors are cached keyed by the exact shapes/strides, so repeated
-calls with the same shapes pay no rebuild cost.
+Performance notes for the pure-Python wrapper:
+
+- All host-side stride/divisor scalars are packed into one small cached int64
+  ``meta`` tensor per call (cached keyed by the exact shapes/strides), which
+  keeps the kernel signatures short and sidesteps Triton's per-argument
+  specialization cost in the Python launcher.
+- The output clone is ``empty_like`` + a Triton copy kernel (vectorized flat
+  copy in the common contiguous case), avoiding the patched ``aten::clone``
+  dispatch under ``use_gems``.
+- Kernel launches go through a cached ``CompiledKernel`` (``_fast_launch``),
+  skipping triton's per-call binder/specialization, which costs ~15us of
+  Python per launch and dominates small shapes. The cache key captures
+  everything the compiled kernel depends on (constexpr values, argument
+  dtypes, each user tensor's 16-byte alignment, num_warps); on signature
+  drift in future triton versions the normal launch path is used instead.
 """
 
 import logging
@@ -45,10 +54,61 @@ from functools import lru_cache
 import torch
 import triton
 import triton.language as tl
+from triton import knobs
+from triton.runtime import driver
 
 logger = logging.getLogger(__name__)
 
 _MAX_NDIM = 6
+
+# Cached CompiledKernel direct launches; see the module docstring.
+_FAST_CACHE = {}
+
+
+def _aligned(t):
+    # torch's caching allocator returns 512B-aligned blocks; only views can
+    # be misaligned, so this check is only needed for user-provided tensors.
+    return t.data_ptr() & 15 == 0
+
+
+def _fast_launch(jit_fn, grid, args, key, num_warps=4):
+    """Launch a cached CompiledKernel, skipping triton's per-call binder.
+
+    ``key`` must capture everything the compiled kernel depends on: constexpr
+    values, argument dtypes, each user tensor's 16-byte alignment and
+    num_warps. Callers build it cheaply from values they already hold.
+    """
+    cache_key = (jit_fn, key)
+    kern = _FAST_CACHE.get(cache_key)
+    if kern is None:
+        kern = jit_fn[grid](*args, num_warps=num_warps)
+        if hasattr(kern, "result"):
+            kern = kern.result()
+        _FAST_CACHE[cache_key] = kern
+        return
+    try:
+        # Direct launch on the current stream, skipping the per-call binder
+        # and the launch-metadata LazyDict. The metadata is None-safe because
+        # the cache key already captures 16-byte alignments and our kernels
+        # declare no launch_metadata function.
+        device = driver.active.get_current_device()
+        stream = driver.active.get_current_stream(device)
+        kern.run(
+            grid[0],
+            grid[1] if len(grid) > 1 else 1,
+            grid[2] if len(grid) > 2 else 1,
+            stream,
+            kern.function,
+            kern.packed_metadata,
+            None,
+            knobs.runtime.launch_enter_hook,
+            knobs.runtime.launch_exit_hook,
+            *args,
+        )
+    except (TypeError, AttributeError):
+        # triton internals changed; the normal path is always correct
+        jit_fn[grid](*args, num_warps=num_warps)
+
 
 # Meta layout (offsets into the meta tensor). The main and scratch kernels
 # share this single layout (the scratch kernel loads only the fields it needs):
@@ -910,8 +970,12 @@ def _launch_copy(dst, src):
         block, num_warps = 8192, 8
     else:
         block, num_warps = 1024, 4
-    _unsafe_index_put_copy_kernel[(triton.cdiv(numel, block),)](
-        src, dst, meta, numel, contiguous, block, num_warps=num_warps
+    _fast_launch(
+        _unsafe_index_put_copy_kernel,
+        (triton.cdiv(numel, block),),
+        (src, dst, meta, numel, contiguous, block),
+        (contiguous, block, num_warps, src.dtype, dst.dtype, _aligned(src)),
+        num_warps=num_warps,
     )
 
 
@@ -953,6 +1017,9 @@ def _launch(out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_num
     # Pad index tensor list for kernel args (kernel always takes _MAX_NDIM
     # pointers; padded slots are never read thanks to the M constexpr).
     kernel_idx = indices + [indices[0]] * (_MAX_NDIM - m)
+    # dtype + 16-byte-alignment tags of the index tensors (part of the fast
+    # launch cache key; the padded pointer slots reuse indices[0]).
+    key = tuple((t.dtype, _aligned(t)) for t in indices)
 
     block_idx, block_suf = _heuristic_2d_blocks(idx_numel, suffix_numel)
     grid = (
@@ -973,71 +1040,103 @@ def _launch(out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_num
         scratch = torch.empty(max_off + 1, dtype=scratch_dtype, device=out.device)
 
         # Prologue: seed the scratch slots with cast(orig).
-        _unsafe_index_put_scratch_kernel[grid](
-            out,
-            scratch,
-            *kernel_idx,
-            meta,
-            idx_numel,
-            suffix_numel,
-            m,
-            idx_ndim,
-            suf_ndim,
-            True,
-            block_idx,
-            block_suf,
+        _fast_launch(
+            _unsafe_index_put_scratch_kernel,
+            grid,
+            (
+                out,
+                scratch,
+                *kernel_idx,
+                meta,
+                idx_numel,
+                suffix_numel,
+                m,
+                idx_ndim,
+                suf_ndim,
+                True,
+                block_idx,
+                block_suf,
+            ),
+            (m, idx_ndim, suf_ndim, True, block_idx, block_suf, out.dtype, *key),
             num_warps=4,
         )
         # Main: atomic_add cast deltas into scratch.
-        _unsafe_index_put_kernel[grid](
-            out,
-            values,
-            scratch,
-            *kernel_idx,
-            meta,
-            idx_numel,
-            suffix_numel,
-            m,
-            idx_ndim,
-            suf_ndim,
-            True,
-            True,
-            block_idx,
-            block_suf,
+        _fast_launch(
+            _unsafe_index_put_kernel,
+            grid,
+            (
+                out,
+                values,
+                scratch,
+                *kernel_idx,
+                meta,
+                idx_numel,
+                suffix_numel,
+                m,
+                idx_ndim,
+                suf_ndim,
+                True,
+                True,
+                block_idx,
+                block_suf,
+            ),
+            (m, idx_ndim, suf_ndim, True, True, block_idx, block_suf, out.dtype, values.dtype, *key),
             num_warps=4,
         )
         # Epilogue: out = cast(scratch) with a single rounding.
-        _unsafe_index_put_scratch_kernel[grid](
-            out,
-            scratch,
-            *kernel_idx,
-            meta,
-            idx_numel,
-            suffix_numel,
-            m,
-            idx_ndim,
-            suf_ndim,
-            False,
-            block_idx,
-            block_suf,
+        _fast_launch(
+            _unsafe_index_put_scratch_kernel,
+            grid,
+            (
+                out,
+                scratch,
+                *kernel_idx,
+                meta,
+                idx_numel,
+                suffix_numel,
+                m,
+                idx_ndim,
+                suf_ndim,
+                False,
+                block_idx,
+                block_suf,
+            ),
+            (m, idx_ndim, suf_ndim, False, block_idx, block_suf, out.dtype, *key),
             num_warps=4,
         )
     else:
-        _unsafe_index_put_kernel[grid](
-            out,
-            values,
-            out,  # scratch_ptr is unused when USE_SCRATCH is False
-            *kernel_idx,
-            meta,
-            idx_numel,
-            suffix_numel,
-            m,
-            idx_ndim,
-            suf_ndim,
-            accumulate,
-            False,
-            block_idx,
-            block_suf,
+        # scratch_ptr is unused when USE_SCRATCH is False
+        _fast_launch(
+            _unsafe_index_put_kernel,
+            grid,
+            (
+                out,
+                values,
+                out,
+                *kernel_idx,
+                meta,
+                idx_numel,
+                suffix_numel,
+                m,
+                idx_ndim,
+                suf_ndim,
+                accumulate,
+                False,
+                block_idx,
+                block_suf,
+            ),
+            (
+                m,
+                idx_ndim,
+                suf_ndim,
+                accumulate,
+                False,
+                block_idx,
+                block_suf,
+                out.dtype,
+                values.dtype,
+                *key,
+            ),
             num_warps=4,
         )
 
@@ -1087,7 +1186,7 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
     processed = []
     for idx in indices:
         if idx is None:
-            raise TypeError("_unsafe_index_put does not accept None indices " "(expected Tensor, but got NoneType)")
+            raise TypeError("_unsafe_index_put does not accept None indices (expected Tensor, but got NoneType)")
         if idx.device != inp.device:
             idx = idx.to(inp.device)
         if idx.dtype in (torch.bool, torch.uint8):

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -1,0 +1,1134 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-Triton ``_unsafe_index_put``.
+
+Port of the C++ wrapper logic from ``new_feature/add_nv_op_unsafe_index_put``
+without any C++ involvement:
+
+- Index preprocessing (bool/byte mask expansion via :func:`torch.nonzero`,
+  device fixup, broadcast shape/strides) happens in Python.
+- Both paths use a 2D-grid Triton kernel. Grid dim 0 walks broadcast
+  index-space positions, grid dim 1 walks suffix positions, so the kernel
+  never performs an expensive division by ``suffix_numel``.
+- ``accumulate=False``: plain store. With duplicate indices the winner is
+  unspecified, matching PyTorch's contract.
+- ``accumulate=True``: ``tl.atomic_add``. Dtypes without a native Triton
+  atomic add (fp16/bf16, int8/int16/uint8/bool) accumulate in a widened
+  scratch buffer (fp32 / int32) with a single cast on writeback, mirroring
+  PyTorch's opmath_t semantics. The summation order of duplicate indices is
+  arbitrary GPU scheduling (same tolerance class as PyTorch's own CPU-vs-CUDA
+  divergence); integer accumulation is exact.
+
+All host-side stride/divisor scalars are packed into one small cached int64
+``meta`` tensor per call. Besides keeping the kernel signatures short, this
+sidesteps Triton's per-argument specialization cost in the Python launcher
+(~80 scalar arguments would otherwise be type-specialized on every launch).
+The meta tensors are cached keyed by the exact shapes/strides, so repeated
+calls with the same shapes pay no rebuild cost.
+"""
+
+import logging
+from functools import lru_cache
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+_MAX_NDIM = 6
+
+# Meta layout (offsets into the meta tensor). The main and scratch kernels
+# share this single layout (the scratch kernel loads only the fields it needs):
+#   [0:6]    idx_div
+#   [6:42]   ts (row-major tensor strides of each index in idx space)
+#   [42:48]  val_adv
+#   [48:54]  self_adv_stride
+#   [54:60]  self_adv_size
+#   [60:66]  suf_div
+#   [66:72]  self_suf_stride
+#   [72:78]  val_suf_stride
+
+
+@triton.jit
+def _unsafe_index_put_kernel(
+    out_ptr,
+    values_ptr,
+    scratch_ptr,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    meta_ptr,
+    idx_numel: "i64",
+    suffix_numel: "i64",
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    ACCUMULATE: tl.constexpr,
+    USE_SCRATCH: tl.constexpr,
+    BLOCK_IDX: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+):
+    # 2D grid: program_id(0) -> idx position, program_id(1) -> suffix
+    # position. Each block handles BLOCK_IDX index positions x BLOCK_SUF
+    # suffix positions.
+    idx_div0 = tl.load(meta_ptr + 0)
+    idx_div1 = tl.load(meta_ptr + 1)
+    idx_div2 = tl.load(meta_ptr + 2)
+    idx_div3 = tl.load(meta_ptr + 3)
+    idx_div4 = tl.load(meta_ptr + 4)
+    idx_div5 = tl.load(meta_ptr + 5)
+    ts_0_0 = tl.load(meta_ptr + 6)
+    ts_0_1 = tl.load(meta_ptr + 7)
+    ts_0_2 = tl.load(meta_ptr + 8)
+    ts_0_3 = tl.load(meta_ptr + 9)
+    ts_0_4 = tl.load(meta_ptr + 10)
+    ts_0_5 = tl.load(meta_ptr + 11)
+    ts_1_0 = tl.load(meta_ptr + 12)
+    ts_1_1 = tl.load(meta_ptr + 13)
+    ts_1_2 = tl.load(meta_ptr + 14)
+    ts_1_3 = tl.load(meta_ptr + 15)
+    ts_1_4 = tl.load(meta_ptr + 16)
+    ts_1_5 = tl.load(meta_ptr + 17)
+    ts_2_0 = tl.load(meta_ptr + 18)
+    ts_2_1 = tl.load(meta_ptr + 19)
+    ts_2_2 = tl.load(meta_ptr + 20)
+    ts_2_3 = tl.load(meta_ptr + 21)
+    ts_2_4 = tl.load(meta_ptr + 22)
+    ts_2_5 = tl.load(meta_ptr + 23)
+    ts_3_0 = tl.load(meta_ptr + 24)
+    ts_3_1 = tl.load(meta_ptr + 25)
+    ts_3_2 = tl.load(meta_ptr + 26)
+    ts_3_3 = tl.load(meta_ptr + 27)
+    ts_3_4 = tl.load(meta_ptr + 28)
+    ts_3_5 = tl.load(meta_ptr + 29)
+    ts_4_0 = tl.load(meta_ptr + 30)
+    ts_4_1 = tl.load(meta_ptr + 31)
+    ts_4_2 = tl.load(meta_ptr + 32)
+    ts_4_3 = tl.load(meta_ptr + 33)
+    ts_4_4 = tl.load(meta_ptr + 34)
+    ts_4_5 = tl.load(meta_ptr + 35)
+    ts_5_0 = tl.load(meta_ptr + 36)
+    ts_5_1 = tl.load(meta_ptr + 37)
+    ts_5_2 = tl.load(meta_ptr + 38)
+    ts_5_3 = tl.load(meta_ptr + 39)
+    ts_5_4 = tl.load(meta_ptr + 40)
+    ts_5_5 = tl.load(meta_ptr + 41)
+    val_adv0 = tl.load(meta_ptr + 42)
+    val_adv1 = tl.load(meta_ptr + 43)
+    val_adv2 = tl.load(meta_ptr + 44)
+    val_adv3 = tl.load(meta_ptr + 45)
+    val_adv4 = tl.load(meta_ptr + 46)
+    val_adv5 = tl.load(meta_ptr + 47)
+    self_adv_stride0 = tl.load(meta_ptr + 48)
+    self_adv_stride1 = tl.load(meta_ptr + 49)
+    self_adv_stride2 = tl.load(meta_ptr + 50)
+    self_adv_stride3 = tl.load(meta_ptr + 51)
+    self_adv_stride4 = tl.load(meta_ptr + 52)
+    self_adv_stride5 = tl.load(meta_ptr + 53)
+    self_adv_size0 = tl.load(meta_ptr + 54)
+    self_adv_size1 = tl.load(meta_ptr + 55)
+    self_adv_size2 = tl.load(meta_ptr + 56)
+    self_adv_size3 = tl.load(meta_ptr + 57)
+    self_adv_size4 = tl.load(meta_ptr + 58)
+    self_adv_size5 = tl.load(meta_ptr + 59)
+    suf_div0 = tl.load(meta_ptr + 60)
+    suf_div1 = tl.load(meta_ptr + 61)
+    suf_div2 = tl.load(meta_ptr + 62)
+    suf_div3 = tl.load(meta_ptr + 63)
+    suf_div4 = tl.load(meta_ptr + 64)
+    suf_div5 = tl.load(meta_ptr + 65)
+    self_suf_stride0 = tl.load(meta_ptr + 66)
+    self_suf_stride1 = tl.load(meta_ptr + 67)
+    self_suf_stride2 = tl.load(meta_ptr + 68)
+    self_suf_stride3 = tl.load(meta_ptr + 69)
+    self_suf_stride4 = tl.load(meta_ptr + 70)
+    self_suf_stride5 = tl.load(meta_ptr + 71)
+    val_suf_stride0 = tl.load(meta_ptr + 72)
+    val_suf_stride1 = tl.load(meta_ptr + 73)
+    val_suf_stride2 = tl.load(meta_ptr + 74)
+    val_suf_stride3 = tl.load(meta_ptr + 75)
+    val_suf_stride4 = tl.load(meta_ptr + 76)
+    val_suf_stride5 = tl.load(meta_ptr + 77)
+
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]  # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]  # (1, BS)
+
+    mask_idx = idx_off < idx_numel
+    mask_suf = suf_off < suffix_numel
+    mask = mask_idx & mask_suf  # (BI, BS)
+
+    val_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    self_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    toff0 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff1 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff2 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff3 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff4 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff5 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    # ---- index-space coordinate decomposition ----
+    rem_idx = idx_off
+    if IDX_NDIM >= 1:
+        c0 = rem_idx // idx_div0
+        rem_idx = rem_idx % idx_div0
+        val_off += c0 * val_adv0
+        if M >= 1:
+            toff0 += c0 * ts_0_0
+        if M >= 2:
+            toff1 += c0 * ts_1_0
+        if M >= 3:
+            toff2 += c0 * ts_2_0
+        if M >= 4:
+            toff3 += c0 * ts_3_0
+        if M >= 5:
+            toff4 += c0 * ts_4_0
+        if M >= 6:
+            toff5 += c0 * ts_5_0
+    if IDX_NDIM >= 2:
+        c1 = rem_idx // idx_div1
+        rem_idx = rem_idx % idx_div1
+        val_off += c1 * val_adv1
+        if M >= 1:
+            toff0 += c1 * ts_0_1
+        if M >= 2:
+            toff1 += c1 * ts_1_1
+        if M >= 3:
+            toff2 += c1 * ts_2_1
+        if M >= 4:
+            toff3 += c1 * ts_3_1
+        if M >= 5:
+            toff4 += c1 * ts_4_1
+        if M >= 6:
+            toff5 += c1 * ts_5_1
+    if IDX_NDIM >= 3:
+        c2 = rem_idx // idx_div2
+        rem_idx = rem_idx % idx_div2
+        val_off += c2 * val_adv2
+        if M >= 1:
+            toff0 += c2 * ts_0_2
+        if M >= 2:
+            toff1 += c2 * ts_1_2
+        if M >= 3:
+            toff2 += c2 * ts_2_2
+        if M >= 4:
+            toff3 += c2 * ts_3_2
+        if M >= 5:
+            toff4 += c2 * ts_4_2
+        if M >= 6:
+            toff5 += c2 * ts_5_2
+    if IDX_NDIM >= 4:
+        c3 = rem_idx // idx_div3
+        rem_idx = rem_idx % idx_div3
+        val_off += c3 * val_adv3
+        if M >= 1:
+            toff0 += c3 * ts_0_3
+        if M >= 2:
+            toff1 += c3 * ts_1_3
+        if M >= 3:
+            toff2 += c3 * ts_2_3
+        if M >= 4:
+            toff3 += c3 * ts_3_3
+        if M >= 5:
+            toff4 += c3 * ts_4_3
+        if M >= 6:
+            toff5 += c3 * ts_5_3
+    if IDX_NDIM >= 5:
+        c4 = rem_idx // idx_div4
+        rem_idx = rem_idx % idx_div4
+        val_off += c4 * val_adv4
+        if M >= 1:
+            toff0 += c4 * ts_0_4
+        if M >= 2:
+            toff1 += c4 * ts_1_4
+        if M >= 3:
+            toff2 += c4 * ts_2_4
+        if M >= 4:
+            toff3 += c4 * ts_3_4
+        if M >= 5:
+            toff4 += c4 * ts_4_4
+        if M >= 6:
+            toff5 += c4 * ts_5_4
+    if IDX_NDIM >= 6:
+        c5 = rem_idx // idx_div5
+        rem_idx = rem_idx % idx_div5
+        val_off += c5 * val_adv5
+        if M >= 1:
+            toff0 += c5 * ts_0_5
+        if M >= 2:
+            toff1 += c5 * ts_1_5
+        if M >= 3:
+            toff2 += c5 * ts_2_5
+        if M >= 4:
+            toff3 += c5 * ts_3_5
+        if M >= 5:
+            toff4 += c5 * ts_4_5
+        if M >= 6:
+            toff5 += c5 * ts_5_5
+
+    # ---- load index values (int32 or int64, converted in-register) ----
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff0, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size0, ind)
+        self_off += ind * self_adv_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff1, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size1, ind)
+        self_off += ind * self_adv_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff2, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size2, ind)
+        self_off += ind * self_adv_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff3, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size3, ind)
+        self_off += ind * self_adv_stride3
+    if M >= 5:
+        ind = tl.load(idx4_ptr + toff4, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size4, ind)
+        self_off += ind * self_adv_stride4
+    if M >= 6:
+        ind = tl.load(idx5_ptr + toff5, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size5, ind)
+        self_off += ind * self_adv_stride5
+
+    # ---- suffix coordinate decomposition ----
+    rem_suf = suf_off
+    if SUF_NDIM >= 1:
+        cs0 = rem_suf // suf_div0
+        rem_suf = rem_suf % suf_div0
+        self_off += cs0 * self_suf_stride0
+        val_off += cs0 * val_suf_stride0
+    if SUF_NDIM >= 2:
+        cs1 = rem_suf // suf_div1
+        rem_suf = rem_suf % suf_div1
+        self_off += cs1 * self_suf_stride1
+        val_off += cs1 * val_suf_stride1
+    if SUF_NDIM >= 3:
+        cs2 = rem_suf // suf_div2
+        rem_suf = rem_suf % suf_div2
+        self_off += cs2 * self_suf_stride2
+        val_off += cs2 * val_suf_stride2
+    if SUF_NDIM >= 4:
+        cs3 = rem_suf // suf_div3
+        rem_suf = rem_suf % suf_div3
+        self_off += cs3 * self_suf_stride3
+        val_off += cs3 * val_suf_stride3
+    if SUF_NDIM >= 5:
+        cs4 = rem_suf // suf_div4
+        rem_suf = rem_suf % suf_div4
+        self_off += cs4 * self_suf_stride4
+        val_off += cs4 * val_suf_stride4
+    if SUF_NDIM >= 6:
+        cs5 = rem_suf // suf_div5
+        rem_suf = rem_suf % suf_div5
+        self_off += cs5 * self_suf_stride5
+        val_off += cs5 * val_suf_stride5
+
+    # ---- load and store / accumulate ----
+    v = tl.load(values_ptr + val_off, mask=mask, other=0)
+    if ACCUMULATE:
+        if USE_SCRATCH:
+            # Scratch-based accumulate for outputs whose dtype lacks native
+            # atomic_add. Scratch slots were seeded by the prologue; here we
+            # only add the cast delta. Lossless for all supported dtypes.
+            tl.atomic_add(scratch_ptr + self_off, v.to(scratch_ptr.dtype.element_ty), mask=mask)
+        else:
+            tl.atomic_add(out_ptr + self_off, v, mask=mask)
+    else:
+        tl.store(out_ptr + self_off, v, mask=mask)
+
+
+@triton.jit
+def _unsafe_index_put_scratch_kernel(
+    out_ptr,
+    scratch_ptr,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    meta_ptr,
+    idx_numel: "i64",
+    suffix_numel: "i64",
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    PROLOGUE: tl.constexpr,
+    BLOCK_IDX: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+):
+    # Scratch prologue/epilogue for the widened-scratch accumulate path.
+    # Recomputes the touched offsets exactly as the main kernel does.
+    #
+    # PROLOGUE=True:  seeds scratch slots with cast(orig) read from the
+    #                 cloned output (idempotent under duplicate slots).
+    # PROLOGUE=False: stores cast(scratch) into out (idempotent too).
+    # Both phases are race-free under duplicate target slots because every
+    # writer stores the same value.
+    idx_div0 = tl.load(meta_ptr + 0)
+    idx_div1 = tl.load(meta_ptr + 1)
+    idx_div2 = tl.load(meta_ptr + 2)
+    idx_div3 = tl.load(meta_ptr + 3)
+    idx_div4 = tl.load(meta_ptr + 4)
+    idx_div5 = tl.load(meta_ptr + 5)
+    ts_0_0 = tl.load(meta_ptr + 6)
+    ts_0_1 = tl.load(meta_ptr + 7)
+    ts_0_2 = tl.load(meta_ptr + 8)
+    ts_0_3 = tl.load(meta_ptr + 9)
+    ts_0_4 = tl.load(meta_ptr + 10)
+    ts_0_5 = tl.load(meta_ptr + 11)
+    ts_1_0 = tl.load(meta_ptr + 12)
+    ts_1_1 = tl.load(meta_ptr + 13)
+    ts_1_2 = tl.load(meta_ptr + 14)
+    ts_1_3 = tl.load(meta_ptr + 15)
+    ts_1_4 = tl.load(meta_ptr + 16)
+    ts_1_5 = tl.load(meta_ptr + 17)
+    ts_2_0 = tl.load(meta_ptr + 18)
+    ts_2_1 = tl.load(meta_ptr + 19)
+    ts_2_2 = tl.load(meta_ptr + 20)
+    ts_2_3 = tl.load(meta_ptr + 21)
+    ts_2_4 = tl.load(meta_ptr + 22)
+    ts_2_5 = tl.load(meta_ptr + 23)
+    ts_3_0 = tl.load(meta_ptr + 24)
+    ts_3_1 = tl.load(meta_ptr + 25)
+    ts_3_2 = tl.load(meta_ptr + 26)
+    ts_3_3 = tl.load(meta_ptr + 27)
+    ts_3_4 = tl.load(meta_ptr + 28)
+    ts_3_5 = tl.load(meta_ptr + 29)
+    ts_4_0 = tl.load(meta_ptr + 30)
+    ts_4_1 = tl.load(meta_ptr + 31)
+    ts_4_2 = tl.load(meta_ptr + 32)
+    ts_4_3 = tl.load(meta_ptr + 33)
+    ts_4_4 = tl.load(meta_ptr + 34)
+    ts_4_5 = tl.load(meta_ptr + 35)
+    ts_5_0 = tl.load(meta_ptr + 36)
+    ts_5_1 = tl.load(meta_ptr + 37)
+    ts_5_2 = tl.load(meta_ptr + 38)
+    ts_5_3 = tl.load(meta_ptr + 39)
+    ts_5_4 = tl.load(meta_ptr + 40)
+    ts_5_5 = tl.load(meta_ptr + 41)
+    self_adv_stride0 = tl.load(meta_ptr + 48)
+    self_adv_stride1 = tl.load(meta_ptr + 49)
+    self_adv_stride2 = tl.load(meta_ptr + 50)
+    self_adv_stride3 = tl.load(meta_ptr + 51)
+    self_adv_stride4 = tl.load(meta_ptr + 52)
+    self_adv_stride5 = tl.load(meta_ptr + 53)
+    self_adv_size0 = tl.load(meta_ptr + 54)
+    self_adv_size1 = tl.load(meta_ptr + 55)
+    self_adv_size2 = tl.load(meta_ptr + 56)
+    self_adv_size3 = tl.load(meta_ptr + 57)
+    self_adv_size4 = tl.load(meta_ptr + 58)
+    self_adv_size5 = tl.load(meta_ptr + 59)
+    suf_div0 = tl.load(meta_ptr + 60)
+    suf_div1 = tl.load(meta_ptr + 61)
+    suf_div2 = tl.load(meta_ptr + 62)
+    suf_div3 = tl.load(meta_ptr + 63)
+    suf_div4 = tl.load(meta_ptr + 64)
+    suf_div5 = tl.load(meta_ptr + 65)
+    self_suf_stride0 = tl.load(meta_ptr + 66)
+    self_suf_stride1 = tl.load(meta_ptr + 67)
+    self_suf_stride2 = tl.load(meta_ptr + 68)
+    self_suf_stride3 = tl.load(meta_ptr + 69)
+    self_suf_stride4 = tl.load(meta_ptr + 70)
+    self_suf_stride5 = tl.load(meta_ptr + 71)
+
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]  # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]  # (1, BS)
+
+    mask_idx = idx_off < idx_numel
+    mask_suf = suf_off < suffix_numel
+    mask = mask_idx & mask_suf  # (BI, BS)
+
+    self_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    toff0 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff1 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff2 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff3 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff4 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff5 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    # ---- index-space coordinate decomposition ----
+    rem_idx = idx_off
+    if IDX_NDIM >= 1:
+        c0 = rem_idx // idx_div0
+        rem_idx = rem_idx % idx_div0
+        if M >= 1:
+            toff0 += c0 * ts_0_0
+        if M >= 2:
+            toff1 += c0 * ts_1_0
+        if M >= 3:
+            toff2 += c0 * ts_2_0
+        if M >= 4:
+            toff3 += c0 * ts_3_0
+        if M >= 5:
+            toff4 += c0 * ts_4_0
+        if M >= 6:
+            toff5 += c0 * ts_5_0
+    if IDX_NDIM >= 2:
+        c1 = rem_idx // idx_div1
+        rem_idx = rem_idx % idx_div1
+        if M >= 1:
+            toff0 += c1 * ts_0_1
+        if M >= 2:
+            toff1 += c1 * ts_1_1
+        if M >= 3:
+            toff2 += c1 * ts_2_1
+        if M >= 4:
+            toff3 += c1 * ts_3_1
+        if M >= 5:
+            toff4 += c1 * ts_4_1
+        if M >= 6:
+            toff5 += c1 * ts_5_1
+    if IDX_NDIM >= 3:
+        c2 = rem_idx // idx_div2
+        rem_idx = rem_idx % idx_div2
+        if M >= 1:
+            toff0 += c2 * ts_0_2
+        if M >= 2:
+            toff1 += c2 * ts_1_2
+        if M >= 3:
+            toff2 += c2 * ts_2_2
+        if M >= 4:
+            toff3 += c2 * ts_3_2
+        if M >= 5:
+            toff4 += c2 * ts_4_2
+        if M >= 6:
+            toff5 += c2 * ts_5_2
+    if IDX_NDIM >= 4:
+        c3 = rem_idx // idx_div3
+        rem_idx = rem_idx % idx_div3
+        if M >= 1:
+            toff0 += c3 * ts_0_3
+        if M >= 2:
+            toff1 += c3 * ts_1_3
+        if M >= 3:
+            toff2 += c3 * ts_2_3
+        if M >= 4:
+            toff3 += c3 * ts_3_3
+        if M >= 5:
+            toff4 += c3 * ts_4_3
+        if M >= 6:
+            toff5 += c3 * ts_5_3
+    if IDX_NDIM >= 5:
+        c4 = rem_idx // idx_div4
+        rem_idx = rem_idx % idx_div4
+        if M >= 1:
+            toff0 += c4 * ts_0_4
+        if M >= 2:
+            toff1 += c4 * ts_1_4
+        if M >= 3:
+            toff2 += c4 * ts_2_4
+        if M >= 4:
+            toff3 += c4 * ts_3_4
+        if M >= 5:
+            toff4 += c4 * ts_4_4
+        if M >= 6:
+            toff5 += c4 * ts_5_4
+    if IDX_NDIM >= 6:
+        c5 = rem_idx // idx_div5
+        rem_idx = rem_idx % idx_div5
+        if M >= 1:
+            toff0 += c5 * ts_0_5
+        if M >= 2:
+            toff1 += c5 * ts_1_5
+        if M >= 3:
+            toff2 += c5 * ts_2_5
+        if M >= 4:
+            toff3 += c5 * ts_3_5
+        if M >= 5:
+            toff4 += c5 * ts_4_5
+        if M >= 6:
+            toff5 += c5 * ts_5_5
+
+    # ---- load index values (int32 or int64, converted in-register) ----
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff0, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size0, ind)
+        self_off += ind * self_adv_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff1, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size1, ind)
+        self_off += ind * self_adv_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff2, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size2, ind)
+        self_off += ind * self_adv_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff3, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size3, ind)
+        self_off += ind * self_adv_stride3
+    if M >= 5:
+        ind = tl.load(idx4_ptr + toff4, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size4, ind)
+        self_off += ind * self_adv_stride4
+    if M >= 6:
+        ind = tl.load(idx5_ptr + toff5, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size5, ind)
+        self_off += ind * self_adv_stride5
+
+    # ---- suffix coordinate decomposition ----
+    rem_suf = suf_off
+    if SUF_NDIM >= 1:
+        cs0 = rem_suf // suf_div0
+        rem_suf = rem_suf % suf_div0
+        self_off += cs0 * self_suf_stride0
+    if SUF_NDIM >= 2:
+        cs1 = rem_suf // suf_div1
+        rem_suf = rem_suf % suf_div1
+        self_off += cs1 * self_suf_stride1
+    if SUF_NDIM >= 3:
+        cs2 = rem_suf // suf_div2
+        rem_suf = rem_suf % suf_div2
+        self_off += cs2 * self_suf_stride2
+    if SUF_NDIM >= 4:
+        cs3 = rem_suf // suf_div3
+        rem_suf = rem_suf % suf_div3
+        self_off += cs3 * self_suf_stride3
+    if SUF_NDIM >= 5:
+        cs4 = rem_suf // suf_div4
+        rem_suf = rem_suf % suf_div4
+        self_off += cs4 * self_suf_stride4
+    if SUF_NDIM >= 6:
+        cs5 = rem_suf // suf_div5
+        rem_suf = rem_suf % suf_div5
+        self_off += cs5 * self_suf_stride5
+
+    if PROLOGUE:
+        orig = tl.load(out_ptr + self_off, mask=mask, other=0)
+        tl.store(scratch_ptr + self_off, orig.to(scratch_ptr.dtype.element_ty), mask=mask)
+    else:
+        v32 = tl.load(scratch_ptr + self_off, mask=mask, other=0)
+        tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _unsafe_index_put_copy_kernel(
+    in_ptr,
+    out_ptr,
+    meta_ptr,
+    numel: "i64",
+    CONTIGUOUS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # Copy used to implement the output clone (empty_like + copy) without
+    # dispatching to the patched aten::clone under use_gems. The common
+    # contiguous case is a flat vectorized copy; the strided fallback
+    # decomposes the flat position into coordinates. meta holds shape (12),
+    # in_stride (12), out_stride (12) -- up to _MAX_NDIM index dims plus
+    # _MAX_NDIM suffix dims; dims beyond the tensor rank are padded with
+    # shape 1 / stride 0 so the decomposition below works for any rank
+    # <= 12 without a rank constexpr.
+    off = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = off < numel
+    if CONTIGUOUS:
+        v = tl.load(in_ptr + off, mask=mask, other=0)
+        tl.store(out_ptr + off, v, mask=mask)
+    else:
+        shape0 = tl.load(meta_ptr + 0)
+        shape1 = tl.load(meta_ptr + 1)
+        shape2 = tl.load(meta_ptr + 2)
+        shape3 = tl.load(meta_ptr + 3)
+        shape4 = tl.load(meta_ptr + 4)
+        shape5 = tl.load(meta_ptr + 5)
+        shape6 = tl.load(meta_ptr + 6)
+        shape7 = tl.load(meta_ptr + 7)
+        shape8 = tl.load(meta_ptr + 8)
+        shape9 = tl.load(meta_ptr + 9)
+        shape10 = tl.load(meta_ptr + 10)
+        shape11 = tl.load(meta_ptr + 11)
+        in_stride0 = tl.load(meta_ptr + 12)
+        in_stride1 = tl.load(meta_ptr + 13)
+        in_stride2 = tl.load(meta_ptr + 14)
+        in_stride3 = tl.load(meta_ptr + 15)
+        in_stride4 = tl.load(meta_ptr + 16)
+        in_stride5 = tl.load(meta_ptr + 17)
+        in_stride6 = tl.load(meta_ptr + 18)
+        in_stride7 = tl.load(meta_ptr + 19)
+        in_stride8 = tl.load(meta_ptr + 20)
+        in_stride9 = tl.load(meta_ptr + 21)
+        in_stride10 = tl.load(meta_ptr + 22)
+        in_stride11 = tl.load(meta_ptr + 23)
+        out_stride0 = tl.load(meta_ptr + 24)
+        out_stride1 = tl.load(meta_ptr + 25)
+        out_stride2 = tl.load(meta_ptr + 26)
+        out_stride3 = tl.load(meta_ptr + 27)
+        out_stride4 = tl.load(meta_ptr + 28)
+        out_stride5 = tl.load(meta_ptr + 29)
+        out_stride6 = tl.load(meta_ptr + 30)
+        out_stride7 = tl.load(meta_ptr + 31)
+        out_stride8 = tl.load(meta_ptr + 32)
+        out_stride9 = tl.load(meta_ptr + 33)
+        out_stride10 = tl.load(meta_ptr + 34)
+        out_stride11 = tl.load(meta_ptr + 35)
+
+        rem = off
+        c11 = rem % shape11
+        rem = rem // shape11
+        c10 = rem % shape10
+        rem = rem // shape10
+        c9 = rem % shape9
+        rem = rem // shape9
+        c8 = rem % shape8
+        rem = rem // shape8
+        c7 = rem % shape7
+        rem = rem // shape7
+        c6 = rem % shape6
+        rem = rem // shape6
+        c5 = rem % shape5
+        rem = rem // shape5
+        c4 = rem % shape4
+        rem = rem // shape4
+        c3 = rem % shape3
+        rem = rem // shape3
+        c2 = rem % shape2
+        rem = rem // shape2
+        c1 = rem % shape1
+        rem = rem // shape1
+        c0 = rem
+
+        src = (
+            c0 * in_stride0
+            + c1 * in_stride1
+            + c2 * in_stride2
+            + c3 * in_stride3
+            + c4 * in_stride4
+            + c5 * in_stride5
+            + c6 * in_stride6
+            + c7 * in_stride7
+            + c8 * in_stride8
+            + c9 * in_stride9
+            + c10 * in_stride10
+            + c11 * in_stride11
+        )
+        dst = (
+            c0 * out_stride0
+            + c1 * out_stride1
+            + c2 * out_stride2
+            + c3 * out_stride3
+            + c4 * out_stride4
+            + c5 * out_stride5
+            + c6 * out_stride6
+            + c7 * out_stride7
+            + c8 * out_stride8
+            + c9 * out_stride9
+            + c10 * out_stride10
+            + c11 * out_stride11
+        )
+        v = tl.load(in_ptr + src, mask=mask, other=0)
+        tl.store(out_ptr + dst, v, mask=mask)
+
+
+# ---------------------------------------------------------------------------
+# Host-side helpers (ports of the C++ wrapper utilities)
+# ---------------------------------------------------------------------------
+
+
+def _volume(shape):
+    n = 1
+    for s in shape:
+        n *= s
+    return n
+
+
+def _broadcast_shapes(shapes):
+    """Fast local replacement for torch.broadcast_shapes (no dispatch)."""
+    ndim = max(len(s) for s in shapes)
+    out = [1] * ndim
+    for shape in shapes:
+        pad = ndim - len(shape)
+        for i, s in enumerate(shape):
+            j = pad + i
+            if s != 1:
+                if out[j] == 1:
+                    out[j] = s
+                elif out[j] != s:
+                    raise RuntimeError(
+                        f"The size of tensor a ({out[j]}) must match the size of "
+                        f"tensor b ({s}) at non-singleton dimension {j}"
+                    )
+    return tuple(out)
+
+
+def _broadcast_strides(shape, stride, target_shape):
+    """Broadcast (shape, stride) into target_shape; 0 stride on expanded dims."""
+    ndim = len(target_shape)
+    pad = ndim - len(shape)
+    out = [0] * ndim
+    for i, s in enumerate(shape):
+        j = pad + i
+        if s == 1 and target_shape[j] != 1:
+            out[j] = 0
+        elif s != target_shape[j]:
+            raise RuntimeError(
+                f"The expanded size of the tensor ({target_shape[j]}) must match "
+                f"the existing size ({s}) at non-singleton dimension {i}."
+            )
+        else:
+            out[j] = stride[i]
+    return out
+
+
+def _trailing_divisors(shape):
+    ndim = len(shape)
+    div = [1] * ndim
+    acc = 1
+    for i in range(ndim - 1, -1, -1):
+        div[i] = acc
+        acc *= shape[i]
+    return div
+
+
+def _pad(seq, n, fill):
+    out = list(seq)
+    out.extend([fill] * (n - len(out)))
+    return out
+
+
+def _pad_2d(arr, rows, cols, fill):
+    out = [row + [fill] * (cols - len(row)) for row in arr]
+    out.extend([[fill] * cols for _ in range(rows - len(out))])
+    return out
+
+
+def _floor_pow2(x):
+    if x <= 1:
+        return 1
+    v = 1
+    while v * 2 <= x:
+        v *= 2
+    return v
+
+
+def _nearest_pow2(x, cap):
+    v = 1
+    while v * 2 <= x and v * 2 <= cap:
+        v *= 2
+    return max(1, min(v, cap))
+
+
+def _heuristic_2d_blocks(idx_numel, suffix_numel):
+    """Pick (BLOCK_IDX, BLOCK_SUF) for the 2D grid, mirroring the C++ wrapper.
+
+    Triton requires tl.arange ranges to be power-of-2.
+    """
+    k_target = 256
+    if suffix_numel <= 32:
+        # Small suffix: minimize grid_y (virtually 1D) to reduce launch overhead.
+        block_suf = _floor_pow2(max(1, suffix_numel))
+        block_idx = _floor_pow2(max(1, min(k_target // block_suf, idx_numel)))
+    elif suffix_numel >= idx_numel * 4:
+        # Large suffix relative to idx: benefit from 2D grid.
+        block_idx = 1
+        block_suf = _nearest_pow2(suffix_numel, 256)
+    elif idx_numel >= suffix_numel * 4:
+        block_suf = max(1, _nearest_pow2(suffix_numel, 256))
+        block_idx = _nearest_pow2(idx_numel, k_target // block_suf)
+    else:
+        ratio = idx_numel // max(1, suffix_numel)
+        if ratio >= 16:
+            block_idx, block_suf = 32, 8
+        elif ratio >= 4:
+            block_idx, block_suf = 16, 16
+        else:
+            block_idx, block_suf = 8, 32
+    block_idx = _floor_pow2(max(1, min(block_idx, idx_numel)))
+    block_suf = _floor_pow2(max(1, min(block_suf, suffix_numel)))
+    return block_idx, block_suf
+
+
+def _idx_key(indices):
+    return tuple((tuple(t.shape), tuple(t.stride())) for t in indices)
+
+
+@lru_cache(maxsize=1024)
+def _store_meta(device, out_shape, out_stride, idx_key, val_shape, val_stride, idx_shape, suffix_shape, m):
+    """Small int64 kernel-parameter buffer, cached per exact shapes/strides."""
+    tensor_strides = [_broadcast_strides(idx_key[i][0], idx_key[i][1], idx_shape) for i in range(m)]
+    ts = _pad_2d(tensor_strides, _MAX_NDIM, _MAX_NDIM, 0)
+    val_strides = _broadcast_strides(val_shape, val_stride, tuple(idx_shape) + tuple(suffix_shape))
+    idx_ndim = len(idx_shape)
+    vals = (
+        list(_pad(_trailing_divisors(idx_shape), _MAX_NDIM, 1))
+        + [ts[r][c] for r in range(_MAX_NDIM) for c in range(_MAX_NDIM)]
+        + list(_pad(val_strides[:idx_ndim], _MAX_NDIM, 0))
+        + list(_pad(out_stride[:m], _MAX_NDIM, 0))
+        + list(_pad(out_shape[:m], _MAX_NDIM, 1))
+        + list(_pad(_trailing_divisors(suffix_shape), _MAX_NDIM, 1))
+        + list(_pad(out_stride[m:], _MAX_NDIM, 0))
+        + list(_pad(val_strides[idx_ndim:], _MAX_NDIM, 0))
+    )
+    return torch.tensor(vals, dtype=torch.int64, device=device)
+
+
+@lru_cache(maxsize=1024)
+def _copy_meta(device, shape, in_stride, out_stride):
+    # Pad to 2 * _MAX_NDIM dims: the op supports up to _MAX_NDIM index dims
+    # plus _MAX_NDIM suffix dims.
+    vals = (
+        list(_pad(list(shape), 2 * _MAX_NDIM, 1))
+        + list(_pad(list(in_stride), 2 * _MAX_NDIM, 0))
+        + list(_pad(list(out_stride), 2 * _MAX_NDIM, 0))
+    )
+    return torch.tensor(vals, dtype=torch.int64, device=device)
+
+
+def _launch_copy(dst, src):
+    contiguous = src.is_contiguous() and dst.is_contiguous()
+    meta = _copy_meta(
+        str(dst.device),
+        tuple(src.shape),
+        tuple(src.stride()),
+        tuple(dst.stride()),
+    )
+    numel = src.numel()
+    if contiguous:
+        block, num_warps = 8192, 8
+    else:
+        block, num_warps = 1024, 4
+    _unsafe_index_put_copy_kernel[(triton.cdiv(numel, block),)](
+        src, dst, meta, numel, contiguous, block, num_warps=num_warps
+    )
+
+
+def _clone_like(inp):
+    """empty_like + Triton copy: avoids the patched aten::clone under use_gems."""
+    out = torch.empty_like(inp)
+    if inp.numel() > 0:
+        _launch_copy(out, inp)
+    return out
+
+
+_SCRATCH_DTYPES = {
+    torch.float16: torch.float32,
+    torch.bfloat16: torch.float32,
+    torch.int8: torch.int32,
+    torch.int16: torch.int32,
+    torch.uint8: torch.int32,
+    torch.bool: torch.int32,
+}
+
+
+def _launch(out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_numel, accumulate):
+    """2D-grid kernel launch; accumulate=True uses scratch for narrow dtypes."""
+    m = len(indices)
+    idx_ndim = len(idx_shape)
+    suf_ndim = len(suffix_shape)
+
+    meta = _store_meta(
+        str(out.device),
+        tuple(out.shape),
+        tuple(out.stride()),
+        _idx_key(indices),
+        tuple(values.shape),
+        tuple(values.stride()),
+        tuple(idx_shape),
+        tuple(suffix_shape),
+        m,
+    )
+    # Pad index tensor list for kernel args (kernel always takes _MAX_NDIM
+    # pointers; padded slots are never read thanks to the M constexpr).
+    kernel_idx = indices + [indices[0]] * (_MAX_NDIM - m)
+
+    block_idx, block_suf = _heuristic_2d_blocks(idx_numel, suffix_numel)
+    grid = (
+        triton.cdiv(idx_numel, block_idx),
+        triton.cdiv(suffix_numel, block_suf),
+    )
+
+    use_scratch = accumulate and out.dtype in _SCRATCH_DTYPES
+    if use_scratch:
+        scratch_dtype = _SCRATCH_DTYPES[out.dtype]
+        # scratch is indexed by the same element offsets used for `out` (valid
+        # for any positive-stride layout), so size it to cover out's maximum
+        # reachable offset + 1. No contiguous working copy is needed.
+        max_off = 0
+        for d in range(out.dim()):
+            if out.size(d) > 0:
+                max_off += (out.size(d) - 1) * out.stride(d)
+        scratch = torch.empty(max_off + 1, dtype=scratch_dtype, device=out.device)
+
+        # Prologue: seed the scratch slots with cast(orig).
+        _unsafe_index_put_scratch_kernel[grid](
+            out,
+            scratch,
+            *kernel_idx,
+            meta,
+            idx_numel,
+            suffix_numel,
+            m,
+            idx_ndim,
+            suf_ndim,
+            True,
+            block_idx,
+            block_suf,
+            num_warps=4,
+        )
+        # Main: atomic_add cast deltas into scratch.
+        _unsafe_index_put_kernel[grid](
+            out,
+            values,
+            scratch,
+            *kernel_idx,
+            meta,
+            idx_numel,
+            suffix_numel,
+            m,
+            idx_ndim,
+            suf_ndim,
+            True,
+            True,
+            block_idx,
+            block_suf,
+            num_warps=4,
+        )
+        # Epilogue: out = cast(scratch) with a single rounding.
+        _unsafe_index_put_scratch_kernel[grid](
+            out,
+            scratch,
+            *kernel_idx,
+            meta,
+            idx_numel,
+            suffix_numel,
+            m,
+            idx_ndim,
+            suf_ndim,
+            False,
+            block_idx,
+            block_suf,
+            num_warps=4,
+        )
+    else:
+        _unsafe_index_put_kernel[grid](
+            out,
+            values,
+            out,  # scratch_ptr is unused when USE_SCRATCH is False
+            *kernel_idx,
+            meta,
+            idx_numel,
+            suffix_numel,
+            m,
+            idx_ndim,
+            suf_ndim,
+            accumulate,
+            False,
+            block_idx,
+            block_suf,
+            num_warps=4,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operator entry point
+# ---------------------------------------------------------------------------
+
+
+def _unsafe_index_put(inp, indices, values, accumulate=False):
+    """_unsafe_index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+
+    Functional advanced indexing scatter. Returns a new tensor. Bool/byte
+    masks are expanded via nonzero; each of the first ``len(indices)`` dims
+    of ``self`` is indexed by the corresponding index tensor and the
+    remaining dims form the value suffix. ``unsafe`` means no upper bounds
+    checking is performed (negative indices wrap), matching PyTorch's
+    contract. accumulate=True uses atomic_add (with a widened scratch buffer
+    for dtypes without native atomics), so duplicate-index summation order is
+    arbitrary GPU scheduling; integer accumulation is exact.
+    """
+    logger.debug("GEMS _UNSAFE_INDEX_PUT")
+
+    if torch.is_tensor(indices):
+        indices = [indices]
+    indices = list(indices)
+
+    if not indices:
+        raise ValueError("At least one index tensor is required")
+
+    # Device/dtype fixups mirroring aten's _index_put_impl_.
+    if values.device != inp.device:
+        if values.numel() == 1 and values.dim() == 0:
+            values = values.to(inp.device)
+        else:
+            raise RuntimeError(
+                f"Expected all tensors to be on the same device, but found at "
+                f"least two devices, {inp.device} and {values.device}!"
+            )
+    if values.dtype != inp.dtype:
+        raise RuntimeError(
+            f"Index put requires the source and destination dtypes match, got "
+            f"{inp.dtype} for the destination and {values.dtype} for the source."
+        )
+
+    # Index preprocessing: expand bool/byte masks, fix devices.
+    processed = []
+    for idx in indices:
+        if idx is None:
+            raise TypeError("_unsafe_index_put does not accept None indices " "(expected Tensor, but got NoneType)")
+        if idx.device != inp.device:
+            idx = idx.to(inp.device)
+        if idx.dtype in (torch.bool, torch.uint8):
+            processed.extend(idx.nonzero(as_tuple=True))
+        elif idx.dtype in (torch.int32, torch.int64):
+            processed.append(idx)
+        else:
+            raise TypeError("tensors used as indices must be long, int, byte or bool tensors")
+
+    m = len(processed)
+    if m > inp.dim():
+        raise IndexError(f"too many indices for tensor of dimension {inp.dim()}")
+    if m > _MAX_NDIM:
+        raise IndexError(f"too many index tensors (max {_MAX_NDIM})")
+
+    suffix_shape = inp.shape[m:]
+    suf_ndim = len(suffix_shape)
+    if suf_ndim > _MAX_NDIM:
+        raise IndexError(f"suffix ndim out of range: {suf_ndim}")
+
+    idx_shape = _broadcast_shapes([t.shape for t in processed])
+    idx_ndim = len(idx_shape)
+    if idx_ndim > _MAX_NDIM:
+        raise IndexError(f"index space rank too large: {idx_ndim}")
+
+    idx_numel = _volume(idx_shape)
+    suffix_numel = _volume(suffix_shape)
+
+    if inp.device.type != "cuda":
+        # Non-CUDA fallback: native implementation (bypasses flag_gems' own
+        # _index_put_impl_ patch which only applies to the CUDA dispatch key).
+        out = inp.clone()
+        torch._index_put_impl_(out, processed, values, accumulate, unsafe=True)
+        return out
+
+    # Functional contract: the input is never modified. empty_like + Triton
+    # copy avoids the patched aten::clone dispatch under use_gems.
+    out = _clone_like(inp)
+
+    if idx_numel == 0 or suffix_numel == 0:
+        return out
+
+    _launch(out, processed, values, idx_shape, suffix_shape, idx_numel, suffix_numel, accumulate)
+    return out

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -134,8 +134,8 @@ def _unsafe_index_put_kernel(
     idx4_ptr,
     idx5_ptr,
     meta_ptr,
-    idx_numel: "i64",
-    suffix_numel: "i64",
+    idx_numel,
+    suffix_numel,
     M: tl.constexpr,
     IDX_NDIM: tl.constexpr,
     SUF_NDIM: tl.constexpr,
@@ -411,7 +411,9 @@ def _unsafe_index_put_kernel(
             # Scratch-based accumulate for outputs whose dtype lacks native
             # atomic_add. Scratch slots were seeded by the prologue; here we
             # only add the cast delta. Lossless for all supported dtypes.
-            tl.atomic_add(scratch_ptr + self_off, v.to(scratch_ptr.dtype.element_ty), mask=mask)
+            tl.atomic_add(
+                scratch_ptr + self_off, v.to(scratch_ptr.dtype.element_ty), mask=mask
+            )
         else:
             tl.atomic_add(out_ptr + self_off, v, mask=mask)
     else:
@@ -429,8 +431,8 @@ def _unsafe_index_put_scratch_kernel(
     idx4_ptr,
     idx5_ptr,
     meta_ptr,
-    idx_numel: "i64",
-    suffix_numel: "i64",
+    idx_numel,
+    suffix_numel,
     M: tl.constexpr,
     IDX_NDIM: tl.constexpr,
     SUF_NDIM: tl.constexpr,
@@ -680,7 +682,9 @@ def _unsafe_index_put_scratch_kernel(
 
     if PROLOGUE:
         orig = tl.load(out_ptr + self_off, mask=mask, other=0)
-        tl.store(scratch_ptr + self_off, orig.to(scratch_ptr.dtype.element_ty), mask=mask)
+        tl.store(
+            scratch_ptr + self_off, orig.to(scratch_ptr.dtype.element_ty), mask=mask
+        )
     else:
         v32 = tl.load(scratch_ptr + self_off, mask=mask, other=0)
         tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty), mask=mask)
@@ -691,7 +695,7 @@ def _unsafe_index_put_copy_kernel(
     in_ptr,
     out_ptr,
     meta_ptr,
-    numel: "i64",
+    numel,
     CONTIGUOUS: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
@@ -709,7 +713,7 @@ def _unsafe_index_put_copy_kernel(
         v = tl.load(in_ptr + off, mask=mask, other=0)
         tl.store(out_ptr + off, v, mask=mask)
     else:
-        shape0 = tl.load(meta_ptr + 0)
+        # shape0 = tl.load(meta_ptr + 0)
         shape1 = tl.load(meta_ptr + 1)
         shape2 = tl.load(meta_ptr + 2)
         shape3 = tl.load(meta_ptr + 3)
@@ -926,11 +930,25 @@ def _idx_key(indices):
 
 
 @lru_cache(maxsize=1024)
-def _store_meta(device, out_shape, out_stride, idx_key, val_shape, val_stride, idx_shape, suffix_shape, m):
+def _store_meta(
+    device,
+    out_shape,
+    out_stride,
+    idx_key,
+    val_shape,
+    val_stride,
+    idx_shape,
+    suffix_shape,
+    m,
+):
     """Small int64 kernel-parameter buffer, cached per exact shapes/strides."""
-    tensor_strides = [_broadcast_strides(idx_key[i][0], idx_key[i][1], idx_shape) for i in range(m)]
+    tensor_strides = [
+        _broadcast_strides(idx_key[i][0], idx_key[i][1], idx_shape) for i in range(m)
+    ]
     ts = _pad_2d(tensor_strides, _MAX_NDIM, _MAX_NDIM, 0)
-    val_strides = _broadcast_strides(val_shape, val_stride, tuple(idx_shape) + tuple(suffix_shape))
+    val_strides = _broadcast_strides(
+        val_shape, val_stride, tuple(idx_shape) + tuple(suffix_shape)
+    )
     idx_ndim = len(idx_shape)
     vals = (
         list(_pad(_trailing_divisors(idx_shape), _MAX_NDIM, 1))
@@ -997,7 +1015,9 @@ _SCRATCH_DTYPES = {
 }
 
 
-def _launch(out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_numel, accumulate):
+def _launch(
+    out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_numel, accumulate
+):
     """2D-grid kernel launch; accumulate=True uses scratch for narrow dtypes."""
     m = len(indices)
     idx_ndim = len(idx_shape)
@@ -1080,7 +1100,18 @@ def _launch(out, indices, values, idx_shape, suffix_shape, idx_numel, suffix_num
                 block_idx,
                 block_suf,
             ),
-            (m, idx_ndim, suf_ndim, True, True, block_idx, block_suf, out.dtype, values.dtype, *key),
+            (
+                m,
+                idx_ndim,
+                suf_ndim,
+                True,
+                True,
+                block_idx,
+                block_suf,
+                out.dtype,
+                values.dtype,
+                *key,
+            ),
             num_warps=4,
         )
         # Epilogue: out = cast(scratch) with a single rounding.
@@ -1186,7 +1217,9 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
     processed = []
     for idx in indices:
         if idx is None:
-            raise TypeError("_unsafe_index_put does not accept None indices (expected Tensor, but got NoneType)")
+            raise TypeError(
+                "_unsafe_index_put does not accept None indices (expected Tensor, but got NoneType)"
+            )
         if idx.device != inp.device:
             idx = idx.to(inp.device)
         if idx.dtype in (torch.bool, torch.uint8):
@@ -1194,7 +1227,9 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
         elif idx.dtype in (torch.int32, torch.int64):
             processed.append(idx)
         else:
-            raise TypeError("tensors used as indices must be long, int, byte or bool tensors")
+            raise TypeError(
+                "tensors used as indices must be long, int, byte or bool tensors"
+            )
 
     m = len(processed)
     if m > inp.dim():
@@ -1229,5 +1264,14 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
     if idx_numel == 0 or suffix_numel == 0:
         return out
 
-    _launch(out, processed, values, idx_shape, suffix_shape, idx_numel, suffix_numel, accumulate)
+    _launch(
+        out,
+        processed,
+        values,
+        idx_shape,
+        suffix_shape,
+        idx_numel,
+        suffix_numel,
+        accumulate,
+    )
     return out

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -110,6 +110,7 @@ from .stack import stack
 from .threshold import threshold, threshold_backward
 from .triu import triu
 from .unique import _unique2
+from .unsafe_index_put import _unsafe_index_put
 from .upsample_bicubic2d_aa import _upsample_bicubic2d_aa
 from .upsample_linear1d_backward import upsample_linear1d_backward
 from .upsample_nearest2d import upsample_nearest2d
@@ -122,6 +123,7 @@ from .zeros_like import zeros_like
 
 __all__ = [
     "_unique2",
+    "_unsafe_index_put",
     "_upsample_bicubic2d_aa",
     "addmm",
     "all",

--- a/src/flag_gems/runtime/backend/_ascend/ops/unsafe_index_put.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/unsafe_index_put.py
@@ -1,0 +1,834 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ascend-specific ``_unsafe_index_put`` (pure Triton).
+
+Design notes:
+
+- The generic implementation's non-CUDA fallback calls ``_index_put_impl_``,
+  which re-enters FlagGems' own patched implementation on Ascend and produces
+  wrong results / crashes. This module implements the op directly instead.
+- All offset arithmetic runs in int32 (native on Ascend); calls whose tensors
+  are too large for int32 offsets fall back to a native CPU run (a direct
+  native re-dispatch is not possible under ``use_gems`` because it re-enters
+  FlagGems' own patched ``_index_put_impl_``).
+- Two Triton kernels are used:
+  1. A prep kernel computes, for every broadcast index-space position, the
+     flat destination offset (``self_base``) and the flat values offset
+     (``val_base``). This hoists all per-position index gathering /
+     coordinate decomposition out of the scatter loop.
+  2. A scatter kernel over a 2D grid (index positions x suffix positions):
+     for ``accumulate=False`` it stores vectorized 2D tiles; for
+     ``accumulate=True`` it emits one-dimensional ``tl.atomic_add`` tiles
+     (the Ascend lowering of a 2D atomic tile is substantially slower) and
+     skips program 0 of axis 0, which may be re-executed during Ascend
+     lowering and would double-apply atomic updates.
+- ``accumulate=True`` for dtypes without a supported Ascend atomic (bf16,
+  fp16 atomics are lossy, narrow ints/bool have none) accumulates in a
+  widened scratch buffer (fp32 / int32) seeded with ``out.to(dtype)`` and
+  written back with ``out.copy_(scratch)``: both are native (unpatched) ops
+  on Ascend and give PyTorch's opmath semantics with a single rounding on
+  writeback.
+"""
+
+import logging
+from functools import lru_cache
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+_MAX_NDIM = 6
+# int32 offset arithmetic guards (native fallback beyond these)
+_MAX_NUMEL = 2**30
+_MAX_IDX_NUMEL = 2**26
+
+
+def _native_fallback(inp, indices, values, accumulate):
+    """Native-implementation fallback for cases the Triton path cannot cover.
+
+    On Ascend the patched dispatcher makes a direct native re-dispatch
+    unreliable (it re-enters FlagGems' own ``_index_put_impl_`` python
+    registration, which crashes on Ascend), so the fallback runs the op on
+    CPU instead. This path is only taken for fp64 (unsupported by the Ascend
+    Triton backend) and for tensors too large for int32 offsets; correctness
+    is exact, performance is secondary.
+    """
+    logger.warning(
+        "GEMS_ASCEND _UNSAFE_INDEX_PUT: native CPU fallback " "(dtype=%s, numel=%s)",
+        inp.dtype,
+        inp.numel(),
+    )
+    out = torch._unsafe_index_put(
+        inp.cpu(), [i.cpu() for i in indices], values.cpu(), accumulate
+    )
+    return out.to(inp.device)
+
+
+# Widened scratch dtype for accumulate when the output dtype has no fast /
+# exact atomic add on Ascend. Mirrors PyTorch's opmath_t accumulation.
+_SCRATCH_DTYPES = {
+    torch.float16: torch.float32,
+    torch.bfloat16: torch.float32,
+    torch.int8: torch.int32,
+    torch.int16: torch.int32,
+    torch.uint8: torch.int32,
+    torch.bool: torch.int32,
+}
+
+# Meta layout (int32): offsets into the meta tensor.
+#   [0:6]    idx_shape (padded 1)
+#   [6:12]   idx_div (trailing divisors of idx_shape, padded 1)
+#   [12:48]  ts (M x _MAX_NDIM broadcast strides of the index tensors)
+#   [48:54]  val_adv (broadcast strides of values into idx_shape)
+#   [54:60]  self_stride (out strides of the indexed dims)
+#   [60:66]  self_size (out sizes of the indexed dims)
+#   [66:72]  suf_shape (padded 1)
+#   [72:78]  suf_div (trailing divisors of suffix_shape, padded 1)
+#   [78:84]  val_suf_stride (broadcast strides of values into suffix_shape)
+
+
+# ---------------------------------------------------------------------------
+# Kernels
+# ---------------------------------------------------------------------------
+
+
+@libentry()
+@triton.jit
+def unsafe_index_put_prep_kernel(
+    base_ptr,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    meta_ptr,
+    idx_numel,
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    BPP: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # Computes per-position [self_base, val_base] flat offsets into the
+    # (2 * idx_numel,) int32 base buffer. All offsets are flat element offsets
+    # into a contiguous output tensor, so the suffix dims only shift by the
+    # flat suffix offset at scatter time.
+    idx_shape0 = tl.load(meta_ptr + 0)
+    idx_shape1 = tl.load(meta_ptr + 1)
+    idx_shape2 = tl.load(meta_ptr + 2)
+    idx_shape3 = tl.load(meta_ptr + 3)
+    idx_shape4 = tl.load(meta_ptr + 4)
+    idx_shape5 = tl.load(meta_ptr + 5)
+    idx_div0 = tl.load(meta_ptr + 6)
+    idx_div1 = tl.load(meta_ptr + 7)
+    idx_div2 = tl.load(meta_ptr + 8)
+    idx_div3 = tl.load(meta_ptr + 9)
+    idx_div4 = tl.load(meta_ptr + 10)
+    idx_div5 = tl.load(meta_ptr + 11)
+    ts_0_0 = tl.load(meta_ptr + 12)
+    ts_0_1 = tl.load(meta_ptr + 13)
+    ts_0_2 = tl.load(meta_ptr + 14)
+    ts_0_3 = tl.load(meta_ptr + 15)
+    ts_0_4 = tl.load(meta_ptr + 16)
+    ts_0_5 = tl.load(meta_ptr + 17)
+    ts_1_0 = tl.load(meta_ptr + 18)
+    ts_1_1 = tl.load(meta_ptr + 19)
+    ts_1_2 = tl.load(meta_ptr + 20)
+    ts_1_3 = tl.load(meta_ptr + 21)
+    ts_1_4 = tl.load(meta_ptr + 22)
+    ts_1_5 = tl.load(meta_ptr + 23)
+    ts_2_0 = tl.load(meta_ptr + 24)
+    ts_2_1 = tl.load(meta_ptr + 25)
+    ts_2_2 = tl.load(meta_ptr + 26)
+    ts_2_3 = tl.load(meta_ptr + 27)
+    ts_2_4 = tl.load(meta_ptr + 28)
+    ts_2_5 = tl.load(meta_ptr + 29)
+    ts_3_0 = tl.load(meta_ptr + 30)
+    ts_3_1 = tl.load(meta_ptr + 31)
+    ts_3_2 = tl.load(meta_ptr + 32)
+    ts_3_3 = tl.load(meta_ptr + 33)
+    ts_3_4 = tl.load(meta_ptr + 34)
+    ts_3_5 = tl.load(meta_ptr + 35)
+    ts_4_0 = tl.load(meta_ptr + 36)
+    ts_4_1 = tl.load(meta_ptr + 37)
+    ts_4_2 = tl.load(meta_ptr + 38)
+    ts_4_3 = tl.load(meta_ptr + 39)
+    ts_4_4 = tl.load(meta_ptr + 40)
+    ts_4_5 = tl.load(meta_ptr + 41)
+    ts_5_0 = tl.load(meta_ptr + 42)
+    ts_5_1 = tl.load(meta_ptr + 43)
+    ts_5_2 = tl.load(meta_ptr + 44)
+    ts_5_3 = tl.load(meta_ptr + 45)
+    ts_5_4 = tl.load(meta_ptr + 46)
+    ts_5_5 = tl.load(meta_ptr + 47)
+    val_adv0 = tl.load(meta_ptr + 48)
+    val_adv1 = tl.load(meta_ptr + 49)
+    val_adv2 = tl.load(meta_ptr + 50)
+    val_adv3 = tl.load(meta_ptr + 51)
+    val_adv4 = tl.load(meta_ptr + 52)
+    val_adv5 = tl.load(meta_ptr + 53)
+    self_stride0 = tl.load(meta_ptr + 54)
+    self_stride1 = tl.load(meta_ptr + 55)
+    self_stride2 = tl.load(meta_ptr + 56)
+    self_stride3 = tl.load(meta_ptr + 57)
+    self_stride4 = tl.load(meta_ptr + 58)
+    self_stride5 = tl.load(meta_ptr + 59)
+    self_size0 = tl.load(meta_ptr + 60)
+    self_size1 = tl.load(meta_ptr + 61)
+    self_size2 = tl.load(meta_ptr + 62)
+    self_size3 = tl.load(meta_ptr + 63)
+    self_size4 = tl.load(meta_ptr + 64)
+    self_size5 = tl.load(meta_ptr + 65)
+
+    pid = tle.program_id(axis=0)
+    for b in tl.static_range(0, BPP):
+        off = (pid * BPP + b) * BLOCK + tl.arange(0, BLOCK)
+        mask = off < idx_numel
+
+        # Coordinate decomposition of the flat index-space position.
+        val_base = tl.zeros((BLOCK,), dtype=tl.int32)
+        if IDX_NDIM >= 1:
+            c0 = (off // idx_div0) % idx_shape0
+            val_base += c0 * val_adv0
+        if IDX_NDIM >= 2:
+            c1 = (off // idx_div1) % idx_shape1
+            val_base += c1 * val_adv1
+        if IDX_NDIM >= 3:
+            c2 = (off // idx_div2) % idx_shape2
+            val_base += c2 * val_adv2
+        if IDX_NDIM >= 4:
+            c3 = (off // idx_div3) % idx_shape3
+            val_base += c3 * val_adv3
+        if IDX_NDIM >= 5:
+            c4 = (off // idx_div4) % idx_shape4
+            val_base += c4 * val_adv4
+        if IDX_NDIM >= 6:
+            c5 = (off // idx_div5) % idx_shape5
+            val_base += c5 * val_adv5
+
+        self_base = tl.zeros((BLOCK,), dtype=tl.int32)
+        for mi in tl.static_range(0, M):
+            if mi == 0:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_0_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_0_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_0_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_0_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_0_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_0_5
+                ind = tl.load(idx0_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size0, ind)
+                self_base += ind * self_stride0
+            if mi == 1:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_1_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_1_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_1_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_1_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_1_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_1_5
+                ind = tl.load(idx1_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size1, ind)
+                self_base += ind * self_stride1
+            if mi == 2:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_2_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_2_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_2_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_2_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_2_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_2_5
+                ind = tl.load(idx2_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size2, ind)
+                self_base += ind * self_stride2
+            if mi == 3:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_3_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_3_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_3_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_3_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_3_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_3_5
+                ind = tl.load(idx3_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size3, ind)
+                self_base += ind * self_stride3
+            if mi == 4:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_4_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_4_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_4_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_4_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_4_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_4_5
+                ind = tl.load(idx4_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size4, ind)
+                self_base += ind * self_stride4
+            if mi == 5:
+                toff = tl.zeros((BLOCK,), dtype=tl.int32)
+                if IDX_NDIM >= 1:
+                    toff += c0 * ts_5_0
+                if IDX_NDIM >= 2:
+                    toff += c1 * ts_5_1
+                if IDX_NDIM >= 3:
+                    toff += c2 * ts_5_2
+                if IDX_NDIM >= 4:
+                    toff += c3 * ts_5_3
+                if IDX_NDIM >= 5:
+                    toff += c4 * ts_5_4
+                if IDX_NDIM >= 6:
+                    toff += c5 * ts_5_5
+                ind = tl.load(idx5_ptr + toff, mask=mask, other=0).to(tl.int32)
+                ind = tl.where(ind < 0, ind + self_size5, ind)
+                self_base += ind * self_stride5
+
+        tl.store(base_ptr + off, self_base, mask=mask)
+        tl.store(base_ptr + off + idx_numel, val_base, mask=mask)
+
+
+@libentry()
+@triton.jit
+def unsafe_index_put_scatter_kernel(
+    out_ptr,
+    values_ptr,
+    target_ptr,
+    base_ptr,
+    meta_ptr,
+    idx_numel,
+    suffix_numel,
+    ACCUMULATE: tl.constexpr,
+    USE_SCRATCH: tl.constexpr,
+    STORE_BPP: tl.constexpr,
+    IDX_PP: tl.constexpr,
+    BLOCK_IDX: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+):
+    # Scatter over a 2D grid (index positions x suffix positions). The output
+    # is contiguous, so the suffix contributes its flat offset directly; the
+    # values tensor keeps its (broadcast) strides, decomposed via a small
+    # div/mod chain on the suffix axis only.
+    suf_shape0 = tl.load(meta_ptr + 66)
+    suf_shape1 = tl.load(meta_ptr + 67)
+    suf_shape2 = tl.load(meta_ptr + 68)
+    suf_shape3 = tl.load(meta_ptr + 69)
+    suf_shape4 = tl.load(meta_ptr + 70)
+    suf_shape5 = tl.load(meta_ptr + 71)
+    suf_div0 = tl.load(meta_ptr + 72)
+    suf_div1 = tl.load(meta_ptr + 73)
+    suf_div2 = tl.load(meta_ptr + 74)
+    suf_div3 = tl.load(meta_ptr + 75)
+    suf_div4 = tl.load(meta_ptr + 76)
+    suf_div5 = tl.load(meta_ptr + 77)
+    val_suf_stride0 = tl.load(meta_ptr + 78)
+    val_suf_stride1 = tl.load(meta_ptr + 79)
+    val_suf_stride2 = tl.load(meta_ptr + 80)
+    val_suf_stride3 = tl.load(meta_ptr + 81)
+    val_suf_stride4 = tl.load(meta_ptr + 82)
+    val_suf_stride5 = tl.load(meta_ptr + 83)
+
+    pid0 = tle.program_id(axis=0)
+    pid1 = tle.program_id(axis=1)
+
+    if ACCUMULATE:
+        # 1D atomics per index position. Program 0 of axis 0 is a no-op: it
+        # may be re-executed during Ascend lowering, which would double-apply
+        # the atomic updates.
+        suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)
+        mask_suf = suf_off < suffix_numel
+        vs = tl.zeros((BLOCK_SUF,), dtype=tl.int32)
+        if SUF_NDIM >= 1:
+            cs0 = (suf_off // suf_div0) % suf_shape0
+            vs += cs0 * val_suf_stride0
+        if SUF_NDIM >= 2:
+            cs1 = (suf_off // suf_div1) % suf_shape1
+            vs += cs1 * val_suf_stride1
+        if SUF_NDIM >= 3:
+            cs2 = (suf_off // suf_div2) % suf_shape2
+            vs += cs2 * val_suf_stride2
+        if SUF_NDIM >= 4:
+            cs3 = (suf_off // suf_div3) % suf_shape3
+            vs += cs3 * val_suf_stride3
+        if SUF_NDIM >= 5:
+            cs4 = (suf_off // suf_div4) % suf_shape4
+            vs += cs4 * val_suf_stride4
+        if SUF_NDIM >= 6:
+            cs5 = (suf_off // suf_div5) % suf_shape5
+            vs += cs5 * val_suf_stride5
+        for r in tl.static_range(0, IDX_PP):
+            pos = (pid0 - 1) * IDX_PP + r
+            ok = (pid0 > 0) & (pos >= 0) & (pos < idx_numel)
+            # Program 0 of axis 0 may be re-executed during Ascend lowering;
+            # masks on loads/atomics are not reliable in that re-execution, so
+            # keep every address valid (clamped) and force the added value to
+            # exactly zero with tl.where instead of relying on any mask.
+            pos_safe = tl.maximum(tl.minimum(pos, idx_numel - 1), 0)
+            self_base = tl.load(base_ptr + pos_safe)
+            val_base = tl.load(base_ptr + pos_safe + idx_numel)
+            row_mask = ok & mask_suf
+            self_off = self_base + suf_off
+            val_off = val_base + vs
+            v = tl.load(values_ptr + val_off)
+            if USE_SCRATCH:
+                v = v.to(target_ptr.dtype.element_ty)
+            v = tl.where(row_mask, v, tl.zeros((BLOCK_SUF,), dtype=v.dtype))
+            tl.atomic_add(target_ptr + self_off, v, sem="relaxed")
+    else:
+        # Plain stores: 2D tiles are efficient and re-executing program 0 is
+        # harmless (the same value is stored again).
+        suf_off2d = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]
+        mask_suf = suf_off2d < suffix_numel
+        vs2d = tl.zeros((1, BLOCK_SUF), dtype=tl.int32)
+        if SUF_NDIM >= 1:
+            cs0 = (suf_off2d // suf_div0) % suf_shape0
+            vs2d += cs0 * val_suf_stride0
+        if SUF_NDIM >= 2:
+            cs1 = (suf_off2d // suf_div1) % suf_shape1
+            vs2d += cs1 * val_suf_stride1
+        if SUF_NDIM >= 3:
+            cs2 = (suf_off2d // suf_div2) % suf_shape2
+            vs2d += cs2 * val_suf_stride2
+        if SUF_NDIM >= 4:
+            cs3 = (suf_off2d // suf_div3) % suf_shape3
+            vs2d += cs3 * val_suf_stride3
+        if SUF_NDIM >= 5:
+            cs4 = (suf_off2d // suf_div4) % suf_shape4
+            vs2d += cs4 * val_suf_stride4
+        if SUF_NDIM >= 6:
+            cs5 = (suf_off2d // suf_div5) % suf_shape5
+            vs2d += cs5 * val_suf_stride5
+        for b in tl.static_range(0, STORE_BPP):
+            idx_off2d = (pid0 * STORE_BPP + b) * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[
+                :, None
+            ]
+            mask_idx = idx_off2d < idx_numel
+            self_base = tl.load(base_ptr + idx_off2d, mask=mask_idx, other=0)
+            val_base = tl.load(base_ptr + idx_off2d + idx_numel, mask=mask_idx, other=0)
+            mask = mask_idx & mask_suf
+            self_off = self_base + suf_off2d
+            val_off = val_base + vs2d
+            v = tl.load(values_ptr + val_off, mask=mask, other=0)
+            tl.store(out_ptr + self_off, v, mask=mask)
+
+
+# ---------------------------------------------------------------------------
+# Host-side helpers
+# ---------------------------------------------------------------------------
+
+
+def _volume(shape):
+    n = 1
+    for s in shape:
+        n *= s
+    return n
+
+
+def _broadcast_shapes(shapes):
+    """Fast local replacement for torch.broadcast_shapes (no dispatch)."""
+    ndim = max(len(s) for s in shapes)
+    out = [1] * ndim
+    for shape in shapes:
+        pad = ndim - len(shape)
+        for i, s in enumerate(shape):
+            j = pad + i
+            if s != 1:
+                if out[j] == 1:
+                    out[j] = s
+                elif out[j] != s:
+                    raise RuntimeError(
+                        f"The size of tensor a ({out[j]}) must match the size of "
+                        f"tensor b ({s}) at non-singleton dimension {j}"
+                    )
+    return tuple(out)
+
+
+def _broadcast_strides(shape, stride, target_shape):
+    """Broadcast (shape, stride) into target_shape; 0 stride on expanded dims."""
+    ndim = len(target_shape)
+    pad = ndim - len(shape)
+    out = [0] * ndim
+    for i, s in enumerate(shape):
+        j = pad + i
+        if s == 1 and target_shape[j] != 1:
+            out[j] = 0
+        elif s != target_shape[j]:
+            raise RuntimeError(
+                f"The expanded size of the tensor ({target_shape[j]}) must match "
+                f"the existing size ({s}) at non-singleton dimension {i}."
+            )
+        else:
+            out[j] = stride[i]
+    return out
+
+
+def _trailing_divisors(shape):
+    ndim = len(shape)
+    div = [1] * ndim
+    acc = 1
+    for i in range(ndim - 1, -1, -1):
+        div[i] = acc
+        acc *= shape[i]
+    return div
+
+
+def _pad(seq, n, fill):
+    out = list(seq)
+    out.extend([fill] * (n - len(out)))
+    return out
+
+
+def _next_pow2(x):
+    v = 1
+    while v < x:
+        v *= 2
+    return v
+
+
+@lru_cache(maxsize=1024)
+def _store_meta(
+    device,
+    out_shape,
+    out_stride,
+    idx_key,
+    val_shape,
+    val_stride,
+    idx_shape,
+    suffix_shape,
+    m,
+):
+    """Small int32 kernel-parameter buffer, cached per exact shapes/strides."""
+    tensor_strides = [
+        _broadcast_strides(idx_key[i][0], idx_key[i][1], idx_shape) for i in range(m)
+    ]
+    ts = []
+    for i in range(m):
+        ts.extend(_pad(tensor_strides[i], _MAX_NDIM, 0))
+    ts = _pad(ts, _MAX_NDIM * _MAX_NDIM, 0)
+    val_strides = _broadcast_strides(
+        val_shape, val_stride, tuple(idx_shape) + tuple(suffix_shape)
+    )
+    idx_ndim = len(idx_shape)
+    vals = (
+        list(_pad(list(idx_shape), _MAX_NDIM, 1))
+        + list(_pad(_trailing_divisors(idx_shape), _MAX_NDIM, 1))
+        + ts
+        + list(_pad(val_strides[:idx_ndim], _MAX_NDIM, 0))
+        + list(_pad(list(out_stride[:m]), _MAX_NDIM, 0))
+        + list(_pad(list(out_shape[:m]), _MAX_NDIM, 1))
+        + list(_pad(list(suffix_shape), _MAX_NDIM, 1))
+        + list(_pad(_trailing_divisors(suffix_shape), _MAX_NDIM, 1))
+        + list(_pad(val_strides[idx_ndim:], _MAX_NDIM, 0))
+    )
+    return torch.tensor(vals, dtype=torch.int32, device=device)
+
+
+def _prep_block_config(idx_numel):
+    # block >= 2: a statically-1 block size crashes the Ascend lowering
+    block = max(2, min(_next_pow2(idx_numel), 1024))
+    blocks = triton.cdiv(idx_numel, block)
+    bpp = _next_pow2(triton.cdiv(blocks, 65535)) if blocks > 65535 else 1
+    return block, bpp
+
+
+def _store_block_config(idx_numel, suffix_numel):
+    """(BLOCK_IDX, BLOCK_SUF, STORE_BPP) for the store scatter path."""
+    # BLOCK_IDX <= 512: wider tiles overflow the unified buffer on Ascend.
+    # BLOCK_IDX >= 2: a statically-1 first tile dim crashes the Ascend
+    # lowering (SubViewOp offset inference).
+    block_idx = max(2, min(_next_pow2(idx_numel), 512))
+    block_suf = min(_next_pow2(suffix_numel), 256)
+    # keep the 2D tile small enough for the unified buffer
+    while block_idx * block_suf > 2048:
+        if block_idx >= block_suf:
+            block_idx //= 2
+        else:
+            block_suf //= 2
+    idx_blocks = triton.cdiv(idx_numel, block_idx)
+    # amortize the per-program meta loads over several idx blocks
+    store_bpp = min(8, _next_pow2(triton.cdiv(idx_blocks, 1024)))
+    # respect the 65535 program limit per grid axis via the block loop
+    if triton.cdiv(idx_numel, block_idx * store_bpp) > 65535:
+        store_bpp = _next_pow2(triton.cdiv(triton.cdiv(idx_numel, block_idx), 65535))
+    if triton.cdiv(suffix_numel, block_suf) > 65535:
+        block_suf = _next_pow2(triton.cdiv(suffix_numel, 65535))
+        if block_idx * block_suf > 8192:
+            return None
+    return block_idx, block_suf, store_bpp
+
+
+def _atomic_block_config(idx_numel, suffix_numel):
+    """(BLOCK_SUF, IDX_PP) for the accumulate scatter path (1D atomics)."""
+    block_suf = min(_next_pow2(suffix_numel), 512)
+    if triton.cdiv(suffix_numel, block_suf) > 65535:
+        block_suf = _next_pow2(triton.cdiv(suffix_numel, 65535))
+    if block_suf > 2048:
+        return None
+    idx_pp = 1
+    while triton.cdiv(idx_numel, idx_pp) + 1 > 65535:
+        idx_pp *= 2
+    if idx_pp > 16:
+        return None
+    return block_suf, idx_pp
+
+
+def _launch_prep(out, indices, meta, idx_shape, idx_numel):
+    m = len(indices)
+    idx_ndim = len(idx_shape)
+    kernel_idx = indices + [indices[0]] * (_MAX_NDIM - m)
+    base = torch.empty(idx_numel * 2, dtype=torch.int32, device=out.device)
+    block, bpp = _prep_block_config(idx_numel)
+    grid = (triton.cdiv(idx_numel, block * bpp),)
+    with torch_device_fn.device(out.device):
+        unsafe_index_put_prep_kernel[grid](
+            base,
+            *kernel_idx,
+            meta,
+            idx_numel,
+            M=m,
+            IDX_NDIM=idx_ndim,
+            BPP=bpp,
+            BLOCK=block,
+        )
+    return base
+
+
+def _launch_scatter(
+    out, values, target, base, meta, idx_numel, suffix_numel, suf_ndim, accumulate
+):
+    use_scratch = target is not out
+    if accumulate:
+        config = _atomic_block_config(idx_numel, suffix_numel)
+        if config is None:
+            return False
+        block_suf, idx_pp = config
+        grid = (
+            triton.cdiv(idx_numel, idx_pp) + 1,
+            triton.cdiv(suffix_numel, block_suf),
+        )
+        with torch_device_fn.device(out.device):
+            unsafe_index_put_scatter_kernel[grid](
+                out,
+                values,
+                target,
+                base,
+                meta,
+                idx_numel,
+                suffix_numel,
+                ACCUMULATE=True,
+                USE_SCRATCH=use_scratch,
+                STORE_BPP=1,
+                IDX_PP=idx_pp,
+                BLOCK_IDX=1,
+                BLOCK_SUF=block_suf,
+                SUF_NDIM=suf_ndim,
+            )
+    else:
+        config = _store_block_config(idx_numel, suffix_numel)
+        if config is None:
+            return False
+        block_idx, block_suf, store_bpp = config
+        grid = (
+            triton.cdiv(idx_numel, block_idx * store_bpp),
+            triton.cdiv(suffix_numel, block_suf),
+        )
+        with torch_device_fn.device(out.device):
+            unsafe_index_put_scatter_kernel[grid](
+                out,
+                values,
+                target,
+                base,
+                meta,
+                idx_numel,
+                suffix_numel,
+                ACCUMULATE=False,
+                USE_SCRATCH=use_scratch,
+                STORE_BPP=store_bpp,
+                IDX_PP=1,
+                BLOCK_IDX=block_idx,
+                BLOCK_SUF=block_suf,
+                SUF_NDIM=suf_ndim,
+            )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Operator entry point
+# ---------------------------------------------------------------------------
+
+
+def _unsafe_index_put(inp, indices, values, accumulate=False):
+    """_unsafe_index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+
+    Functional advanced indexing scatter. Returns a new tensor. Bool/byte
+    masks are expanded via nonzero; each of the first ``len(indices)`` dims
+    of ``self`` is indexed by the corresponding index tensor and the
+    remaining dims form the value suffix. ``unsafe`` means no upper bounds
+    checking is performed (negative indices wrap), matching PyTorch's
+    contract. accumulate=True uses atomic_add (with a widened scratch buffer
+    for dtypes without a supported Ascend atomic), so duplicate-index
+    summation order is arbitrary GPU scheduling; integer accumulation is
+    exact.
+    """
+    logger.debug("GEMS_ASCEND _UNSAFE_INDEX_PUT")
+
+    if torch.is_tensor(indices):
+        indices = [indices]
+    indices = list(indices)
+
+    if not indices:
+        raise ValueError("At least one index tensor is required")
+
+    # Device/dtype fixups mirroring aten's _index_put_impl_.
+    if values.device != inp.device:
+        if values.numel() == 1 and values.dim() == 0:
+            values = values.to(inp.device)
+        else:
+            raise RuntimeError(
+                f"Expected all tensors to be on the same device, but found at "
+                f"least two devices, {inp.device} and {values.device}!"
+            )
+    if values.dtype != inp.dtype:
+        raise RuntimeError(
+            f"Index put requires the source and destination dtypes match, got "
+            f"{inp.dtype} for the destination and {values.dtype} for the source."
+        )
+
+    # Index preprocessing: expand bool/byte masks, fix devices.
+    processed = []
+    for idx in indices:
+        if idx is None:
+            raise TypeError(
+                "_unsafe_index_put does not accept None indices "
+                "(expected Tensor, but got NoneType)"
+            )
+        if idx.device != inp.device:
+            idx = idx.to(inp.device)
+        if idx.dtype in (torch.bool, torch.uint8):
+            processed.extend(idx.nonzero(as_tuple=True))
+        elif idx.dtype in (torch.int32, torch.int64):
+            processed.append(idx)
+        else:
+            raise TypeError(
+                "tensors used as indices must be long, int, byte or bool tensors"
+            )
+
+    m = len(processed)
+    if m > inp.dim():
+        raise IndexError(f"too many indices for tensor of dimension {inp.dim()}")
+    if m > _MAX_NDIM:
+        raise IndexError(f"too many index tensors (max {_MAX_NDIM})")
+
+    suffix_shape = inp.shape[m:]
+    suf_ndim = len(suffix_shape)
+    if suf_ndim > _MAX_NDIM:
+        raise IndexError(f"suffix ndim out of range: {suf_ndim}")
+
+    idx_shape = _broadcast_shapes([t.shape for t in processed])
+    idx_ndim = len(idx_shape)
+    if idx_ndim > _MAX_NDIM:
+        raise IndexError(f"index space rank too large: {idx_ndim}")
+
+    idx_numel = _volume(idx_shape)
+    suffix_numel = _volume(suffix_shape)
+
+    # Cases outside the int32-offset Triton path (fp64 is not supported by
+    # the Ascend Triton backend at all): fall back to a CPU-native run.
+    if (
+        inp.dtype == torch.float64
+        or inp.numel() > _MAX_NUMEL
+        or idx_numel > _MAX_IDX_NUMEL
+        or suffix_numel > _MAX_NUMEL
+    ):
+        return _native_fallback(inp, indices, values, accumulate)
+
+    # Functional contract: the input is never modified. The scatter kernels
+    # require a contiguous output; clone preserves the input layout.
+    out = inp.clone()
+    if not out.is_contiguous():
+        out = out.contiguous()
+    if not values.is_contiguous():
+        values = values.contiguous()
+
+    if idx_numel == 0 or suffix_numel == 0:
+        return out
+
+    use_scratch = accumulate and out.dtype in _SCRATCH_DTYPES
+    if use_scratch:
+        # Native (unpatched on Ascend) full-tensor cast seeds the widened
+        # scratch; the epilogue cast-back rounds each element exactly once.
+        scratch = out.to(_SCRATCH_DTYPES[out.dtype])
+        target = scratch
+    else:
+        target = out
+
+    meta = _store_meta(
+        str(out.device),
+        tuple(out.shape),
+        tuple(out.stride()),
+        tuple((tuple(t.shape), tuple(t.stride())) for t in processed),
+        tuple(values.shape),
+        tuple(values.stride()),
+        tuple(idx_shape),
+        tuple(suffix_shape),
+        m,
+    )
+
+    base = _launch_prep(out, processed, meta, idx_shape, idx_numel)
+
+    if not _launch_scatter(
+        out, values, target, base, meta, idx_numel, suffix_numel, suf_ndim, accumulate
+    ):
+        # Extreme shapes beyond the Triton path: native fallback.
+        return _native_fallback(inp, indices, values, accumulate)
+
+    if use_scratch:
+        out.copy_(scratch)
+
+    return out

--- a/tests/test_unsafe_index_put.py
+++ b/tests/test_unsafe_index_put.py
@@ -7,9 +7,9 @@ import flag_gems
 from . import accuracy_utils as utils
 from . import conftest as cfg
 
-pytestmark = pytest.mark.skipif(
-    flag_gems.vendor_name == "sunrise", reason="Issues #3836: To Fix (Runtime Or LLVM)"
-)
+# pytestmark = pytest.mark.skipif(
+#     flag_gems.vendor_name == "sunrise", reason="Issues #3836: To Fix (Runtime Or LLVM)"
+# )
 
 
 if cfg.QUICK_MODE:

--- a/tests/test_unsafe_index_put.py
+++ b/tests/test_unsafe_index_put.py
@@ -1,0 +1,274 @@
+import numpy as np
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+pytestmark = pytest.mark.skipif(
+    flag_gems.vendor_name == "sunrise", reason="Issues #3836: To Fix (Runtime Or LLVM)"
+)
+
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    INT_DTYPES = [torch.int32]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    INT_DTYPES = [torch.int32, torch.int64, torch.int16, torch.int8, torch.uint8]
+
+ALL_INPUT_DTYPES = FLOAT_DTYPES + INT_DTYPES + [torch.bool]
+INDEX_DTYPES = [torch.int32, torch.int64]
+
+# Test shapes: (input_shape, [indices_shapes...], values_shape, accumulate)
+UNSAFE_INDEX_PUT_SHAPES = (
+    ((32,), ((8,),), (8,), False),
+    ((100,), ((100,),), (100,), True),
+    ((32, 32), ((8,), (8,)), (8,), False),
+    ((32, 32), ((8,), (2, 8)), (8,), False),
+    ((32, 32), ((2, 8),), (32,), False),
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), False),
+    ((100,), ((100,),), (100,), True),
+    ((32, 32), ((32, 32),), (32, 32, 32), True),
+    ((16, 16, 4), ((16,),), (16, 16, 4), False),
+)
+
+
+def _make_input(shape, dtype, device, is_float):
+    if dtype == torch.bool:
+        return torch.randint(0, 2, shape, device=device).to(torch.bool)
+    elif is_float:
+        return torch.randn(shape, dtype=dtype, device=device)
+    else:
+        return torch.randint(1, 10, shape, device=device).to(dtype)
+
+
+def _make_values(shape, dtype, device, is_float):
+    return _make_input(shape, dtype, device, is_float)
+
+
+def gen_indices(input_shape, indices_shapes, accumulate, device, dtype=torch.int64):
+    indices = []
+    for i, shape in enumerate(indices_shapes):
+        index = np.random.choice(
+            np.arange(input_shape[i]), size=shape, replace=accumulate
+        )
+        indices.append(torch.tensor(index, dtype=dtype, device=device))
+    return indices
+
+
+def assert_accumulate_close(res, ref, dtype):
+    """Assert helper for accumulate=True float tests.
+
+    With duplicate indices the summation order is implementation-defined:
+    PyTorch's CUDA kernel accumulates serially after a radix sort, while
+    FlagGems accumulates via fp32 atomic_add in arbitrary GPU scheduling
+    order. Both accumulate in fp32 and round to fp16/bf16 once, but fp32
+    reassociation noise can flip the final rounding by 1 ulp of the output
+    dtype. This is not an implementation defect — even PyTorch's own CPU vs
+    CUDA results bit-differ on essentially every run for this case — so the
+    tolerance must cover >=2 ulp. bf16's default rtol (0.016) already does;
+    fp16's (0.001) does not.
+    """
+    if dtype == torch.float16:
+        torch.testing.assert_close(res, ref, atol=1e-3, rtol=4e-3)
+    else:
+        utils.gems_assert_close(res, ref, dtype)
+
+
+# ---- Core dtype × index_dtype tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("inp_dtype", ALL_INPUT_DTYPES)
+@pytest.mark.parametrize("idx_dtype", INDEX_DTYPES)
+def test_unsafe_index_put_dtypes(inp_dtype, idx_dtype):
+    """Test all input and index dtype combinations."""
+    shape = (32, 32)
+    is_float = inp_dtype.is_floating_point
+
+    inp = _make_input(shape, inp_dtype, flag_gems.device, is_float)
+    indices = gen_indices(shape, [(2, 8)], False, flag_gems.device, idx_dtype)
+    values = _make_values((32,), inp_dtype, flag_gems.device, is_float)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    if is_float:
+        utils.gems_assert_close(res_out, ref_out, inp_dtype)
+    else:
+        utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Bool mask index tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("inp_dtype", ALL_INPUT_DTYPES)
+def test_unsafe_index_put_bool_mask_dtypes(inp_dtype):
+    """Test bool mask indices with all input dtypes."""
+    shape = (16, 16)
+    is_float = inp_dtype.is_floating_point
+
+    inp = _make_input(shape, inp_dtype, flag_gems.device, is_float)
+    mask = torch.randint(0, 2, (16,), dtype=torch.bool, device=flag_gems.device)
+    K = mask.sum().item()
+    if K == 0:
+        pytest.skip("empty bool mask")
+    values = _make_values((K, 16), inp_dtype, flag_gems.device, is_float)
+
+    ref_inp = utils.to_reference(inp)
+    ref_mask = utils.to_reference(mask)
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, [ref_mask], ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, [mask], values, False)
+
+    if is_float:
+        utils.gems_assert_close(res_out, ref_out, inp_dtype)
+    else:
+        utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Shape parametrized tests (floats) ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize(
+    "input_shape, indices_shapes, values_shape, accumulate",
+    UNSAFE_INDEX_PUT_SHAPES,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_shapes(
+    input_shape, indices_shapes, values_shape, accumulate, dtype
+):
+    inp = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
+    indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
+    values = torch.randn(values_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, accumulate)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, accumulate)
+        # res_out = torch._unsafe_index_put(inp, indices, values, accumulate)
+
+    if accumulate:
+        assert_accumulate_close(res_out, ref_out, dtype)
+    else:
+        utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# ---- Integer shape tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize(
+    "input_shape, indices_shapes, values_shape, accumulate",
+    UNSAFE_INDEX_PUT_SHAPES[:5],
+)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_unsafe_index_put_int_shapes(
+    input_shape, indices_shapes, values_shape, accumulate, dtype
+):
+    inp = torch.randint(1, 10, input_shape, device=flag_gems.device).to(dtype)
+    indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
+    values = torch.randint(1, 10, values_shape, device=flag_gems.device).to(dtype)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, accumulate)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, accumulate)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Specific behavior tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_negative_indices(dtype):
+    inp = torch.randn((32, 64), dtype=dtype, device=flag_gems.device)
+    indices = [torch.tensor([-1, -5, -10], device=flag_gems.device)]
+    values = torch.randn((3, 64), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.unsafe_index_put
+def test_unsafe_index_put_functional():
+    inp = torch.randn((32, 32), device=flag_gems.device)
+    inp_copy = inp.clone()
+    indices = [torch.randint(0, 32, (8,), device=flag_gems.device)]
+    values = torch.randn((8, 32), device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        out = torch._unsafe_index_put(inp, indices, values, False)
+
+    assert torch.equal(inp, inp_copy), "Input tensor was modified"
+    assert not torch.equal(out, inp), "Output should differ from input"
+
+
+@pytest.mark.unsafe_index_put
+def test_unsafe_index_put_scalar_value():
+    inp = torch.randn((16, 16), device=flag_gems.device)
+    indices = [torch.tensor([0, 5, 10], device=flag_gems.device)]
+    values = torch.tensor(3.14, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_accumulate(dtype):
+    inp = torch.randn((32, 32), dtype=dtype, device=flag_gems.device)
+    indices = [torch.randint(0, 32, (64,), device=flag_gems.device)]
+    values = torch.randn((64, 32), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, True)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, True)
+
+    assert_accumulate_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_unsafe_index_put_int_accumulate(dtype):
+    inp = torch.randint(1, 5, (32, 32), device=flag_gems.device).to(dtype)
+    indices = [torch.randint(0, 32, (64,), device=flag_gems.device)]
+    values = torch.randint(1, 5, (64, 32), device=flag_gems.device).to(dtype)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, True)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, True)
+
+    utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
 Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add _unsafe_index_put op in triton
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
nv:
```bash
root@741314c552f8:/workspace/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.5.0, anyio-4.12.1, hypothesis-6.130.8, flakefinder-1.1.0, rerunfailures-16.1, shard-0.1.2, xdist-3.8.0
collected 4 items
Running 4 items in this shard

benchmark/test_unsafe_index_put.py
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007552            0.008448               0.894          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010528            0.008864               1.188          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.321760            0.270464               1.190          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.008896            0.008992               0.989          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009728            0.009744               0.998          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.011264            0.010624               1.060          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011520            0.011552               0.997          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.033632            0.031232               1.077          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.007968            0.010240               0.778          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.010976            0.010368               1.059          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009728            0.011200               0.869          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013472            0.011104               1.213          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.028416            0.026304               1.080          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009088            0.012192               0.745          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.150048            0.138320               1.085          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.153760            0.139328               1.104          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.601408            0.836672               0.719          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.027296            0.026048               1.048          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.027680            0.026048               1.063          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007392            0.008128               0.909          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010752            0.009152               1.175          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.663248            0.560848               1.183          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009120            0.009184               0.993          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009376            0.009504               0.987          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.012064            0.011136               1.083          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.012480            0.012480               1.000          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.051360            0.048352               1.062          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008032            0.010336               0.777          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009696            0.010624               0.913          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.010752            0.011168               0.963          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013568            0.011616               1.168          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.046240            0.042848               1.079          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009440            0.012320               0.766          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.340592            0.283680               1.201          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.314528            0.272544               1.154          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.735712            0.965632               0.762          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.045408            0.042432               1.070          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045376            0.042432               1.069          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007744            0.008608               0.900          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010848            0.009504               1.141          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.156544            1.044192               1.108          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009280            0.009376               0.990          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009632            0.010432               0.923          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014464            0.014016               1.032          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.014688            0.014976               0.981          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.085888            0.079584               1.079          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008096            0.010496               0.771          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009920            0.010624               0.934          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.013088            0.013248               0.988          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.015360            0.013472               1.140          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.080512            0.074048               1.087          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.010176            0.012608               0.807          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.606112            0.546688               1.109          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.587184            0.544640               1.078          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.050048            1.220448               0.860          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.080000            0.073504               1.088          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.080288            0.074048               1.084          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007520            0.008384               0.897          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010624            0.009248               1.149          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.316640            0.270784               1.169          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009088            0.009280               0.979          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009696            0.009792               0.990          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.011104            0.010688               1.039          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011456            0.011424               1.003          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.033600            0.031200               1.077          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008032            0.010400               0.772          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009344            0.010496               0.890          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009792            0.010976               0.892          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013440            0.011296               1.190          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.028576            0.026304               1.086          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009088            0.013120               0.693          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.148864            0.138240               1.077          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.153888            0.139136               1.106          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.601232            0.837408               0.718          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.027360            0.026112               1.048          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.027648            0.025920               1.067          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007328            0.008224               0.891          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010624            0.009344               1.137          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.566880            0.530688               1.068          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009056            0.009472               0.956          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009792            0.010240               0.956          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.012096            0.011520               1.050          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.012544            0.012512               1.003          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.051456            0.048416               1.063          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008064            0.010912               0.739          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009376            0.010976               0.854          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.010752            0.011680               0.921          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013568            0.011840               1.146          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.046400            0.042944               1.080          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009440            0.012384               0.762          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.288928            0.269280               1.073          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.294400            0.269696               1.092          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.733440            0.964592               0.760          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.045376            0.042624               1.065          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045632            0.042624               1.071          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007648            0.008800               0.869          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010784            0.009408               1.146          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.122848            1.035104               1.085          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009280            0.009216               1.007          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009632            0.010400               0.926          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014528            0.013984               1.039          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.014752            0.014944               0.987          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.086016            0.079456               1.083          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008096            0.010176               0.796          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009856            0.010208               0.966          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.013120            0.013248               0.990          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.016704            0.013504               1.237          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.080576            0.073792               1.092          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.010144            0.013472               0.753          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.564960            0.520960               1.084          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.570304            0.520560               1.096          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.017616            1.219840               0.834          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.080032            0.073376               1.091          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.080000            0.073952               1.082          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.037600            0.030752               1.223          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071168            0.032736               2.174          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.066080            0.035904               1.840          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.066976            0.037440               1.789          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.067264            0.036640               1.836          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.110208            0.039808               2.768          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.222848            0.147536               1.510          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.224128            0.150784               1.486          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.037696            0.008928               4.222          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.070720            0.010752               6.577          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.067200            0.010944               6.140          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.066976            0.013056               5.130          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.067712            0.012672               5.343          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.108672            0.012384               8.775          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.362320            0.271808               1.333          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.365280            0.274208               1.332          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.038016            0.008832               4.304          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.073056            0.011104               6.579          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.067984            0.011312               6.010          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.067744            0.012608               5.373          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.068416            0.014592               4.689          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.109536            0.013536               8.092          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.719216            0.545280               1.319          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.710576            0.550080               1.292          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.037280            0.031568               1.181          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071104            0.032560               2.184          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.066656            0.035328               1.887          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.066912            0.037120               1.803          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.067488            0.036672               1.840          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.109504            0.038880               2.816          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.223104            0.145920               1.529          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.224256            0.148640               1.509          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.037568            0.009088               4.134          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.070528            0.010496               6.720          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.067456            0.011328               5.955          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.067184            0.012448               5.397          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.067744            0.012768               5.306          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.109888            0.012736               8.628          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.362624            0.270368               1.341          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.365184            0.271696               1.344          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.038208            0.008864               4.310          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.069824            0.011104               6.288          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.067712            0.011328               5.977          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.067872            0.012704               5.343          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.068384            0.014592               4.686          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.109632            0.013728               7.986          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.637696            0.522656               1.220          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.638368            0.523808               1.219          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.

========================================================================================= 4 passed in 255.99s (0:04:15) =========================================================================================

ascend:

root@bm-ctyun-wq-910b-64g-0-13:/home/secure/lgw/unsafe_index_put/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.11.13, pytest-8.3.2, pluggy-1.6.0
rootdir: /home/secure/lgw/unsafe_index_put/FlagGems
configfile: pytest.ini
plugins: timeout-2.4.0, xdist-3.6.1, anyio-4.10.0
collected 4 items

Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.398100           11.210133               1.017          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS              16.496933          112.920267               0.146          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS             641.842800          497.323200               1.291          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               4.381400            6.696200               0.654          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               9.181567           46.820933               0.196          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               7.281467           15.983533               0.456          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               7.919367           61.927867               0.128          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS              13.342233          145.226967               0.092          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               6.782167            2.914767               2.327          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS             100.946067            4.524767              22.310          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               8.752867            9.948833               0.880          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              58.507167           39.956800               1.464          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS              16.932367           36.532100               0.463          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               6.720833            4.942133               1.360          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS             222.489833          162.773967               1.367          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             285.325000          188.051733               1.517          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             496.376633        18984.909500               0.026          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS              16.576900           15.611667               1.062          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              16.314967           19.447000               0.839          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              12.426933           10.754933               1.155          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS              14.918267          113.161667               0.132          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS            1062.692733          782.390967               1.358          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               4.500033            6.703500               0.671          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               9.568867           46.920300               0.204          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               7.958867           16.263033               0.489          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS             267.762667          128.413933               2.085          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS              44.814167          175.934167               0.255          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               6.577400            2.820700               2.332          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS              97.953300            4.478800              21.870          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               8.791467           10.268900               0.856          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              58.439100           40.256800               1.452          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS              62.116433           67.338633               0.922          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               7.613433            4.970100               1.532          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS             435.042800          304.816100               1.427          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             497.112533          330.941867               1.502          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             726.209767        19006.919500               0.038          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS              62.503933           46.753667               1.337          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              61.303933           49.705800               1.233          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.237533           10.912267               1.030          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS              16.129667          110.870900               0.145          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS             662.508600          497.454633               1.332          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               4.438733            6.693533               0.663          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               9.794100           46.774867               0.209          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               7.928100           15.857100               0.500          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               8.656800           61.807200               0.140          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS              14.737633          145.166200               0.102          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               7.162167            2.759400               2.596          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS              98.826033            4.570767              21.621          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               9.346867            9.918900               0.942          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              61.246533           40.104167               1.527          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS              17.554433           36.842833               0.476          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               7.591533            4.934100               1.539          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS             222.394400          162.187867               1.371          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             280.531000          186.498333               1.504          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             572.032733        18986.609500               0.030          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS              52.816467           32.889233               1.606          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              16.873667           19.753067               0.854          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              10.131467           11.048800               0.917          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS              15.138333          111.537000               0.136          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS            1067.133933          783.562300               1.362          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               4.553467            6.820833               0.668          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               9.510200           46.943300               0.203          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               8.090100           16.488233               0.491          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               8.660033           62.869067               0.138          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS              43.941533          171.043367               0.257          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               6.896167            2.726700               2.529          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS              98.552000            4.485500              21.971          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               8.796067           10.312833               0.853          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              65.192033           40.324167               1.617          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS              56.458433           63.806600               0.885          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               6.889533            4.996133               1.379          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS             435.185300          305.428133               1.425          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             496.291867          328.456633               1.511          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             738.246000        19001.550000               0.039          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS              57.704400           42.934133               1.344          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              62.708633           51.381033               1.220          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              67.203300           11.470233               5.859          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS              89.039900          115.619633               0.770          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS            1887.808348         1324.324591               1.425          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               6.562767            7.802767               0.841          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS             100.622700           35.458667               2.838          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS              97.595267           19.873700               4.911          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS             120.291033           75.668833               1.590          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS             323.967867          246.807667               1.313          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS              12.688967            2.908667               4.362          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS             100.472100            4.691400              21.416          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS             523.622500           11.467667              45.661          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS              68.995967           41.774933               1.652          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS             166.634767          105.218800               1.584          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS              52.904367            5.238067              10.100          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS             915.817600          591.142367               1.549          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS             922.292400          619.529633               1.489          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS           20531.070000        22084.901000               0.930          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS             165.302567           83.817100               1.972          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS             172.581467           86.805600               1.988          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.628767            7.587467               0.610          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS              23.751767           56.532400               0.420          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               2.844000            1.832700               1.552          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               5.586100           23.943800               0.233          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               5.949567           43.840200               0.136          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               5.893467            3.816133               1.544          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS             114.715000          359.837867               0.319          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS             114.313633          372.517467               0.307          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              12.948967           12.972900               0.998          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS              86.670267           98.478000               0.880          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               7.272800            2.374000               3.064          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS              10.566900           36.332700               0.291          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS            5140.652900           68.526100              75.017          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               7.622067            4.502800               1.693          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS             437.399367          299.315333               1.461          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS             503.883367          410.225533               1.228          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.610800            7.662867               0.602          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS              24.314500           56.908433               0.427          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS              13.640267            1.957333               6.969          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               5.558767           23.484433               0.237          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               8.198867           43.808233               0.187          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               6.469400            3.913400               1.653          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS            1470.908667          360.123200               4.084          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS             515.954300          374.441500               1.378          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              12.246933           35.344600               0.347          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS              85.621700           99.354633               0.862          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               7.288800            2.237333               3.258          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS              10.546000           36.347367               0.290          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS              11.268133           68.208133               0.165          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               7.707533            4.604867               1.674          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS             436.997400          298.711333               1.463          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS             437.014767          318.416333               1.372          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              18.908333           79.084933               0.239          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS             197.835200         1779.336360               0.111          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS              12.914967            7.126067               1.812          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS              79.314233          125.131800               0.634          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS             109.158833          209.977600               0.520          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS              45.084833           13.247567               3.403          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS             940.340067          643.058767               1.462          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS             938.156067          684.756400               1.370          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

thead:

(venv) root@dsw-910739-597bfb889f-tcggv:~/lgw/FlagGems# pytest tests/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-7.2.0, pluggy-1.3.0
rootdir: /root/lgw/FlagGems, configfile: pytest.ini
plugins: xdist-3.6.1, hypothesis-6.103.4, anyio-4.12.1
collected 92 items

tests/test_unsafe_index_put.py ............................................................................................

============================================================================================== 92 passed in 34.92s ==============================================================================================
(venv) root@dsw-910739-597bfb889f-tcggv:~/lgw/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-7.2.0, pluggy-1.3.0
rootdir: /root/lgw/FlagGems, configfile: pytest.ini
plugins: xdist-3.6.1, hypothesis-6.103.4, anyio-4.12.1
collected 4 items

benchmark/test_unsafe_index_put.py
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005540            0.004240               1.307          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009360            0.005200               1.800          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.544640            0.538880               1.011          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007680            0.006120               1.255          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008280            0.006600               1.255          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.011320            0.008920               1.269          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011280            0.009840               1.146          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.063400            0.060220               1.053          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004480               1.330          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007800            0.005440               1.434          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009040            0.007920               1.141          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013560            0.009760               1.389          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.059240            0.055400               1.069          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.007200            0.006600               1.091          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.280680            0.277480               1.012          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.286740            0.279500               1.026          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.665800            0.860080               0.774          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.057360            0.054640               1.050          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.057840            0.055600               1.040          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005520            0.004480               1.232          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009520            0.005400               1.763          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.052360            1.032780               1.019          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007800            0.005880               1.327          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008520            0.006840               1.246          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014920            0.012200               1.223          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.015200            0.013200               1.152          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.095720            0.090000               1.064          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004680               1.274          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007880            0.005440               1.449          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.012560            0.011240               1.117          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017200            0.013000               1.323          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.091440            0.085000               1.076          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.008160            0.007520               1.085          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.536160            0.523440               1.024          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.541120            0.525760               1.029          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.921320            1.105940               0.833          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.089720            0.084640               1.060          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.090140            0.085520               1.054          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005520            0.004920               1.122          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009480            0.006120               1.549          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               2.093280            2.043880               1.024          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007800            0.006120               1.275          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008640            0.007760               1.113          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.021480            0.018200               1.180          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.021920            0.019440               1.128          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.159600            0.152640               1.046          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004960               1.202          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007880            0.005880               1.340          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.019160            0.017280               1.109          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.023600            0.019120               1.234          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.155400            0.147360               1.055          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009520            0.009440               1.008          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.043720            1.020120               1.023          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.049680            1.022200               1.027          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.431200            1.608880               0.890          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.153040            0.147400               1.038          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.153460            0.148280               1.035          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005480            0.004480               1.223          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009440            0.005400               1.748          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.545080            0.538760               1.012          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007600            0.005880               1.293          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008120            0.006560               1.238          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.011320            0.009000               1.258          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011360            0.010040               1.131          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.063440            0.060280               1.052          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004480               1.330          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007840            0.005440               1.441          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009040            0.008000               1.130          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013480            0.009800               1.376          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.059240            0.055360               1.070          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.007200            0.006600               1.091          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.280960            0.277600               1.012          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.287200            0.279560               1.027          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.665760            0.860060               0.774          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.057400            0.054680               1.050          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.057840            0.055560               1.041          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005520            0.004480               1.232          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009480            0.005440               1.743          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.054400            1.031900               1.022          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007840            0.006080               1.289          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008640            0.006840               1.263          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014880            0.012160               1.224          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.015160            0.013200               1.148          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.096320            0.090120               1.069          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004720               1.263          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007880            0.005640               1.397          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.012600            0.011240               1.121          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017160            0.013040               1.316          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.092200            0.085200               1.082          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.008160            0.007520               1.085          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.535600            0.523720               1.023          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.541080            0.525920               1.029          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.920880            1.105960               0.833          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.089880            0.084520               1.063          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.090360            0.085640               1.055          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005520            0.004960               1.113          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.009480            0.006120               1.549          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               2.080040            2.043800               1.018          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.007880            0.006360               1.239          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.008760            0.007960               1.101          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.021400            0.018240               1.173          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.022000            0.019440               1.132          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.159400            0.152800               1.043          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.005960            0.004960               1.202          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.007840            0.005880               1.333          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.019120            0.017320               1.104          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.023760            0.019080               1.245          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.155240            0.147560               1.052          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009480            0.009440               1.004          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.046200            1.019660               1.026          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.049560            1.022320               1.027          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.433800            1.609120               0.891          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.153000            0.147400               1.038          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.153680            0.148360               1.036          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.046480            0.009240               5.030          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.076260            0.013040               5.848          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.065440            0.008800               7.436          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.073080            0.013240               5.520          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.076440            0.016680               4.583          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.088520            0.011600               7.631          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.369160            0.283080               1.304          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.369580            0.288640               1.280          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.046000            0.004720               9.746          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.076240            0.006560              11.622          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.065120            0.004480              14.536          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.073600            0.007960               9.246          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.079080            0.013160               6.009          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.089160            0.006600              13.509          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.624240            0.523120               1.193          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.623780            0.526640               1.184          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.047240            0.004960               9.524          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.077720            0.007320              10.617          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.066040            0.004720              13.992          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.075360            0.009680               7.785          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.086080            0.019200               4.483          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.090880            0.008480              10.717          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.140600            1.019920               1.118          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.131120            1.023160               1.106          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.046240            0.009400               4.919          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.076080            0.013400               5.678          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.065560            0.009040               7.252          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.073240            0.013480               5.433          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.075800            0.016840               4.501          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.088720            0.011840               7.493          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.369220            0.283200               1.304          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.369560            0.288800               1.280          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.046120            0.004720               9.771          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.076280            0.006800              11.218          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.065280            0.004480              14.571          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.073480            0.008000               9.185          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.079040            0.013160               6.006          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.089440            0.006600              13.552          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.624320            0.523260               1.193          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.625400            0.526600               1.188          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.046440            0.004960               9.363          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.077200            0.007520              10.266          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.065760            0.004920              13.366          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.075640            0.009840               7.687          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.086120            0.019240               4.476          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.091160            0.008480              10.750          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.132400            1.019720               1.111          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.135520            1.022920               1.110          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.

========================================================================================= 4 passed in 251.71s (0:04:11) =========================================================================================

hygon:

(venv) root@f218d3e1644e:~/lgw/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /root/lgw/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 4 items                                                                                                                                                                                                         

benchmark/test_unsafe_index_put.py 
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.031840               0.437          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017120            0.011360               1.507          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.780002            0.862401               2.064          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.015840            0.012320               1.286          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.016640            0.012480               1.333          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.021120            0.013120               1.610          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.021760            0.015680               1.388          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.132321            0.072320               1.830          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014400            0.015520               0.928          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018240            0.011680               1.562          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.019040            0.019200               0.992          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.024480            0.018400               1.330          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.123520            0.059680               2.070          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.015200            0.018880               0.805          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.889121            0.427361               2.080          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.899041            0.428161               2.100          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.500802            1.439042               1.043          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.122400            0.059200               2.068          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.124961            0.059680               2.094          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.011360               1.225          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017120            0.011520               1.486          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.531684            1.785282               1.978          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.015840            0.015200               1.042          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.016800            0.012800               1.312          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.028000            0.015360               1.823          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.028960            0.017760               1.631          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.242880            0.129120               1.881          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014400            0.018400               0.783          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018240            0.019520               0.934          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.026080            0.017760               1.468          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.031520            0.021920               1.438          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.233440            0.116480               2.004          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.015680            0.021120               0.742          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.764802            0.885601               1.993          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.774883            0.885761               2.004          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.379523            2.872164               0.828          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.232000            0.115680               2.006          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.234720            0.115920               2.025          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.011200               1.243          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017280            0.011520               1.500          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               7.034569            3.691044               1.906          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.016000            0.011840               1.351          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.017120            0.012800               1.338          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.042081            0.021440               1.963          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.043360            0.024320               1.783          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.462880            0.247200               1.872          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014400            0.017760               0.811          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018240            0.014880               1.226          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.039680            0.021440               1.851          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045280            0.021600               2.096          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.452480            0.234240               1.932          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.019520            0.024160               0.808          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               3.515524            1.847522               1.903          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.526404            1.847843               1.908          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               4.149925            5.766567               0.720          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.450881            0.233600               1.930          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.453760            0.233760               1.941          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.011200               1.243          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017120            0.011520               1.486          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.780323            0.862881               2.063          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.015840            0.015360               1.031          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.016640            0.012320               1.351          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.020960            0.013120               1.598          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.021760            0.016640               1.308          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.132480            0.072400               1.830          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014400            0.018080               0.796          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018240            0.018880               0.966          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.019040            0.018400               1.035          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.024480            0.018240               1.342          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.123680            0.059680               2.072          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.015200            0.024320               0.625          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.888961            0.427521               2.079          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.899201            0.428321               2.099          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.500962            1.439362               1.043          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.122400            0.059200               2.068          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.124960            0.059680               2.094          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.011200               1.243          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017120            0.011680               1.466          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.531925            1.792962               1.970          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.015840            0.011840               1.338          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.016640            0.012480               1.333          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.028160            0.016800               1.676          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.028960            0.017760               1.631          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.242880            0.129120               1.881          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014400            0.015200               0.947          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018240            0.018560               0.983          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.026080            0.022080               1.181          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.031520            0.017600               1.791          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.233440            0.116480               2.004          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.016000            0.020960               0.763          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.764802            0.886081               1.992          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.775042            0.886081               2.003          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.379523            2.865924               0.830          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.232000            0.115680               2.006          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.234721            0.115680               2.029          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013920            0.011200               1.243          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.017280            0.011520               1.500          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               7.034568            3.707045               1.898          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.016000            0.015840               1.010          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.017120            0.016480               1.039          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.042080            0.021440               1.963          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.043360            0.024320               1.783          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.463041            0.247360               1.872          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.014561            0.036640               0.397          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.018560            0.040800               0.455          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.039680            0.040320               0.984          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045280            0.042720               1.060          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.452480            0.234241               1.932          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.019520            0.044160               0.442          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               3.516164            1.848002               1.903          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.525684            1.848963               1.907          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               4.150725            5.765847               0.720          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.450881            0.233521               1.931          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.453760            0.233920               1.940          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.116480            0.093200               1.250          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.147040            0.098080               1.499          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.297441            0.102400               2.905          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.338241            0.109280               3.095          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.248001            0.111520               2.224          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.425600            0.112000               3.800          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.038881            0.438721               2.368          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.038641            0.441281               2.354          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.103280            0.036160               2.856          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.137280            0.034720               3.954          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.345280            0.039200               8.808          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.258400            0.044000               5.873          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.253440            0.044800               5.657          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.436161            0.050560               8.627          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.917602            0.885761               2.165          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.915362            0.886561               2.160          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.104960            0.034880               3.009          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.125600            0.033281               3.774          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.350001            0.037120               9.429          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.234961            0.045440               5.171          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.248961            0.042880               5.806          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.379201            0.045280               8.375          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               3.667525            1.847682               1.985          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               3.660805            1.848963               1.980          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.098320            0.095520               1.029          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.126560            0.097840               1.294          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.304560            0.102560               2.970          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.328160            0.110240               2.977          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.249440            0.106800               2.336          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.413281            0.109760               3.765          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.038561            0.438720               2.367          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.035522            0.441121               2.347          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.090880            0.030240               3.005          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.130240            0.031680               4.111          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.341280            0.036160               9.438          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.245440            0.040800               6.016          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.239120            0.043360               5.515          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.333280            0.037600               8.864          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.910563            0.884881               2.159          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.903762            0.886721               2.147          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.072800            0.024960               2.917          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.120640            0.031600               3.818          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.286721            0.034720               8.258          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.208240            0.039040               5.334          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.202081            0.036000               5.613          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.326800            0.042400               7.708          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               3.663845            1.848802               1.982          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               3.650244            1.850242               1.973          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

metax:

root@bm-zksg-wx-zone1-d-mc550-64g-2-120:/data/lgw/FlagGems# pytest tests/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.11, pytest-9.1.1, pluggy-1.6.0
rootdir: /data/lgw/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdist-3.8.0
collected 92 items

tests/test_unsafe_index_put.py ............................................................................................

=============================================================================================== warnings summary ================================================================================================
src/flag_gems/utils/libentry.py:411
  /data/lgw/FlagGems/src/flag_gems/utils/libentry.py:411: RuntimeWarning: active Triton backend does not provide a replay benchmarker; falling back to event timing
    resolved_benchmark = resolve_benchmarker(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 92 passed, 1 warning in 21.01s =========================================================================================
root@bm-zksg-wx-zone1-d-mc550-64g-2-120:/data/lgw/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.11, pytest-9.1.1, pluggy-1.6.0
rootdir: /data/lgw/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdist-3.8.0
collected 4 items

benchmark/test_unsafe_index_put.py
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016128            0.017536               0.920          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019200            0.017408               1.103          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.920576            0.871168               1.057          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.019968            0.017920               1.114          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.022272            0.022016               1.012          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.049920            0.022784               2.191          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.050688            0.038400               1.320          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.108032            0.110592               0.977          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.016896            0.019200               0.880          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019712            0.018176               1.085          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.046080            0.019968               2.308          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.051200            0.020992               2.439          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.095232            0.061952               1.537          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.024320            0.018944               1.284          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.417664            0.374272               1.116          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.423680            0.375552               1.128          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.529344            5.049088               0.303          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.094208            0.062208               1.514          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.098304            0.063232               1.555          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016384            0.017920               0.914          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019200            0.018432               1.042          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.655040            1.592320               1.039          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.019968            0.019200               1.040          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.024576            0.023040               1.067          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.057344            0.026880               2.133          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.057600            0.041216               1.398          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.153344            0.157440               0.974          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.017408            0.018304               0.951          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019712            0.018688               1.055          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.053504            0.024320               2.200          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.058880            0.025088               2.347          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.141056            0.108032               1.306          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.031744            0.020736               1.531          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.780032            0.737024               1.058          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.788864            0.738560               1.068          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.891200            5.453824               0.347          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.139776            0.108288               1.291          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.144128            0.109056               1.322          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016640            0.019456               0.855          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019456            0.020224               0.962          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.125248            3.100160               1.008          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.020224            0.020736               0.975          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.028160            0.025344               1.111          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.063232            0.032000               1.976          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.064000            0.047360               1.351          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.247040            0.259584               0.952          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.017152            0.019968               0.859          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019712            0.020224               0.975          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.059136            0.029440               2.009          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.064512            0.030464               2.118          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.234368            0.207360               1.130          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.046592            0.022784               2.045          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.515520            1.464576               1.035          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.524224            1.465856               1.040          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.649088            6.284288               0.422          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.232448            0.202240               1.149          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.236544            0.203008               1.165          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016640            0.017280               0.963          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019200            0.017408               1.103          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.924416            0.874496               1.057          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.020224            0.018432               1.097          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.022272            0.022016               1.012          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.050176            0.022528               2.227          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.050688            0.038400               1.320          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.107776            0.110592               0.975          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.017152            0.017152               1.000          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019712            0.017920               1.100          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.046336            0.019968               2.321          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.051456            0.020736               2.481          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.095488            0.061952               1.541          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.024320            0.018944               1.284          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.417536            0.374528               1.115          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.423936            0.375552               1.129          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.528576            5.046016               0.303          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.094720            0.062208               1.523          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.098560            0.063232               1.559          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016640            0.017920               0.929          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019456            0.018432               1.056          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.657088            1.597952               1.037          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.020224            0.019200               1.053          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.024320            0.023296               1.044          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.057088            0.026624               2.144          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.058112            0.041472               1.401          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.153856            0.157952               0.974          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.016896            0.018176               0.930          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019712            0.018688               1.055          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.053504            0.024064               2.223          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.059136            0.025088               2.357          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.141568            0.108032               1.310          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.031744            0.020736               1.531          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.780032            0.737280               1.058          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.787968            0.738304               1.067          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.891328            5.456896               0.347          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.140800            0.107776               1.306          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.144640            0.108800               1.329          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.016640            0.019456               0.855          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.019456            0.019968               0.974          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.125504            3.071872               1.017          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.020224            0.020736               0.975          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.028416            0.025344               1.121          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.063232            0.032256               1.960          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.064256            0.047104               1.364          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.246784            0.258560               0.954          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.017152            0.019968               0.859          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.019968            0.020224               0.987          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.059520            0.029696               2.004          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.064512            0.029952               2.154          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.234240            0.206336               1.135          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.046336            0.022784               2.034          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.512192            1.473536               1.026          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.523456            1.490560               1.022          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.647296            6.316544               0.419          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.232192            0.201984               1.150          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.236288            0.201984               1.170          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.072192            0.023552               3.065          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.137984            0.024832               5.557          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094208            0.024576               3.833          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.121344            0.027392               4.430          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.152320            0.030208               5.042          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.133888            0.028160               4.755          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.540544            0.384512               1.406          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.545536            0.388096               1.406          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.071936            0.017920               4.014          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.137728            0.018432               7.472          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094208            0.017920               5.257          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.128768            0.019456               6.618          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.159232            0.024576               6.479          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.140800            0.019840               7.097          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.904704            0.736000               1.229          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.909568            0.737024               1.234          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.072192            0.019200               3.760          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.141824            0.019968               7.103          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094976            0.019456               4.882          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.143616            0.021504               6.679          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.166912            0.029952               5.573          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.155136            0.022272               6.966          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.641472            1.467136               1.119          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.645056            1.468160               1.120          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.072448            0.023296               3.110          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.137472            0.024832               5.536          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094464            0.024064               3.926          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.121088            0.027392               4.421          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.152320            0.030208               5.042          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.133632            0.028416               4.703          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.541952            0.384000               1.411          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.547328            0.387840               1.411          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.071936            0.017664               4.072          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.137728            0.018432               7.472          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094464            0.017920               5.271          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.128768            0.019200               6.707          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.159744            0.024320               6.568          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.140800            0.019968               7.051          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.904704            0.735744               1.230          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.909440            0.737280               1.234          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.072192            0.019200               3.760          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.140544            0.019968               7.038          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.094464            0.019456               4.855          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.143872            0.021504               6.690          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.166656            0.029952               5.564          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.155904            0.022016               7.081          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               1.638912            1.500416               1.092          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               1.644032            1.502592               1.094          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

iluvatar:

(venv) root@57deda95280a:~/lgw/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.10.18, pytest-9.0.2, pluggy-1.6.0
rootdir: /root/lgw/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.1
collected 4 items                                                                                                                                                                                                  

benchmark/test_unsafe_index_put.py 
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.012327            0.008192               1.505          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.015365            0.008942               1.718          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.901077            1.936116               0.982          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.012673            0.008981               1.411          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.020173            0.015635               1.290          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.027308            0.022250               1.227          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.029904            0.034038               0.879          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.163385            0.172673               0.946          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.011385            0.008442               1.349          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014269            0.009115               1.565          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.021308            0.019538               1.091          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.025269            0.020500               1.233          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.143154            0.138346               1.035          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.016269            0.012808               1.270          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.936481            0.953038               0.983          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.944135            0.953250               0.990          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.307500            4.973019               0.464          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.141750            0.138731               1.022          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.141038            0.139500               1.011          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011769            0.008423               1.397          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.014712            0.009365               1.571          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.739692            3.800096               0.984          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.012827            0.009519               1.347          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.020731            0.016327               1.270          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.034558            0.033250               1.039          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.037558            0.044942               0.836          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.277577            0.288115               0.963          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.011481            0.008904               1.289          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014288            0.009538               1.498          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.028519            0.030365               0.939          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.032558            0.031327               1.039          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.256981            0.253865               1.012          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.017885            0.015077               1.186          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.848115            1.887212               0.979          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.856385            1.886038               0.984          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.218288            5.914788               0.544          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.255904            0.254192               1.007          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.255712            0.255096               1.002          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011231            0.008308               1.352          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.015596            0.011212               1.391          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               7.389000            8.093211               0.913          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.013019            0.009942               1.309          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.021635            0.020519               1.054          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.049558            0.057962               0.855          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.052558            0.070212               0.749          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.508500            0.555423               0.916          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.012308            0.009096               1.353          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014404            0.009808               1.469          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.043365            0.054635               0.794          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.047615            0.056442               0.844          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.487673            0.521135               0.936          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.021635            0.020962               1.032          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               3.684115            4.012980               0.918          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.686327            4.014231               0.918          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               5.053212            8.026770               0.630          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.485500            0.520404               0.933          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.483404            0.522289               0.926          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011212            0.008096               1.385          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.014635            0.009000               1.626          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.899885            1.930423               0.984          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.012654            0.008962               1.412          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.020096            0.015731               1.278          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.027019            0.022346               1.209          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.029577            0.034038               0.869          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.163519            0.172865               0.946          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.011365            0.008423               1.349          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014212            0.009115               1.559          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.021173            0.019558               1.083          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.025462            0.020462               1.244          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.143173            0.138404               1.034          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.016212            0.012846               1.262          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.936885            0.952904               0.983          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.944192            0.953019               0.991          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               2.307212            4.975192               0.464          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.141654            0.138712               1.021          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.141135            0.139827               1.009          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011038            0.008442               1.308          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.014692            0.009385               1.566          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               3.735404            3.818154               0.978          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.012750            0.009481               1.345          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.020865            0.016327               1.278          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.034365            0.033192               1.035          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.037231            0.044981               0.828          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.277596            0.288077               0.964          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.011462            0.008827               1.298          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014308            0.009538               1.500          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.028558            0.030346               0.941          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.032538            0.031308               1.039          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.257019            0.253942               1.012          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.017712            0.015135               1.170          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               1.848115            1.882788               0.982          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.854212            1.885827               0.983          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.218846            5.911538               0.545          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.255558            0.254077               1.006          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.256154            0.255115               1.004          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011135            0.008346               1.334          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.016058            0.011212               1.432          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               7.393481            8.078846               0.915          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.013038            0.009962               1.309          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.021788            0.020462               1.065          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.049308            0.057923               0.851          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.052173            0.070077               0.745          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.508558            0.554846               0.917          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.011577            0.009115               1.270          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.014404            0.009808               1.469          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.043212            0.054615               0.791          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.047500            0.056346               0.843          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.487865            0.520365               0.938          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.021615            0.020923               1.033          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               3.679750            4.017058               0.916          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               3.688558            4.010231               0.920          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               5.057250            8.054346               0.628          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.485596            0.520654               0.933          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.483135            0.522346               0.925          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.s
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.264250            0.008846              29.872          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.429596            0.011981              35.857          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.349750            0.009019              38.778          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.389923            0.014327              27.216          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.429192            0.030923              13.879          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.390885            0.015250              25.632          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               2.239404            1.884058               1.189          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               2.221827            1.885519               1.178          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.264596            0.009558              27.684          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.435596            0.016269              26.774          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.352788            0.009827              35.900          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.398558            0.021327              18.688          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.447846            0.056365               7.945          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.393827            0.021981              17.917          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               4.080077            4.013923               1.016          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               4.059269            4.016596               1.011          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]
```
