### PR TITLE
fix(cambricon): use elementwise & | ~ instead of Python and/or/not on tensor masks

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/fused/cross_entropy_loss.py
+++ b/src/flag_gems/runtime/backend/_cambricon/fused/cross_entropy_loss.py
@@ -88,7 +88,7 @@ def softmax_forward_kernel(
                 inp_ptrs = (
                     inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
                 )
-                inp_mask = offset_c[:, None] < C and offset_d[None, :] < D
+                inp_mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
                 inp = tl.load(inp_ptrs, mask=inp_mask, other=-float("inf")).to(
                     tl.float32
                 )
@@ -237,7 +237,7 @@ def nllloss_without_weight_kernel(
     tgt_mask = offset_n < N
     tgt = tl.load(tgt_ptrs, mask=tgt_mask, other=0)
 
-    ignore_mask = not (tgt == ignore_index)
+    ignore_mask = ~(tgt == ignore_index)
 
     final_max_ptrs = final_max_ptr + offset_n * D + offset_d
     final_sum_ptrs = final_sum_ptr + offset_n * D + offset_d
@@ -251,7 +251,7 @@ def nllloss_without_weight_kernel(
     out = tl.log2(final_sum) * loge2 + final_max - inp_tgt
 
     out_ptrs = out_ptr + offset_n * D + offset_d
-    tl.store(out_ptrs, out, mask=tgt_mask and ignore_mask)
+    tl.store(out_ptrs, out, mask=tgt_mask & ignore_mask)
 
 
 @triton.heuristics(
@@ -281,7 +281,7 @@ def nllloss_with_weight_kernel(
     tgt_ptrs = tgt_ptr + pid_n * D + offset_d
     tgt = tl.load(tgt_ptrs)
 
-    ignore_mask = not (tgt == ignore_index)
+    ignore_mask = ~(tgt == ignore_index)
 
     if w_ptr is None:
         w_tgt = ignore_mask
@@ -333,7 +333,7 @@ def celoss_probability_kernel(
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        inp_mask = offset_c[:, None] < C and offset_d[None, :] < D
+        inp_mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, inp_mask, other=-float("inf")).to(tl.float32)
         cur_max = tl.maximum(tmp_max, inp)
         cur_exp = tl.exp(inp - cur_max)
@@ -348,7 +348,7 @@ def celoss_probability_kernel(
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
         tgt_ptrs = tgt_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        mask = offset_c[:, None] < C and offset_d[None, :] < D
+        mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, mask, other=0).to(tl.float32)
         tgt = tl.load(tgt_ptrs, mask, other=0).to(tl.float32)
         tgt = tgt * (1.0 - label_smoothing) + label_smoothing / C
@@ -392,7 +392,7 @@ def celoss_indices_smooth_kernel(
     tgt_mask = offset_d < D
     tgt = tl.load(tgt_ptrs, mask=tgt_mask, other=0)
 
-    ignore_mask = not (tgt == ignore_index) and tgt_mask
+    ignore_mask = (~(tgt == ignore_index)) & tgt_mask
 
     if w_ptr is None:
         w_tgt = ignore_mask
@@ -407,7 +407,7 @@ def celoss_indices_smooth_kernel(
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        mask = offset_c[:, None] < C and offset_d[None, :] < D
+        mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, mask, other=-float("inf")).to(tl.float32)
         cur_max = tl.maximum(tmp_max, inp)
         cur_exp = tl.exp(inp - cur_max)
@@ -422,7 +422,7 @@ def celoss_indices_smooth_kernel(
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        mask = offset_c[:, None] < C and offset_d[None, :] < D
+        mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, mask, other=0).to(tl.float32)
 
         w_mask = offset_c < C
@@ -477,7 +477,7 @@ def single_celoss_indice_bwd(
     inp_grad_ptrs = (
         inp_grad_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
     )
-    tl.store(inp_grad_ptrs, inp_grad, mask=inp_mask and ignore_mask)
+    tl.store(inp_grad_ptrs, inp_grad, mask=inp_mask & ignore_mask)
 
 
 def config_prune(configs, named_args, **kwargs):
@@ -670,7 +670,7 @@ def celoss_probability_bwd(
 
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
-        mask = offset_c[:, None] < C and offset_d[None, :] < D
+        mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
         inp = tl.load(inp_ptrs, mask, other=-float("inf")).to(tl.float32)
 
@@ -700,7 +700,7 @@ def celoss_probability_bwd(
         offset_c = off + tl.arange(0, BLOCK_C)
         offset = pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
         inp_ptrs = inp_ptr + offset
-        mask = offset_c[:, None] < C and offset_d[None, :] < D
+        mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, mask, other=0).to(tl.float32)
 
         tgt_ptrs = tgt_ptr + offset
@@ -760,7 +760,7 @@ def celoss_indices_smooth_bwd(
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        inp_mask = offset_c[:, None] < C and offset_d[None, :] < D
+        inp_mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, inp_mask, other=-float("inf")).to(tl.float32)
 
         w_mask = offset_c < C
@@ -791,7 +791,7 @@ def celoss_indices_smooth_bwd(
     for off in range(0, C, BLOCK_C):
         offset_c = off + tl.arange(0, BLOCK_C)
         inp_ptrs = inp_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
-        inp_mask = offset_c[:, None] < C and offset_d[None, :] < D
+        inp_mask = (offset_c[:, None] < C) & (offset_d[None, :] < D)
         inp = tl.load(inp_ptrs, inp_mask, other=-float("inf")).to(tl.float32)
 
         w_mask = offset_c < C
@@ -812,7 +812,7 @@ def celoss_indices_smooth_bwd(
         inp_grad_ptrs = (
             inp_grad_ptr + pid_n * C * D + offset_c[:, None] * D + offset_d[None, :]
         )
-        tl.store(inp_grad_ptrs, inp_grad, mask=inp_mask and ignore_mask)
+        tl.store(inp_grad_ptrs, inp_grad, mask=inp_mask & ignore_mask)
 
 
 class CrossEntropyLoss(torch.autograd.Function):

--- a/src/flag_gems/runtime/backend/_cambricon/fused/skip_layernorm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/fused/skip_layernorm.py
@@ -148,7 +148,7 @@ def skip_layer_norm_kernel(
     for off in range(0, N, BLOCK_COL_SIZE):
         cols = off + tl.arange(0, BLOCK_COL_SIZE)[None, :]
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
 
         x = tl.load(X + cols, mask, other=0.0).to(tl.float32)
         r = tl.load(R + cols, mask, other=0.0).to(tl.float32)
@@ -167,7 +167,7 @@ def skip_layer_norm_kernel(
     for off in range(0, N, BLOCK_COL_SIZE):
         cols = off + tl.arange(0, BLOCK_COL_SIZE)[None, :]
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
 
         w = tl.load(W + cols, col_mask)
         b = tl.load(B + cols, col_mask)

--- a/src/flag_gems/runtime/backend/_cambricon/fused/weight_norm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/fused/weight_norm.py
@@ -61,7 +61,7 @@ def weight_norm_except_dim_kernel(
         n_idx = row_offset
         k_idx = col_offset % v_shape2
 
-        mask = m_idx < v_shape0 and row_mask
+        mask = (m_idx < v_shape0) & row_mask
 
         v_offsets = m_idx * v_shape1 * v_shape2 + n_idx * v_shape2 + k_idx
         v_value = tl.load(v + v_offsets, mask=mask)
@@ -77,7 +77,7 @@ def weight_norm_except_dim_kernel(
         n_idx = row_offset
         k_idx = col_offset % v_shape2
 
-        mask = m_idx < v_shape0 and row_mask
+        mask = (m_idx < v_shape0) & row_mask
 
         v_offsets = m_idx * v_shape1 * v_shape2 + n_idx * v_shape2 + k_idx
         v_value = tl.load(v + v_offsets, mask=mask)
@@ -122,7 +122,7 @@ def weight_norm_except_dim_bwd_kernel(
         n_idx = row_offset
         k_idx = col_offset % v_shape2
 
-        mask = m_idx < v_shape0 and row_mask
+        mask = (m_idx < v_shape0) & row_mask
 
         v_offsets = m_idx * v_shape1 * v_shape2 + n_idx * v_shape2 + k_idx
         v_value = tl.load(v + v_offsets, mask=mask).to(tl.float32)
@@ -136,7 +136,7 @@ def weight_norm_except_dim_bwd_kernel(
         n_idx = row_offset
         k_idx = col_offset % v_shape2
 
-        mask = m_idx < v_shape0 and row_mask
+        mask = (m_idx < v_shape0) & row_mask
 
         v_offsets = m_idx * v_shape1 * v_shape2 + n_idx * v_shape2 + k_idx
         v_value = tl.load(v + v_offsets, mask=mask).to(tl.float32)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/all.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/all.py
@@ -57,10 +57,10 @@ def all_kernel_dim(
     for off in range(0, N, BLOCK_N):
         cols = off + tl.arange(0, BLOCK_N)[None, :]
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
 
         a = tl.load(inp + cols, mask, other=1.0)
-        _all = _all and (a != 0)
+        _all = _all & (a != 0)
     all = tl.reduce(_all, axis=1, combine_fn=reduce_all)
     tl.store(out, all[:, None], row_mask)
 
@@ -85,13 +85,13 @@ def all_kernel_1(
         offset = off + tl.arange(0, BLOCK_SIZE)
         mask = offset < M
         inp_val = tl.load(inp + offset, mask=mask, other=1.0)
-        _tmp = _tmp and (inp_val != 0)
+        _tmp = _tmp & (inp_val != 0)
 
     # Reset to original reduce programming mode after optimizing the tl.reduce.
     for x in tl.static_range(1, int(ITER_NUM), 1):
         _tmp[: BLOCK_SIZE // (2**x)] = (
             _tmp[: BLOCK_SIZE // (2**x)]
-            and _tmp[BLOCK_SIZE // (2**x) : (BLOCK_SIZE // (2**x)) * 2]
+            & _tmp[BLOCK_SIZE // (2**x) : (BLOCK_SIZE // (2**x)) * 2]
         )
 
     tl.atomic_and(out, _tmp[0].to(tl.int32))

--- a/src/flag_gems/runtime/backend/_cambricon/ops/amax.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/amax.py
@@ -133,7 +133,7 @@ def amax_kernel(
         for off in range(0, N, BLOCK_N):
             cols = off + tl.arange(0, BLOCK_N)[None, :]
             col_mask = cols < N
-            mask = row_mask and col_mask
+            mask = row_mask & col_mask
 
             a = tl.load(new_inp + cols, mask, other=-float("inf"))
             _all = tl.maximum(a, _all)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/any.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/any.py
@@ -57,10 +57,10 @@ def any_kernel_dim(
     for off in range(0, N, BLOCK_N):
         cols = off + tl.arange(0, BLOCK_N)[None, :]
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
 
         a = tl.load(inp + cols, mask, other=0.0)
-        _any = _any or (a != 0)
+        _any = _any | (a != 0)
     any = tl.reduce(_any, axis=1, combine_fn=reduce_any)
     tl.store(out, any[:, None], row_mask)
 
@@ -85,13 +85,13 @@ def any_kernel_1(
         offset = off + tl.arange(0, BLOCK_SIZE)
         mask = offset < M
         inp_val = tl.load(inp + offset, mask=mask, other=0.0)
-        _tmp = _tmp or (inp_val != 0)
+        _tmp = _tmp | (inp_val != 0)
 
     # Reset to original reduce programming mode after optimizing the tl.reduce.
     for x in tl.static_range(1, int(ITER_NUM), 1):
         _tmp[: BLOCK_SIZE // (2**x)] = (
             _tmp[: BLOCK_SIZE // (2**x)]
-            or _tmp[BLOCK_SIZE // (2**x) : (BLOCK_SIZE // (2**x)) * 2]
+            | _tmp[BLOCK_SIZE // (2**x) : (BLOCK_SIZE // (2**x)) * 2]
         )
 
     tl.atomic_or(out, _tmp[0].to(tl.int32))

--- a/src/flag_gems/runtime/backend/_cambricon/ops/argmax.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/argmax.py
@@ -136,7 +136,7 @@ def argmax_kernel(
     for start_n in range(0, N, BLOCK_N):
         n_offset = start_n + tl.arange(0, BLOCK_N)
         offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=-float("inf"))
         local_max, local_argmax = tl.max(

--- a/src/flag_gems/runtime/backend/_cambricon/ops/cumsum.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/cumsum.py
@@ -195,7 +195,7 @@ def cumsum_blelloch(
         n_offset = col_offset + tl.arange(0, BLOCK_N)
         # Pointers to the start of the row
         offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
         x_ptrs = inp + offsets
         y_ptrs = out + offsets
 
@@ -332,9 +332,11 @@ def cumsum_kernel_mid(
         * K
         + k_offset[None, None, :]
     )
-    mask = (m_offset[:, None, None] < M and n_offset[None, :, None] < N) and k_offset[
-        None, None, :
-    ] < K
+    mask = (
+        (m_offset[:, None, None] < M)
+        & (n_offset[None, :, None] < N)
+        & (k_offset[None, None, :] < K)
+    )
     x_ptrs = inp + offsets
     y_ptrs = out + offsets
 
@@ -348,7 +350,7 @@ def cumsum_kernel_mid(
     prefix_sum_offsets = (
         m_offset[:, None] * num_jobs_n * K + pid_n * K + k_offset[None, :]
     )
-    prefix_sum_mask = m_offset[:, None] < M and k_offset[None, :] < K
+    prefix_sum_mask = (m_offset[:, None] < M) & (k_offset[None, :] < K)
     prefix_sum_ptrs = prefix_sum + prefix_sum_offsets
     tl.store(prefix_sum_ptrs, x_block[:, BLOCK_N - 1, :], prefix_sum_mask)
 
@@ -425,9 +427,11 @@ def cumsum_kernel_result(
         * K
         + k_offset[None, None, :]
     )
-    mask = (m_offset[:, None, None] < M and n_offset[None, :, None] < N) and k_offset[
-        None, None, :
-    ] < K
+    mask = (
+        (m_offset[:, None, None] < M)
+        & (n_offset[None, :, None] < N)
+        & (k_offset[None, None, :] < K)
+    )
     x_ptrs = inp + offsets
     y_ptrs = out + offsets
 
@@ -438,7 +442,7 @@ def cumsum_kernel_result(
         sum_offsets = (
             m_offset[:, None] * num_jobs_n * K + (pid_n - 1) * K + k_offset[None, :]
         )
-        sum_mask = m_offset[:, None] < M and k_offset[None, :] < K
+        sum_mask = (m_offset[:, None] < M) & (k_offset[None, :] < K)
         sum_ptrs = prefix_sum + sum_offsets
         sum_block = tl.load(sum_ptrs, mask=sum_mask, other=0.0).to(tl.dtype(DTYPE))
         x_block += sum_block[:, None, :]

--- a/src/flag_gems/runtime/backend/_cambricon/ops/groupnorm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/groupnorm.py
@@ -140,9 +140,8 @@ def group_norm_kernel_opt(
             mean = tl.zeros([BLOCK_GROUP_SIZE, BLOCK_HW_SIZE], tl.float32)
             var = tl.zeros([BLOCK_GROUP_SIZE, BLOCK_HW_SIZE], tl.float32)
             for idy in range(0, hw_iter):
-                xy_mask = (
-                    group_offset[:, None] < group_size
-                    and (idy * BLOCK_HW_SIZE + hw_offset[None, :]) < HW
+                xy_mask = (group_offset[:, None] < group_size) & (
+                    (idy * BLOCK_HW_SIZE + hw_offset[None, :]) < HW
                 )
                 tmp = tl.load(
                     X + idy * BLOCK_HW_SIZE + xy_offset,
@@ -168,9 +167,8 @@ def group_norm_kernel_opt(
                 bias = tl.load(B_ptr + group_offset, cache_modifier=".cg")[:, None]
 
             for idy in range(0, hw_iter):
-                xy_mask = (
-                    group_offset[:, None] < group_size
-                    and (idy * BLOCK_HW_SIZE + hw_offset[None, :]) < HW
+                xy_mask = (group_offset[:, None] < group_size) & (
+                    (idy * BLOCK_HW_SIZE + hw_offset[None, :]) < HW
                 )
                 tmp = tl.load(
                     X + idy * BLOCK_HW_SIZE + xy_offset,

--- a/src/flag_gems/runtime/backend/_cambricon/ops/index_add.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/index_add.py
@@ -61,7 +61,7 @@ def index_add_kernel(
 
     rows_mask = rows_offsets < M
     index_mask = cols_offsets < N
-    block_mask = rows_mask and index_mask
+    block_mask = rows_mask & index_mask
 
     cur_indices = tl.load(index + cols_offsets, mask=index_mask, other=0)
     inp_off = rows_offsets * inp_len + cur_indices[None, :]

--- a/src/flag_gems/runtime/backend/_cambricon/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/index_select.py
@@ -269,7 +269,7 @@ def multi_batch_index_select_kernel(
 
         input_output_mask = (
             batch_mask[:, None, None]
-            and (index_mask[:, None] and c_mask[None, :])[None, :, :]
+            & (index_mask[:, None] & c_mask[None, :])[None, :, :]
         )
 
         index_cur = tl.load(index + index_offsets, mask=index_mask, other=0)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/isin.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/isin.py
@@ -58,11 +58,11 @@ def isin_by_comparation_impl(
     for col_off in range(0, N, BLOCK_N):
         cols = col_off + tl.arange(0, BLOCK_N)[None, :]
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
         in1 = tl.load(in1_ravel_ptr + cols, mask, other=0)
         block = tl.where(
             mask,
-            tl.where(invert, block and (in0 != in1), block or (in0 == in1)),
+            tl.where(invert, block & (in0 != in1), block | (in0 == in1)),
             invert,
         )
     out = tl.reduce(block, axis=1, combine_fn=(reduce_all if invert else reduce_any))
@@ -166,9 +166,9 @@ def isin_by_search_impl(
     for i in range(log_n):
         mid = tl.where(while_mask, start + (end - start) // 2, 0)
         mid_val = tl.load(in1_sorted_ptr + mid, mask=while_mask)
-        out = tl.where(while_mask, out or (mid_val == in0_ravel), out)  # found
-        start = tl.where(while_mask and (mid_val < in0_ravel), mid + 1, start)
-        end = tl.where(while_mask and (mid_val > in0_ravel), mid, end)
+        out = tl.where(while_mask, out | (mid_val == in0_ravel), out)  # found
+        start = tl.where(while_mask & (mid_val < in0_ravel), mid + 1, start)
+        end = tl.where(while_mask & (mid_val > in0_ravel), mid, end)
         while_mask = start < end
 
     # store out

--- a/src/flag_gems/runtime/backend/_cambricon/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/layernorm.py
@@ -148,7 +148,7 @@ def layer_norm_kernel_non_inner(
     # for off in range(0, N, BLOCK_COL_SIZE):
     cols = tl.arange(0, BLOCK_COL_SIZE)[None, :]
     col_mask = cols < N
-    mask = row_mask and col_mask
+    mask = row_mask & col_mask
     a = tl.load(X + cols, mask, other=0.0).to(tl.float32)
     _mean += a
     _var += a * a
@@ -213,7 +213,7 @@ def layer_norm_kernel_inner(
     for off in range(0, N, BLOCK_COL_SIZE):
         cols = off + block_col_size
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
         a = tl.load(X + cols, mask, other=0.0).to(tl.float32)
         _mean += a
         _var += a * a
@@ -232,7 +232,7 @@ def layer_norm_kernel_inner(
     for off in range(0, N, BLOCK_COL_SIZE):
         cols = off + block_col_size
         col_mask = cols < N
-        mask = row_mask and col_mask
+        mask = row_mask & col_mask
         if W is None:
             w = 1
         else:
@@ -306,7 +306,7 @@ def input_backward_kernel(
         for off in range(0, N, BLOCK_COL_SIZE):
             cols = off + tl.arange(0, BLOCK_COL_SIZE)
             col_mask = cols[None, :] < N
-            mask = row_mask and col_mask
+            mask = row_mask & col_mask
             dy = tl.load(new_dY + cols[None, :], mask, other=0.0).to(tl.float32)
             x = tl.load(new_X + cols[None, :], mask, other=0.0).to(tl.float32)
             x_hat = (x - mean) * rstd
@@ -326,7 +326,7 @@ def input_backward_kernel(
         for off in range(0, N, BLOCK_COL_SIZE):
             cols = off + tl.arange(0, BLOCK_COL_SIZE)
             col_mask = cols[None, :] < N
-            mask = row_mask and col_mask
+            mask = row_mask & col_mask
             dy = tl.load(new_dY + cols[None, :], mask, other=0.0).to(tl.float32)
             x = tl.load(new_X + cols[None, :], mask, other=0.0).to(tl.float32)
             if W is None:
@@ -379,7 +379,7 @@ def weight_bias_backward_kernel(
         for off in range(0, M, BLOCK_ROW_SIZE):
             rows = off + tl.arange(0, BLOCK_ROW_SIZE)
             row_mask = rows[:, None] < M
-            mask = row_mask and col_mask
+            mask = row_mask & col_mask
             dy = tl.load(new_dY + rows[:, None] * N, mask, other=0.0).to(tl.float32)
             x = tl.load(new_X + rows[:, None] * N, mask, other=0.0).to(tl.float32)
             mean = tl.load(Mean + rows, mask=rows < M, other=0.0)[:, None].to(

--- a/src/flag_gems/runtime/backend/_cambricon/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/log_softmax.py
@@ -348,7 +348,7 @@ def log_softmax_kernel_inner(
             for start_n in range(0, N, BLOCK_N):
                 n_offset = start_n + tl.arange(0, BLOCK_N)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_offset[:, None] < M and n_offset[None, :] < N
+                mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
                 inp = tl.load(input_ptr + offset, mask=mask, other=-float("inf")).to(
                     tl.float32
                 )
@@ -373,7 +373,7 @@ def log_softmax_kernel_inner(
             for start_n in range(0, N, BLOCK_N):
                 n_offset = start_n + tl.arange(0, BLOCK_N)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_offset[:, None] < M and n_offset[None, :] < N
+                mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
                 inp = tl.load(input_ptr + offset, mask=mask, other=-float("inf")).to(
                     tl.float32
                 )
@@ -767,7 +767,7 @@ def log_softmax_backward_kernel_inner(
             m_offset = m_start + m_idx + tl.arange(0, BLOCK_M)
             n_offset = tl.arange(0, BLOCK_N)
             offset = m_offset[:, None] * N + n_offset[None, :]
-            mask = m_offset[:, None] < M and n_offset[None, :] < N
+            mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
             out_tile = tl.load(output_ptr + offset, mask=mask).to(tl.float32)
             out_grad_tile = tl.load(out_grad_ptr + offset, mask=mask).to(tl.float32)
             scale = tl.sum(out_grad_tile, 1)
@@ -780,14 +780,14 @@ def log_softmax_backward_kernel_inner(
             for start_n in range(0, N, BLOCK_N):
                 n_offset = start_n + tl.arange(0, BLOCK_N)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_offset[:, None] < M and n_offset[None, :] < N
+                mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
                 out_grad_tile = tl.load(out_grad_ptr + offset, mask=mask).to(tl.float32)
                 scale += out_grad_tile
             scale = tl.sum(scale, 1)
             for start_n in range(0, N, BLOCK_N):
                 n_offset = start_n + tl.arange(0, BLOCK_N)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_offset[:, None] < M and n_offset[None, :] < N
+                mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
                 out_tile = tl.load(
                     output_ptr + offset, mask=mask, eviction_policy="evict_first"
                 ).to(tl.float32)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/masked_fill.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/masked_fill.py
@@ -38,9 +38,9 @@ def masked_fill_kernel(inp, expand_mask, value, out, N, BLOCK_SIZE: tl.constexpr
     mask = offsets < N
 
     fill_mask = tl.load(expand_mask + offsets, mask=mask, other=0).to(tl.int1)
-    cur_inp = tl.load(inp + offsets, mask=(not fill_mask) and mask, other=0)
-    tl.store(out + offsets, cur_inp, (not fill_mask) and mask)
-    tl.store(out + offsets, value, fill_mask and mask)
+    cur_inp = tl.load(inp + offsets, mask=(~fill_mask) & mask, other=0)
+    tl.store(out + offsets, cur_inp, (~fill_mask) & mask)
+    tl.store(out + offsets, value, fill_mask & mask)
 
 
 @libtuner(
@@ -60,7 +60,7 @@ def masked_fill_kernel_self(inp, expand_mask, value, N, BLOCK_SIZE: tl.constexpr
 
         fill_mask = tl.load(expand_mask + offsets, mask=mask, other=0).to(tl.int1)
         cur_val = tl.full((BLOCK_SIZE,), value, dtype=inp.dtype.element_ty)
-        tl.store(inp + offsets, cur_val, fill_mask and mask)
+        tl.store(inp + offsets, cur_val, fill_mask & mask)
 
 
 def masked_fill(inp, mask, value):

--- a/src/flag_gems/runtime/backend/_cambricon/ops/max.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/max.py
@@ -211,7 +211,7 @@ def max_kernel(
         n_offset = i + tl.arange(0, BLOCK_N)
         offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
         # set mask
-        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=min_value)
         max_value, max_index = tl.max(inp_vals, axis=1, return_indices=True)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/mean.py
@@ -93,7 +93,7 @@ def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr)
         for off in range(0, N, BLOCK_N):
             cols = off + tl.arange(0, BLOCK_N)[None, :]
             col_mask = cols < N
-            mask = row_mask and col_mask
+            mask = row_mask & col_mask
 
             a = tl.load(X_ptr + cols, mask, other=0.0).to(tl.float32)
             _mean += a

--- a/src/flag_gems/runtime/backend/_cambricon/ops/min.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/min.py
@@ -201,7 +201,7 @@ def min_kernel(
     for start_n in range(0, N, BLOCK_N):
         n_offset = start_n + tl.arange(0, BLOCK_N)
         offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        mask = (m_offset[:, None] < M) & (n_offset[None, :] < N)
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=max_value)
         local_min, local_argmin = tl.min(inp_vals, 1, return_indices=True)

--- a/src/flag_gems/runtime/backend/_cambricon/ops/nonzero.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/nonzero.py
@@ -53,7 +53,7 @@ def nonzero_kernel(
         mask = offset < n_elements
 
         inp_vals = tl.load(inp + offset, mask=mask, other=0.0).to(tl.int1)
-        nonzero_mask = mask and inp_vals
+        nonzero_mask = mask & inp_vals
         out_row_offset = tl.load(prefix_sum + offset, mask=nonzero_mask) - 1
         out_col_offset = tl.arange(0, ndim)
         out_offsets = out_row_offset[:, None] * ndim + out_col_offset[None, :]

--- a/src/flag_gems/runtime/backend/_cambricon/ops/pad.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/pad.py
@@ -505,7 +505,7 @@ def pad_1d_constant_kernel(
     out_elements = pad_left + inp_elements + pad_right
     for off in range(start, out_elements, step):
         inp_offset = off + tl.arange(0, BLOCK_SIZE) - pad_left
-        inp_mask = inp_offset >= 0 and inp_offset < inp_elements
+        inp_mask = (inp_offset >= 0) & (inp_offset < inp_elements)
         inp = tl.load(inp_ptr + inp_offset, mask=inp_mask, other=pad_value)
         out_offset = off + tl.arange(0, BLOCK_SIZE)
         out_mask = out_offset < out_elements
@@ -544,15 +544,18 @@ def pad_2d_constant_kernel(
         offset_h = tl.arange(0, BLOCK_H) + batch_idx - pad_top
         offset_w = tl.arange(0, out_W) - pad_left
         offsets = offset_h[:, None] * W + offset_w[None, :]
-        mask = (offset_h[:, None] >= 0 and offset_h[:, None] < H) and (
-            offset_w[None, :] >= 0 and offset_w[None, :] < W
+        mask = (
+            (offset_h[:, None] >= 0)
+            & (offset_h[:, None] < H)
+            & (offset_w[None, :] >= 0)
+            & (offset_w[None, :] < W)
         )
         inp = tl.load(inp_ptr + offsets, mask=mask, other=pad_value)
 
         out_offset_c = tl.arange(0, out_W)
         out_offset_n = tl.arange(0, BLOCK_H) + batch_idx
         out_offsets = out_offset_n[:, None] * out_W + out_offset_c[None, :]
-        out_mask = out_offset_n[:, None] < out_H and out_offset_c[None, :] < out_W
+        out_mask = (out_offset_n[:, None] < out_H) & (out_offset_c[None, :] < out_W)
         tl.store(out_ptr + out_offsets, inp, mask=out_mask)
 
 

--- a/src/flag_gems/runtime/backend/_cambricon/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/randperm.py
@@ -265,7 +265,7 @@ def digit_hist_kernel(
         blk_bin_start = bin_segid * bins_segment
         for s in range(bins_segment):
             bin_id = s + blk_bin_start
-            digit_mask = tl.where(key_digit == bin_id and key_mask, 1, 0)
+            digit_mask = tl.where((key_digit == bin_id) & key_mask, 1, 0)
             digit_sum = tl.sum(digit_mask)
             # +1 for exclusive
             bin_offset = p * (bins + 1) * grid0 + (bin_id + 1) * grid0 + pid0

--- a/src/flag_gems/runtime/backend/_cambricon/ops/triu.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/triu.py
@@ -57,7 +57,7 @@ def triu_kernel(
             for n_offset in range(0, N, N_BLOCK_SIZE):
                 cols = n_offset + tl.arange(0, N_BLOCK_SIZE)[None, :]
                 n_mask = cols < N
-                mask = m_mask and n_mask
+                mask = m_mask & n_mask
 
                 x = tl.load(PX + cols, mask, other=0.0)
                 y = tl.where(row + diagonal <= cols, x, 0.0)
@@ -107,7 +107,7 @@ def triu_batch_kernel(
 
     cols = mn_id * MN_BLOCK_SIZE + tl.arange(0, MN_BLOCK_SIZE)[None, :]
     mn_mask = cols < MN
-    mask = batch_mask and mn_mask
+    mask = batch_mask & mn_mask
     x = tl.load(X + cols, mask, other=0.0)
     m = cols // N
     n = cols % N

--- a/src/flag_gems/runtime/backend/_cambricon/ops/weightnorm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/weightnorm.py
@@ -55,7 +55,7 @@ def weight_norm_kernel_last(
     v_block = tl.zeros([BLOCK_COL_SIZE, BLOCK_ROW_SIZE], dtype=tl.float32)
     for base in range(0, M, BLOCK_ROW_SIZE):
         row_offset = base + ty
-        mask = row_offset < M and col_mask
+        mask = (row_offset < M) & col_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         v_block += v_value * v_value
 
@@ -65,7 +65,7 @@ def weight_norm_kernel_last(
 
     for base in range(0, M, BLOCK_ROW_SIZE):
         row_offset = base + ty
-        mask = row_offset < M and col_mask
+        mask = (row_offset < M) & col_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         v_vec = v_value / normalized[:, None]
         out = v_vec * g_value
@@ -194,7 +194,7 @@ def weight_norm_kernel_first(
             for start_n in range(0, N, BLOCK_COL_SIZE):
                 n_offset = start_n + tl.arange(0, BLOCK_COL_SIZE)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_mask and n_offset[None, :] < N
+                mask = m_mask & (n_offset[None, :] < N)
                 v_value = tl.load(v + offset, mask=mask).to(tl.float32)
                 v_block += v_value * v_value
 
@@ -205,7 +205,7 @@ def weight_norm_kernel_first(
             for start_n in range(0, N, BLOCK_COL_SIZE):
                 n_offset = start_n + tl.arange(0, BLOCK_COL_SIZE)
                 offset = m_offset[:, None] * N + n_offset[None, :]
-                mask = m_mask and n_offset[None, :] < N
+                mask = m_mask & (n_offset[None, :] < N)
                 v_value = tl.load(v + offset, mask=mask).to(tl.float32)
                 v_vec = v_value / normalized[:, None]
                 out = v_vec * g_value
@@ -246,7 +246,7 @@ def weight_norm_bwd_kernel_last(
     vw_block = tl.zeros([BLOCK_COL_SIZE, BLOCK_ROW_SIZE], dtype=tl.float32)
     for base in range(0, M, BLOCK_ROW_SIZE):
         row_offset = base + ty
-        mask = row_offset < M and col_mask
+        mask = (row_offset < M) & col_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         w_value = tl.load(w + row_offset * N + col_offset, mask=mask).to(tl.float32)
         vw_block += v_value * w_value
@@ -254,7 +254,7 @@ def weight_norm_bwd_kernel_last(
 
     for base in range(0, M, BLOCK_ROW_SIZE):
         row_offset = base + ty
-        mask = row_offset < M and col_mask
+        mask = (row_offset < M) & col_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         w_value = tl.load(w + row_offset * N + col_offset, mask=mask).to(tl.float32)
         v_grad_value = g_value * (w_value * norm_1 - v_value * norm_3 * vw_sum)
@@ -298,7 +298,7 @@ def weight_norm_bwd_kernel_first(
     v_block = tl.zeros([BLOCK_ROW_SIZE, BLOCK_COL_SIZE], dtype=tl.float32)
     for base in range(0, N, BLOCK_COL_SIZE):
         col_offset = base + tx
-        mask = col_offset < N and row_mask
+        mask = (col_offset < N) & row_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         w_value = tl.load(w + row_offset * N + col_offset, mask=mask).to(tl.float32)
         v_block += v_value * w_value
@@ -306,7 +306,7 @@ def weight_norm_bwd_kernel_first(
 
     for base in range(0, N, BLOCK_COL_SIZE):
         col_offset = base + tx
-        mask = col_offset < N and row_mask
+        mask = (col_offset < N) & row_mask
         v_value = tl.load(v + row_offset * N + col_offset, mask=mask).to(tl.float32)
         w_value = tl.load(w + row_offset * N + col_offset, mask=mask).to(tl.float32)
         v_grad_value = g_value * (w_value * norm_1 - v_value * norm_3 * vw_sum)


### PR DESCRIPTION
Fixes #5744

Cambricon kernels in `ops/` and `fused/` combine tensor masks with Python `and`/`or`/`not`, which calls `__bool__` on a multi-element tensor. This emits:

    UserWarning: Logical operators 'and' and 'or' are deprecated for non-scalar tensors

and produces wrong masks. Replace them with elementwise `&`/`|`/`~`, adding parentheses where `&` binds tighter than `<` (e.g. `a < M & b < N` would otherwise parse as a chained comparison).

23 files changed, 92 insertions, 85 deletions.

This PR was written in part with the assistance of generative AI.