### PR TITLE
Add 'decorator' to the dependencies for Ascend CANN 8.5.0 backend.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dependencies = [
 ascend-cann850 = [
     "torch==2.9.0+cpu",
     "torch-npu==2.9.0",
+    "decorator==5.1.1",
 ]
 
 ascend-cann900 = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -83,6 +83,7 @@ backends:
     deps:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
+      - decorator==5.1.1
 
   ascend-cann900:
     python: "3.11"


### PR DESCRIPTION
in the ascending kann850 environment, the default environment is missing the decorator Python library.

### PR Category
CI

### Type of Change
Bug Fix

### Description
When calling the torch.linalg.matrix_norm operator, return error 50001.

The root cause is that the default installation of Cann850 does not have the decorator Python library installed.

We fixed it by when calling the torch.linalg.martinx_norm operator in the ascending kann850 environment, the default environment is missing the decorator Python library.

### Issue
N/A


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
