### PR TITLE
[KMComplier][NVIDIA][Thead][MetaX][iluvatar] Fix test_linalg_det hang with `--ref cpu`

### DIFF
--- a/tests/test_linalg_det.py
+++ b/tests/test_linalg_det.py
@@ -87,6 +87,13 @@ def _ref_det(A):
     prev = torch.get_num_threads()
     torch.set_num_threads(min(prev, 64))
     try:
+        batch = math.prod(A.shape[:-2])
+        if A.dim() > 2 and batch > 0 and A.shape[-1] > 0:
+            n = A.shape[-1]
+            flat = A.reshape(batch, n, n)
+            return torch.stack([torch.linalg.det(a) for a in flat]).reshape(
+                A.shape[:-2]
+            )
         return torch.linalg.det(A)
     finally:
         torch.set_num_threads(prev)


### PR DESCRIPTION
### PR Category
OP Test
### Type of Change
Bug Fix

### Description
`pytest tests/test_linalg_det.py -v -s --ref cpu` hung indefinitely at`test_linalg_det_random_batch[dtype0-shape13]` (shape `(8, 256, 256)`, float32) on a many-core NVIDIA H20 host, while the same suite passed in ~3s without `--ref cpu`.

Root cause: with `--ref cpu`, the reference is computed by `torch.linalg.det` on CPU.PyTorch's batched CPU `linalg_det` goes through `lu_factor`, which parallelizes over the batch dimension with `at::parallel_for` and calls LAPACK `sgetrf` per matrix on thread-pool worker threads (`aten/src/ATen/native/BatchLinearAlgebraKernel.cpp`). The test's `torch.set_num_threads(min(prev, 64))` cap only takes effect for MKL via `mkl_set_num_threads_local()`, which is **thread-local**: it does not apply to pool worker
threads. For `(8, 256, 256)` — the only case with `batch > 1` and `n` large enough for MKL to go multi-threaded — each of the 8 worker threads spawns up to host-core-count MKL (Intel OpenMP) threads. The resulting nested-OpenMP oversubscription deadlocks/thrashes inside a container.

Fix in `_ref_det` (`tests/test_linalg_det.py`): for batched CPU inputs, compute the reference determinant per matrix (2D `torch.linalg.det` calls) and stack the results, so LAPACK always runs on the calling thread where the MKL thread cap applies. Empty inputs (`batch == 0` or `n == 0`, e.g. `(3, 0, 0)`) fall back to the direct call since no LU work is performed.

### Correctness
`pytest tests/test_linalg_det.py -v -s --ref cpu`: 84 passed
