### PR TITLE
[KernelGen] Fix special_shifted_chebyshev_polynomial_w: test_error

### DIFF
--- a/benchmark/test_special_shifted_chebyshev_polynomial_w.py
+++ b/benchmark/test_special_shifted_chebyshev_polynomial_w.py
@@ -8,8 +8,8 @@ from . import base
 
 # TODO: Reference GitHub issue for multi-backend support
 @pytest.mark.skipif(
-    flag_gems.vendor_name not in ("nvidia", "thead"),
-    reason="Only nvidia and thead backends support this op",
+    flag_gems.vendor_name not in ("nvidia", "iluvatar", "metax", "thead"),
+    reason="Only nvidia, iluvatar, metax, and thead backends support this op",
 )
 @pytest.mark.special_shifted_chebyshev_polynomial_w
 def test_special_shifted_chebyshev_polynomial_w():

--- a/tests/test_special_shifted_chebyshev_polynomial_w.py
+++ b/tests/test_special_shifted_chebyshev_polynomial_w.py
@@ -8,8 +8,8 @@ from . import accuracy_utils as utils
 
 # TODO: Reference GitHub issue for multi-backend support
 @pytest.mark.skipif(
-    flag_gems.vendor_name not in ("nvidia", "thead"),
-    reason="Only nvidia and thead backends support this op",
+    flag_gems.vendor_name not in ("nvidia", "iluvatar", "metax", "thead"),
+    reason="Only nvidia, iluvatar, metax, and thead backends support this op",
 )
 @pytest.mark.special_shifted_chebyshev_polynomial_w
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
@@ -33,8 +33,8 @@ def test_special_shifted_chebyshev_polynomial_w(shape, dtype):
 
 
 @pytest.mark.skipif(
-    flag_gems.vendor_name not in ("nvidia", "thead"),
-    reason="Only nvidia and thead backends support this op",
+    flag_gems.vendor_name not in ("nvidia", "iluvatar", "metax", "thead"),
+    reason="Only nvidia, iluvatar, metax, and thead backends support this op",
 )
 @pytest.mark.special_shifted_chebyshev_polynomial_w
 def test_special_shifted_chebyshev_polynomial_w_n_out_of_range():


### PR DESCRIPTION
## Summary
- **Operator:** special_shifted_chebyshev_polynomial_w
- **Error type:** test_error
- **Files modified:**
  - `benchmark/test_special_shifted_chebyshev_polynomial_w.py`
  - `tests/test_special_shifted_chebyshev_polynomial_w.py`

## Commit Message
```
fix: enable special_shifted_chebyshev_polynomial_w tests for iluvatar and metax backends

PR #3662 added backend overrides for iluvatar, metax, and thead, but the
test skip condition only allowed nvidia and thead to run. This left the
iluvatar and metax implementations untested.

This commit updates the skipif condition to include all four backends that
have implementations: nvidia, iluvatar, metax, and thead.

Fixes: #3662
```

## Verification
- Test command: `pytest -m 'special_shifted_chebyshev_polynomial_w' tests/ --ref cpu -vs`
- Benchmark command: `pytest -m 'special_shifted_chebyshev_polynomial_w' benchmark/ --level core --record log`

## Test Plan
- [ ] `pytest -m 'special_shifted_chebyshev_polynomial_w' tests/ --ref cpu -vs`
- [ ] `pytest -m 'special_shifted_chebyshev_polynomial_w' benchmark/ --level core --record log`

## Issue
- WEEKTEST-3662
- Fixes #3662
