### PR TITLE
Add psutil to dependency for CANN 8.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ ascend-cann850 = [
     "torch-npu==2.9.0",
     "decorator==5.1.1",
     "attrs==24.2.0",
+    "psutil==6.0.0",
 ]
 
 ascend-cann900 = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -85,6 +85,7 @@ backends:
       - torch-npu==2.9.0
       - decorator==5.1.1
       - attrs==24.2.0
+      - psutil==6.0.0
 
   ascend-cann900:
     python: "3.11"


### PR DESCRIPTION
in the ascending kann850 environment, the default environment is missing the psutil Python library.

### PR Category
CI

### Type of Change
Bug Fix 

### Description
N/A

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
