### PR TITLE
fix: elu positive-branch input_scale and randint high specialization

### DIFF
--- a/src/flag_gems/ops/elu.py
+++ b/src/flag_gems/ops/elu.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def elu_forward_kernel(x, alpha, scale, input_scale):
     return tl.where(
         x > 0,
-        scale * input_scale * x,
+        scale * x,
         scale * alpha * (tl.exp(x.to(tl.float32) * input_scale) - 1),
     )
 
@@ -42,7 +42,7 @@ def elu_backward_kernel_with_self(grad_output, alpha, scale, input_scale, x):
     x_fp32 = x.to(tl.float32)
     grad_input = tl.where(
         x > 0,
-        grad_output * scale * input_scale,
+        grad_output * scale,
         grad_output * (scale * alpha * tl.exp(x_fp32 * input_scale) * input_scale),
     )
     return grad_input
@@ -55,7 +55,7 @@ def elu_backward_kernel_with_self(grad_output, alpha, scale, input_scale, x):
 def elu_backward_kernel_with_result(grad_output, alpha, scale, input_scale, y):
     grad_input = tl.where(
         y > 0,
-        grad_output * scale * input_scale,
+        grad_output * scale,
         grad_output * ((y + scale * alpha) * input_scale),
     )
     return grad_input

--- a/src/flag_gems/ops/randint.py
+++ b/src/flag_gems/ops/randint.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 @libentry()
-@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N"])
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N", "high"])
 def randint_kernel(
     out_ptr,
     N,

--- a/src/flag_gems/ops/randint_like.py
+++ b/src/flag_gems/ops/randint_like.py
@@ -32,7 +32,7 @@ UNROLL = 4
 
 
 @triton.heuristics(runtime.get_heuristic_config("rand"))
-@triton.jit(do_not_specialize=["philox_seed", "philox_offset"])
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "high"])
 def randint_kernel(
     out_ptr,
     N,


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description

Two kernel fixes:

1. **elu**: the forward/backward kernels multiplied the positive branch by
   `input_scale` (`scale * input_scale * x`); PyTorch applies `input_scale`
   only inside the exponential, so non-default `input_scale` gave wrong
   results on the positive branch (measured max diff 0.7 vs CPU reference on
   RTX 5060; fixed to 4.5e-8). Default parameters unaffected.
2. **randint/randint_like**: `high` was missing from `do_not_specialize`, so
   `high=1` was constexpr-specialized and `high.to(tl.uint64)` ran on a Python
   int (`AttributeError`). Adding `"high"` to the list makes the kernel accept
   any value with a single compilation.

### Issue
- Resolves #5714

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact: elu is a pointwise kernel; randint now compiles once
instead of once per high value (fewer recompilations for varying high).
