### PR TITLE
[KMCompiler]Add stages to the linalg_lstsq operator entry

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6288,6 +6288,8 @@ ops:
     kind:
       - LinearAlg
       - BLAS
+    stages:
+      - alpha: '5.4'
   - id: linalg_lu_factor
     description: |
       Computes a compact representation of the LU factorization with partial pivoting of a matrix.


### PR DESCRIPTION
## Summary

`linalg_lstsq` is missing the `stages` field in `conf/operators.yaml`. 

```yaml
   - id: linalg_lstsq
     ...
     kind:
       - LinearAlg
       - BLAS
+    stages:
+      - alpha: '5.4'
```

## Testing

Documentation only — no kernel, host, dispatch, or registration change, so runtime behaviour is untouched. `conf/operators.yaml` re-parses cleanly with `yaml.safe_load` and the entry ordering is unchanged.

## Files Changed

- `conf/operators.yaml`: add the `stages` field to the `linalg_lstsq` entry (+2 lines)
