### PR TITLE
[Triton] Fix tl.where input param in randperm op

### DIFF
--- a/src/flag_gems/ops/randperm.py
+++ b/src/flag_gems/ops/randperm.py
@@ -111,16 +111,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_ascend/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/randperm.py
@@ -112,19 +112,19 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     if tl.constexpr(k.dtype == tl.int8):
         ik = k.to(tl.int8, bitcast=True)
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
         ik = k.to(tl.int16, bitcast=True)
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
         ik = k.to(tl.int32, bitcast=True)
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
         ik = k.to(tl.int64, bitcast=True)
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_cambricon/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/randperm.py
@@ -222,16 +222,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_enflame/gcu300/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu300/ops/randperm.py
@@ -112,10 +112,10 @@ def radix_type_convert(k):
     tl.static_assert(k.dtype != tl.int64, "int64 is not supported")
     ik = k.to(tl.int32)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
         # XOR with sign bit flips it: clears if set, sets if not

--- a/src/flag_gems/runtime/backend/_enflame/gcu400/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu400/ops/randperm.py
@@ -111,16 +111,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_hygon/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/randperm.py
@@ -111,16 +111,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/randperm.py
@@ -112,19 +112,19 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     if tl.constexpr(k.dtype == tl.int8):
         ik = k.to(tl.int8, bitcast=True)
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
         ik = k.to(tl.int16, bitcast=True)
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
         ik = k.to(tl.int32, bitcast=True)
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
         ik = k.to(tl.int64, bitcast=True)
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_mthreads/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/randperm.py
@@ -111,16 +111,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k

--- a/src/flag_gems/runtime/backend/_sunrise/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/randperm.py
@@ -111,16 +111,16 @@ def bitonic_sortbykey_kernel(
 def radix_type_convert(k):
     ik = k.to(tl.int64)
     if tl.constexpr(k.dtype == tl.int8):
-        mask = (ik >> 7) & 0x1
+        mask = ((ik >> 7) & 0x1) != 0
         o = tl.where(mask, ik & 0x7F, ik | 0x80)
     elif tl.constexpr(k.dtype == tl.int16):
-        mask = (ik >> 15) & 0x1
+        mask = ((ik >> 15) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFF, ik | 0x8000)
     elif tl.constexpr(k.dtype == tl.int32):
-        mask = (ik >> 31) & 0x1
+        mask = ((ik >> 31) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFF, ik | 0x80000000)
     elif tl.constexpr(k.dtype == tl.int64):
-        mask = (ik >> 63) & 0x1
+        mask = ((ik >> 63) & 0x1) != 0
         o = tl.where(mask, ik & 0x7FFFFFFFFFFFFFFF, ik | 0x8000000000000000)
     else:
         o = k


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
tl.where input param `condition` should be tl.int1, or cause warning from https://github.com/triton-lang/triton/blob/release/3.6.x/python/triton/language/semantic.py#L1668

```python
    def where(self, condition: TensorTy, x: TensorTy, y: TensorTy) -> TensorTy:
        if condition.dtype != tl.int1:
            warnings.warn(
                f"tl.where with a non-boolean condition is deprecated and will error out in a future triton release. Got {condition.dtype}"
            )
        ...
```

### Issue


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

