### PR TITLE
[KMCompiler]Optimize log_sigmoid_backward Ascend performance

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/log_sigmoid_backward.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/log_sigmoid_backward.py
@@ -15,6 +15,7 @@
 import logging
 from contextlib import nullcontext
 
+import torch
 import triton
 import triton.language as tl
 
@@ -37,6 +38,15 @@ _LOG_SIGMOID_BACKWARD_CONFIG = CodeGenConfig(
     prefer_1d_tile=True,
 )
 
+# Reusing the forward buffer removes the exponential and permits a wider tile.
+_LOG_SIGMOID_BACKWARD_BUFFER_CONFIG = CodeGenConfig(
+    max_tile_size=4096,
+    max_grid_size=(65535, 1, 1),
+    max_num_warps_per_cta=32,
+    prefer_block_pointer=False,
+    prefer_1d_tile=True,
+)
+
 
 @pointwise_dynamic(
     is_tensor=[True, True],
@@ -48,6 +58,18 @@ def log_sigmoid_backward_kernel(grad_output, self):
     self_fp32 = self.to(tl.float32)
     z = tl.exp(-tl.abs(self_fp32))
     derivative = tl.where(self_fp32 < 0.0, 1.0 / (1.0 + z), z / (1.0 + z))
+    return grad_output * derivative
+
+
+@pointwise_dynamic(
+    is_tensor=[True, True, True],
+    promotion_methods=[(0, 1, "DEFAULT")],
+    config=_LOG_SIGMOID_BACKWARD_BUFFER_CONFIG,
+)
+@triton.jit
+def log_sigmoid_backward_buffer_kernel(grad_output, self, buffer):
+    z = buffer
+    derivative = tl.where(self < 0.0, 1.0, z) / (1.0 + z)
     return grad_output * derivative
 
 
@@ -73,6 +95,30 @@ def log_sigmoid_backward_contiguous_kernel(
         tl.store(grad_input + offsets, result, mask=mask)
 
 
+@libentry()
+@triton.jit
+def log_sigmoid_backward_buffer_contiguous_kernel(
+    grad_output,
+    self,
+    buffer,
+    grad_input,
+    n_elements,
+    TILES_PER_PROGRAM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    program_id = ext.program_id(0)
+    program_count = ext.num_programs(0)
+    lane_offsets = tl.arange(0, BLOCK_SIZE)
+    for tile in tl.range(0, TILES_PER_PROGRAM):
+        offsets = (program_id + tile * program_count) * BLOCK_SIZE + lane_offsets
+        mask = offsets < n_elements
+        grad = tl.load(grad_output + offsets, mask=mask)
+        inp = tl.load(self + offsets, mask=mask)
+        z = tl.load(buffer + offsets, mask=mask)
+        derivative = tl.where(inp < 0.0, 1.0, z) / (1.0 + z)
+        tl.store(grad_input + offsets, grad * derivative, mask=mask)
+
+
 def _can_use_contiguous_kernel(grad_output, self, grad_input=None):
     return (
         grad_output.shape == self.shape
@@ -80,6 +126,14 @@ def _can_use_contiguous_kernel(grad_output, self, grad_input=None):
         and grad_output.is_contiguous()
         and self.is_contiguous()
         and (grad_input is None or grad_input.is_contiguous())
+    )
+
+
+def _can_use_buffer(self, buffer):
+    return (
+        buffer.shape == self.shape
+        and buffer.dtype == self.dtype
+        and buffer.is_contiguous()
     )
 
 
@@ -111,10 +165,42 @@ def _launch_contiguous_kernel(grad_output, self, grad_input):
     return grad_input
 
 
+def _launch_buffer_contiguous_kernel(grad_output, self, buffer, grad_input):
+    n_elements = self.numel()
+    if n_elements == 0:
+        return grad_input
+
+    block_size = (
+        8192
+        if self.dtype == torch.bfloat16
+        else _LOG_SIGMOID_BACKWARD_BUFFER_CONFIG.max_tile_size
+    )
+    tile_count = triton.cdiv(n_elements, block_size)
+    grid_size = min(tile_count, 65535)
+    tiles_per_program = triton.cdiv(tile_count, grid_size)
+    with _device_guard(self):
+        log_sigmoid_backward_buffer_contiguous_kernel[(grid_size,)](
+            grad_output,
+            self,
+            buffer,
+            grad_input,
+            n_elements,
+            TILES_PER_PROGRAM=tiles_per_program,
+            BLOCK_SIZE=block_size,
+        )
+    return grad_input
+
+
 def log_sigmoid_backward(grad_output, self, buffer):
     logger.debug("GEMS_ASCEND LOG_SIGMOID BACKWARD")
 
-    del buffer
+    if _can_use_buffer(self, buffer):
+        if _can_use_contiguous_kernel(grad_output, self):
+            grad_input = torch.empty_like(self)
+            return _launch_buffer_contiguous_kernel(
+                grad_output, self, buffer, grad_input
+            )
+        return log_sigmoid_backward_buffer_kernel(grad_output, self, buffer)
     return log_sigmoid_backward_kernel(grad_output, self)
 
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description

- Keep the Ascend `log_sigmoid_backward` implementation entirely in Triton without calling the native `PrivateUse1` kernel.
- Reuse a valid forward buffer to avoid recomputing the exponential; use a handwritten contiguous Triton kernel for the common path and the pointwise Triton kernel for fallback layouts.
- Use a 4096-element tile for FP16/FP32 and an 8192-element tile for BF16. Retain the UB-safe 512-element recompute path when the forward buffer is unavailable.
- Leave `benchmark/base.py` unchanged.

### Issue

- Follow-up optimization for #5012.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

| Mode | FP16 | FP32 | BF16 | Final |
|---|---:|---:|---:|---:|
| operator | 0.854x | 0.682x | 0.935x | 0.824x |
| kernel | 0.978x | 0.815x | 1.058x | 0.950x |

Both modes pass the final `>0.8x` requirement. Device reference: 48 passed. CPU reference: 48 passed. No UB overflow on the tested Ascend 910B environment.