### PR TITLE
[KMcompiler][Ascend] When calling the torch.linalg.martinx_norm operator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ascend-cann850 = [
     "torch==2.9.0+cpu",
     "torch-npu==2.9.0",
     "decorator==5.1.1",
+    "attrs==24.2.0",
 ]
 
 ascend-cann900 = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -84,6 +84,7 @@ backends:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
       - decorator==5.1.1
+      - attrs==24.2.0
 
   ascend-cann900:
     python: "3.11"


### PR DESCRIPTION
in the ascending kann850 environment, the default environment is missing the attrs Python library.

### PR Category
CI

### Type of Change
Bug Fix 

### Description

 When calling the torch.linalg.martinx_norm operator in the ascending kann850 environment, the default environment is missing the psutil Python library.

### Issue
N/A


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
