### PR TITLE
[AMD] Add RDNA3 split softmax

### DIFF
--- a/src/flag_gems/runtime/backend/_amd/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/__init__.py
@@ -35,6 +35,7 @@ LDS, so the RDNA4 candidates would be a poor fit for them.
 """
 
 ARCH_MAP = {
+    "gfx1100": "rdna3",
     "gfx1200": "rdna4",
     "gfx1201": "rdna4",
 }

--- a/src/flag_gems/runtime/backend/_amd/rdna3/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna3/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/flag_gems/runtime/backend/_amd/rdna3/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna3/ops/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Only names bound here are picked up: the arch loader collects every function in
+# this namespace with inspect.getmembers and overwrites the same-named generic op,
+# so helpers must not be re-exported from here.
+from .softmax import softmax, softmax_out
+
+__all__ = [
+    "softmax",
+    "softmax_out",
+]

--- a/src/flag_gems/runtime/backend/_amd/rdna3/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna3/ops/softmax.py
@@ -59,22 +59,22 @@ _BLOCKS_PER_CU = 4
 # CUs by itself, and splitting past that point only buys a second launch. Narrow
 # elements stay ahead of the generic kernel with twice as many rows in flight, so
 # they get the looser row budget, paired with the shortest row at which that row
-# count turns positive. Wider elements finish within a few percent of the generic
-# kernel at that row count whatever the length, so they take the tighter row
-# budget and, with it, a shorter minimum row.
+# count turns positive. Wider elements only track the generic kernel at that row
+# count whatever the length, so they take the tighter row budget and, with it, a
+# shorter minimum row.
 #
 # Both CU figures are deliberately separate from _BLOCKS_PER_CU: that one sets how
 # many blocks to aim for, these decide which shapes are eligible at all.
 #
 # The row budgets were measured on gfx1100 by sweeping row counts against row
-# lengths with the eligibility checks bypassed. Split stays ahead of the generic
-# kernel up to 16 rows for narrow elements and 8 for wide ones; past that it can
+# lengths with the eligibility checks bypassed: split stays ahead of the generic
+# kernel up to a row count that depends on element width, and past that it can
 # lose. The binding constraint is not the longest rows but the shortest eligible
 # ones: the generic kernel's tile choice makes its cost a step function of N, and
-# just past the minimum length above it sits on a favourable step, so a cap
-# chosen at 1M rows would give away a few percent around 52K-57K (narrow) and
-# 40K-45K (wide). Note that HIP reports WGPs here rather than CUs, so a 96-CU
-# part gives cu = 48 and these divisors yield 16 and 8.
+# just past the minimum length above it sits on a favourable step, so a budget
+# chosen from the longest rows alone would give ground just above the minimum.
+# Note that HIP reports WGPs here rather than CUs, so cu is half the CU count the
+# part is marketed with, and these divisors are set accordingly.
 _NARROW_MAX_ITEMSIZE = 2
 _NARROW_MIN_SPLIT_N = 48 * 1024
 _NARROW_MIN_CUS_PER_ROW = 3

--- a/src/flag_gems/runtime/backend/_amd/rdna3/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna3/ops/softmax.py
@@ -1,0 +1,252 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RDNA3 softmax: split the reduction across workgroups when rows are scarce.
+
+The generic softmax_kernel_inner launches grid (M, 1, 1), one workgroup per row,
+so parallelism is bounded by the row count rather than by the size of the
+reduction. A 1-D input collapses to M=1, which leaves all but one CU idle no
+matter how large N is.
+
+Here each row is split across NUM_BLOCKS workgroups. Pass 1 reduces one chunk
+per workgroup into a partial (max, sum-of-exp) pair; pass 2 combines the partials
+with the online-softmax identity and writes the normalized output. The grid
+becomes (NUM_BLOCKS, M), so parallelism no longer depends on how many rows there
+are. Traffic stays at two reads plus one write, the same as the generic loop
+path, and the combine costs a few KB out of cache instead of a third launch.
+
+Only the starved regime is taken over; softmax_out falls through to the generic
+implementation everywhere else, which already fills the card once there are
+enough rows to go around.
+"""
+
+import logging
+from functools import lru_cache
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.softmax import softmax_out as generic_softmax_out
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+# Tile size and warp count turned out not to be sensitive; the workgroup count is
+# what the shape has to drive, so _BLOCKS_PER_CU is the only one of the three that
+# feeds the plan below.
+_TILE_N = 2048
+_NUM_WARPS = 8
+_BLOCKS_PER_CU = 4
+
+# Eligibility is a pair of limits picked by element width: the shortest reduction
+# still worth splitting, and how many CUs each row must be able to claim.
+#
+# Rows stop being scarce once the generic grid, one workgroup per row, fills the
+# CUs by itself, and splitting past that point only buys a second launch. Narrow
+# elements stay ahead of the generic kernel with twice as many rows in flight, so
+# they get the looser row budget, paired with the shortest row at which that row
+# count turns positive. Wider elements finish within a few percent of the generic
+# kernel at that row count whatever the length, so they take the tighter row
+# budget and, with it, a shorter minimum row.
+#
+# Both CU figures are deliberately separate from _BLOCKS_PER_CU: that one sets how
+# many blocks to aim for, these decide which shapes are eligible at all.
+#
+# The row budgets were measured on gfx1100 by sweeping row counts against row
+# lengths with the eligibility checks bypassed. Split stays ahead of the generic
+# kernel up to 16 rows for narrow elements and 8 for wide ones; past that it can
+# lose. The binding constraint is not the longest rows but the shortest eligible
+# ones: the generic kernel's tile choice makes its cost a step function of N, and
+# just past the minimum length above it sits on a favourable step, so a cap
+# chosen at 1M rows would give away a few percent around 52K-57K (narrow) and
+# 40K-45K (wide). Note that HIP reports WGPs here rather than CUs, so a 96-CU
+# part gives cu = 48 and these divisors yield 16 and 8.
+_NARROW_MAX_ITEMSIZE = 2
+_NARROW_MIN_SPLIT_N = 48 * 1024
+_NARROW_MIN_CUS_PER_ROW = 3
+_WIDE_MIN_SPLIT_N = 40 * 1024
+_WIDE_MIN_CUS_PER_ROW = 6
+
+
+@lru_cache(maxsize=8)
+def _cu_count(device_index):
+    return torch_device_fn.get_device_properties(device_index).multi_processor_count
+
+
+def _prev_power_of_2(n):
+    return 1 << (n.bit_length() - 1) if n >= 1 else 1
+
+
+def _split_plan(m, n, itemsize, device_index):
+    """Workgroups per row, or None to leave this shape to the generic kernel."""
+    if itemsize <= _NARROW_MAX_ITEMSIZE:
+        min_n, cus_per_row = _NARROW_MIN_SPLIT_N, _NARROW_MIN_CUS_PER_ROW
+    else:
+        min_n, cus_per_row = _WIDE_MIN_SPLIT_N, _WIDE_MIN_CUS_PER_ROW
+    cu = _cu_count(device_index)
+    if m > cu // cus_per_row or n < min_n:
+        return None
+    target_blocks = _BLOCKS_PER_CU * cu
+    num_blocks = _prev_power_of_2(max(1, target_blocks // m))
+    # Cap so every workgroup still gets at least one whole tile.
+    num_blocks = min(num_blocks, _prev_power_of_2(n // _TILE_N))
+    return num_blocks if num_blocks >= 2 else None
+
+
+@libentry()
+@triton.jit
+def softmax_split_reduce_kernel(
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+    row = inp_ptr + pid_m * N
+
+    m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
+    z = tl.zeros([TILE_N], dtype=tl.float32)
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        m_new = tl.maximum(m, inp)
+        # An all -inf window must keep z at 0 rather than accumulate exp(nan).
+        all_neg_inf = m_new == float("-inf")
+        z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+        m = m_new
+
+    m_reduced = tl.max(m, 0)
+    # Lanes still at -inf would give exp(-inf - -inf) = exp(nan) when the whole
+    # chunk is -inf, so select the scale instead of computing it.
+    scale = tl.where(m == float("-inf"), 0.0, tl.exp(m - m_reduced))
+    z_reduced = tl.sum(z * scale, 0)
+
+    tl.store(partial_max_ptr + pid_m * NUM_BLOCKS + pid_b, m_reduced)
+    tl.store(partial_sum_ptr + pid_m * NUM_BLOCKS + pid_b, z_reduced)
+
+
+@libentry()
+@triton.jit
+def softmax_split_normalize_kernel(
+    out_ptr,
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+    TILE_B: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+
+    # Every workgroup redoes the combine over the NUM_BLOCKS partials. That is a
+    # few KB already in cache, and it avoids both a third launch and passing the
+    # row scalars through memory.
+    b_offsets = tl.arange(0, TILE_B)
+    b_mask = b_offsets < NUM_BLOCKS
+    partial_offset = pid_m * NUM_BLOCKS + b_offsets
+    partial_max = tl.load(
+        partial_max_ptr + partial_offset, mask=b_mask, other=-float("inf")
+    )
+    partial_sum = tl.load(partial_sum_ptr + partial_offset, mask=b_mask, other=0.0)
+
+    row_max = tl.max(partial_max, 0)
+    scale = tl.where(partial_max == float("-inf"), 0.0, tl.exp(partial_max - row_max))
+    row_sum = tl.sum(partial_sum * scale, 0)
+
+    row_in = inp_ptr + pid_m * N
+    row_out = out_ptr + pid_m * N
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row_in + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        out = tl.exp(inp - row_max) / row_sum
+        tl.store(row_out + n_offsets, out.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def softmax_out(self, dim, half_to_float=False, *, out):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dim = dim % self.ndim
+    N = self.shape[dim]
+    M = 1
+    for i in range(dim):
+        M *= self.shape[i]
+    K = self.numel() // M // N if self.numel() else 0
+
+    # half_to_float widens the store to fp32, so the plan sees the wider element.
+    itemsize = 4 if half_to_float else self.element_size()
+    plan = (
+        _split_plan(M, N, itemsize, self.device.index)
+        if K == 1 and self.numel()
+        else None
+    )
+    if plan is None:
+        return generic_softmax_out(self, dim, half_to_float, out=out)
+
+    logger.debug("GEMS_RDNA3 SOFTMAX_OUT SPLIT M=%d N=%d blocks=%d", M, N, plan)
+
+    self = self.contiguous()
+    dtype = torch.float32 if half_to_float else self.dtype
+    if tuple(out.shape) != tuple(self.shape):
+        out.resize_(self.shape)
+    if out.dtype != dtype:
+        raise RuntimeError(f"_softmax.out: expected out dtype {dtype}, got {out.dtype}")
+
+    # One allocation for both partials; the two rows stay contiguous.
+    partials = torch.empty((2, M * plan), dtype=torch.float32, device=self.device)
+    grid = (plan, M, 1)
+
+    with torch_device_fn.device(self.device):
+        softmax_split_reduce_kernel[grid](
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            num_warps=_NUM_WARPS,
+        )
+        softmax_split_normalize_kernel[grid](
+            out,
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            TILE_B=triton.next_power_of_2(plan),
+            num_warps=_NUM_WARPS,
+        )
+    return out
+
+
+def softmax(self, dim, half_to_float=False):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dtype = torch.float32 if half_to_float else self.dtype
+    out = torch.empty_like(self, dtype=dtype)
+    return softmax_out(self, dim, half_to_float, out=out)

--- a/tests/test_rdna_split_softmax.py
+++ b/tests/test_rdna_split_softmax.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the RDNA4-specific split softmax.
+"""Tests for the RDNA split softmax overrides.
 
 The generic softmax test file only uses shapes with either many rows or a short
 reduction, so none of them reach the split path; these cover the regime the arch
-override exists for. The arch loader imports the override under the top-level
-name "rdna4.ops.softmax", so that is where the gate function has to be read from
+override exists for. The arch loader imports the override under a top-level name
+like "rdna4.ops.softmax", so that is where the gate function has to be read from
 to be sure the module under test is the one actually installed.
+
+RDNA3 and RDNA4 share the kernel and the gate structure, differing only in the
+row budget, and every assertion below is written against the module's own
+constants rather than literals. So the same file covers whichever override is
+installed; at most one of them ever is.
 """
 
 import math
@@ -32,12 +37,21 @@ import flag_gems
 from . import accuracy_utils as utils
 from . import conftest as cfg
 
-ARCH_SOFTMAX = sys.modules.get("rdna4.ops.softmax")
-INSTALLED = ARCH_SOFTMAX is not None and ARCH_SOFTMAX.softmax is flag_gems.softmax
+ARCH_NAMES = ("rdna3", "rdna4")
+ARCH_SOFTMAX = next(
+    (
+        mod
+        for name in ARCH_NAMES
+        if (mod := sys.modules.get(f"{name}.ops.softmax")) is not None
+        and mod.softmax is flag_gems.softmax
+    ),
+    None,
+)
+INSTALLED = ARCH_SOFTMAX is not None
 
 pytestmark = pytest.mark.skipif(
     not INSTALLED,
-    reason="RDNA4 split softmax is not the installed softmax on this device",
+    reason="no RDNA split softmax is the installed softmax on this device",
 )
 
 # Element widths the gate treats differently, and the widths the test suite has to
@@ -100,7 +114,7 @@ def split_plan(shape, dim, itemsize):
 @pytest.mark.softmax
 @pytest.mark.parametrize("itemsize", ITEMSIZES)
 @pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
-def test_rdna4_softmax_gate_engages(shape, dim, itemsize):
+def test_split_softmax_gate_engages(shape, dim, itemsize):
     m, n, _ = mnk(shape, dim)
     plan = split_plan(shape, dim, itemsize)
     assert plan is not None, f"expected the split path for M={m} N={n}"
@@ -117,14 +131,14 @@ def test_rdna4_softmax_gate_engages(shape, dim, itemsize):
 @pytest.mark.softmax
 @pytest.mark.parametrize("itemsize", ITEMSIZES)
 @pytest.mark.parametrize("shape, dim", GENERIC_SHAPES)
-def test_rdna4_softmax_gate_defers(shape, dim, itemsize):
+def test_split_softmax_gate_defers(shape, dim, itemsize):
     assert (
         split_plan(shape, dim, itemsize) is None
     ), f"{shape} dim={dim} should fall through to the generic implementation"
 
 
 @pytest.mark.softmax
-def test_rdna4_softmax_gate_limits_follow_element_width():
+def test_split_softmax_gate_limits_follow_element_width():
     """Pin both limits from both sides, for both element widths.
 
     The two crossovers sit in different places, so a shape the gate accepts for a
@@ -165,7 +179,7 @@ def test_rdna4_softmax_gate_limits_follow_element_width():
 @pytest.mark.softmax
 @pytest.mark.parametrize("shape, dim", SPLIT_SHAPES + GENERIC_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rdna4_softmax(shape, dim, dtype):
+def test_split_softmax(shape, dim, dtype):
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_inp = utils.to_reference(inp, True)
 
@@ -181,7 +195,7 @@ def test_rdna4_softmax(shape, dim, dtype):
 @pytest.mark.softmax
 @pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rdna4_softmax_out(shape, dim, dtype):
+def test_split_softmax_out(shape, dim, dtype):
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_inp = utils.to_reference(inp, True)
     # Deliberately the wrong size, so the resize path is covered too.
@@ -196,7 +210,7 @@ def test_rdna4_softmax_out(shape, dim, dtype):
 
 @pytest.mark.softmax
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rdna4_softmax_half_to_float(dtype):
+def test_split_softmax_half_to_float(dtype):
     if dtype is torch.float32:
         pytest.skip("half_to_float only applies to reduced-precision input")
     shape, dim = SPLIT_SHAPES[0]
@@ -215,7 +229,7 @@ def test_rdna4_softmax_half_to_float(dtype):
 
 @pytest.mark.softmax
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rdna4_softmax_neg_inf(dtype):
+def test_split_softmax_neg_inf(dtype):
     """Masked attention rows are the reason the combine needs an -inf guard.
 
     A chunk that is entirely -inf must contribute a zero sum instead of exp(nan),
@@ -256,7 +270,7 @@ def test_rdna4_softmax_neg_inf(dtype):
 
 @pytest.mark.softmax
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_rdna4_softmax_at_row_cap(dtype):
+def test_split_softmax_at_row_cap(dtype):
     """Cover grid.y at the row cap: every row combines its own set of partials.
 
     The shapes in SPLIT_SHAPES only reach M=4, so without this the widest grid the
@@ -286,7 +300,7 @@ def test_rdna4_softmax_at_row_cap(dtype):
 
 
 @pytest.mark.softmax
-def test_rdna4_softmax_non_contiguous():
+def test_split_softmax_non_contiguous():
     shape, dim = SPLIT_SHAPES[0]
     n = shape[dim]
     base = torch.randn(


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization

### Description

Brings the split softmax to RDNA3 (gfx1100). The kernel is the same two-pass reduction as #5327 and is carried over unchanged, as is the gate structure; the only difference is the row budget. gfx1100 stays ahead of the generic kernel with more rows in flight than gfx1201 does, so `_NARROW_MIN_CUS_PER_ROW` goes from 4 to 3 and `_WIDE_MIN_CUS_PER_ROW` from 8 to 6, admitting up to 16 rows for fp16/bf16 and 8 for fp32 on a 48-WGP W7900. The length thresholds are unchanged at 48K for narrow elements and 40K for wide ones. Shapes outside the gate fall through to the generic kernel untouched.

#### Results

Speedup over the generic kernel, with speedup over torch in brackets. bf16, gfx1100 (W7900, 48 WGP), idle card, median of 40 iterations with L2 flushed before each.

| rows | N=49152 | N=131072 | N=524288 | N=2097152 |
|---|---|---|---|---|
| M=1 | 1.39x (1.17x) | 2.50x (2.04x) | 7.02x (5.73x) | 15.13x (12.31x) |
| M=2 | 1.37x (1.18x) | 2.38x (1.90x) | 5.43x (4.48x) | 9.85x (8.94x) |
| M=4 | 1.24x (1.07x) | 2.15x (1.80x) | 4.16x (3.47x) | 5.97x (5.52x) |
| M=8 | 1.19x (1.05x) | 1.68x (1.50x) | 2.71x (2.55x) | 3.03x (2.89x) |
| M=16 | 1.05x (1.02x) | 1.35x (1.20x) | 1.72x (1.68x) | 1.65x (1.66x) |

Across all 64 gated shapes (fp16/bf16/fp32) the median is 1.73x over generic and 1.77x over torch, worst case 1.01x over generic. fp32 admits fewer rows but shorter ones, and gains 1.01x to 9.85x over generic across its own gated range. The 98 measured shapes outside the gate keep using the generic kernel, so they are unchanged.

Correctness: the RDNA4 test file already wrote every assertion against the module's own constants rather than literals, so it is renamed to `test_rdna_split_softmax.py` and picks up whichever override is installed instead of being duplicated. On gfx1100 it runs 75 passed, 1 skipped, covering both sides of the gate, each element width, `half_to_float`, non-inner dims, non-contiguous input and -inf rows. Upstream `test_softmax.py`, `test_safe_softmax.py` and `test_log_softmax.py`: 294 passed.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress