### PR TITLE
fix: randperm dtype=None and batch_norm 1-D input robustness

### DIFF
--- a/src/flag_gems/ops/batch_norm.py
+++ b/src/flag_gems/ops/batch_norm.py
@@ -337,6 +337,8 @@ def batch_norm(
     eps=1e-05,
 ):
     logger.debug("GEMS BATCHNORM FORWARD")
+    if input.dim() < 2:
+        raise ValueError("batch_norm requires input with at least 2 dimensions")
 
     input_3d = make_3d_for_bn(input)
 

--- a/src/flag_gems/ops/randperm.py
+++ b/src/flag_gems/ops/randperm.py
@@ -433,6 +433,8 @@ def randperm(
     pin_memory=False,
 ):
     logger.debug("GEMS RANDPERM")
+    if dtype is None:
+        dtype = torch.int64
     assert dtype == torch.int16 or dtype == torch.int32 or dtype == torch.int64
     assert n <= _MAX_INT64_VAL, "n exceeds maximum int64"
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

Two robustness fixes:

1. **randperm**: `dtype=None` (PyTorch default, resolves to int64) failed
   the int-dtype assert with an empty AssertionError; ATen callers passing
   `dtype=None` explicitly hit it. Default to int64 before the assert.
2. **batch_norm**: 1-D inputs (invalid for batch norm, but rejected cleanly
   by PyTorch's CPU reference) crashed the process via an unpack error in
   the launch path; reject `input.dim() < 2` with a clear ValueError.

### Issue
- Resolves #5720

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

No performance impact; both are input-validation paths.
