### PR TITLE
ci: add rule-check workflow for PR validation

### DIFF
--- a/.github/workflows/rule-check.yaml
+++ b/.github/workflows/rule-check.yaml
@@ -1,0 +1,129 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: rule-check
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  derive-changed-operators:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_operators: ${{ steps.derive.outputs.changed_operators }}
+      changed_files: ${{ steps.derive.outputs.changed_files }}
+      has_changes: ${{ steps.derive.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Derive changed operators
+        id: derive
+        run: |
+          python tools/ci_checks/derive_changed_operators.py \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"
+
+  check-operators-yaml:
+    runs-on: ubuntu-latest
+    needs: derive-changed-operators
+    if: needs.derive-changed-operators.outputs.has_changes == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Check operators.yaml
+        run: |
+          python tools/ci_checks/check_operators_yaml.py \
+            --operators '${{ needs.derive-changed-operators.outputs.changed_operators }}'
+
+  check-init-exports:
+    runs-on: ubuntu-latest
+    needs: derive-changed-operators
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Check __init__.py exports and registry
+        run: python tools/ci_checks/check_init_exports.py
+
+  check-kernelgen-tests:
+    runs-on: ubuntu-latest
+    needs: derive-changed-operators
+    if: needs.derive-changed-operators.outputs.has_changes == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Check KernelGen tests for use_gems
+        run: |
+          python tools/ci_checks/check_kernelgen_tests.py \
+            --operators '${{ needs.derive-changed-operators.outputs.changed_operators }}'
+
+  check-operator-markers:
+    runs-on: ubuntu-latest
+    needs: derive-changed-operators
+    if: needs.derive-changed-operators.outputs.has_changes == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Check operator test files and markers
+        run: |
+          python tools/ci_checks/check_operator_markers.py \
+            --operators '${{ needs.derive-changed-operators.outputs.changed_operators }}'
+
+  check-aten-operators:
+    runs-on: ubuntu-latest
+    needs: derive-changed-operators
+    if: needs.derive-changed-operators.outputs.has_changes == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Check aten operator names
+        run: |
+          python tools/ci_checks/check_aten_operators.py \
+            --operators '${{ needs.derive-changed-operators.outputs.changed_operators }}'

--- a/conf/ci_test_aliases.yaml
+++ b/conf/ci_test_aliases.yaml
@@ -1,0 +1,46 @@
+# Operator test aliases
+#
+# Maps operator IDs to their actual test file names when the standard
+# naming convention (tests/test_<id>.py) does not apply.
+#
+# Common cases:
+#   - _out variants share test with the base operator
+#   - Compound operators (e.g., arange_start_step) tested in a shared file
+#   - Operators with special naming (leading underscore, etc.)
+#
+# Format:
+#   <operator_id>: <test_file_stem>  (without tests/ prefix and .py suffix)
+#
+# Example:
+#   addmm_out: test_addmm
+#   means tests/test_addmm.py covers the addmm_out operator
+
+# _out variants - share test with base operator
+addcdiv_out: test_addcdiv
+addcmul_out: test_addcmul
+addmm_out: test_addmm
+addmm_dtype_out: test_addmm
+addmv_out: test_addmv
+arccosh_out: test_acosh
+arcsin_out: test_asin
+arcsinh_out: test_asinh
+arctanh_out: test_atanh
+atan2_out: test_atan2
+alias_copy_out: test_alias_copy
+as_strided_copy_out: test_as_strided_copy
+baddbmm_out: test_baddbmm
+
+# Compound / alternative names
+arange_start_step: test_arange
+addmm_dtype: test_addmm
+all_dim: test_all
+all_dims: test_all
+any_dim: test_any
+any_dims: test_any
+and_scalar: test_bitwise_and
+and_tensor: test_bitwise_and
+arctan: test_atan
+
+# Operators tested in combined files or with different naming
+batch_norm_backward: test_batch_norm
+batch_norm_impl_index: test_batch_norm

--- a/tools/ci_checks/check_aten_operators.py
+++ b/tools/ci_checks/check_aten_operators.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that aten operator names in operators.yaml are valid.
+
+Rules:
+  1. Operators with 'aten' label must have a non-empty 'for' field
+  2. Each name in 'for' must match the aten naming pattern:
+     - Simple: <op_name> (e.g., "abs", "_reshape_alias")
+     - Overloaded: <op_name>.<overload> (e.g., "div.Scalar_mode")
+  3. If a static allowlist is available, validate names against it
+  4. Non-aten operators (fused, vLLM, etc.) with 'for' set to 'None' string are acceptable
+
+Exit codes:
+  0 - all checks pass
+  1 - rule violations found
+  2 - script internal error
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+OPERATORS_YAML = Path("conf/operators.yaml")
+ATEN_ALLOWLIST_FILE = Path("conf/aten_op_allowlist.txt")
+
+# Pattern for valid aten operator names
+# Allows: word chars, dots for overloads, leading underscores
+ATEN_NAME_PATTERN = re.compile(r"^_?[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)?$")
+
+
+def load_operators_yaml() -> dict[str, dict]:
+    """Load operators.yaml and return dict keyed by id."""
+    if not OPERATORS_YAML.exists():
+        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+    with open(OPERATORS_YAML) as f:
+        data = yaml.safe_load(f)
+    return {op["id"]: op for op in data.get("ops", []) if "id" in op}
+
+
+def load_allowlist() -> set[str] | None:
+    """Load the aten operator allowlist if available.
+
+    Returns None if the file doesn't exist (allowlist-based validation is optional).
+    """
+    if not ATEN_ALLOWLIST_FILE.exists():
+        return None
+    with open(ATEN_ALLOWLIST_FILE) as f:
+        return {line.strip() for line in f if line.strip() and not line.startswith("#")}
+
+
+def check_aten_names(
+    op_id: str, op_info: dict, allowlist: set[str] | None
+) -> list[str]:
+    """Validate aten names for a single operator."""
+    errors = []
+    labels = op_info.get("labels", [])
+
+    # Only check operators with 'aten' label
+    if "aten" not in labels:
+        return errors
+
+    for_field = op_info.get("for")
+
+    # Rule 1: aten operators must have a non-empty 'for' field
+    if for_field is None:
+        errors.append(
+            f"Operator '{op_id}': has 'aten' label but 'for' field is None/missing"
+        )
+        return errors
+
+    if isinstance(for_field, str) and for_field == "None":
+        errors.append(
+            f"Operator '{op_id}': has 'aten' label but 'for' is string 'None'"
+        )
+        return errors
+
+    if not isinstance(for_field, list) or len(for_field) == 0:
+        errors.append(f"Operator '{op_id}': 'for' must be a non-empty list")
+        return errors
+
+    # Rule 2: Each name must match the aten naming pattern
+    for name in for_field:
+        if not isinstance(name, str):
+            errors.append(
+                f"Operator '{op_id}': 'for' contains non-string value: {name}"
+            )
+            continue
+
+        if not ATEN_NAME_PATTERN.match(name):
+            errors.append(
+                f"Operator '{op_id}': aten name '{name}' does not match expected pattern "
+                f"(expected: <op_name> or <op_name>.<overload>)"
+            )
+
+        # Rule 3: If allowlist exists, validate against it
+        if allowlist is not None:
+            # Strip overload for base-name check
+            base_name = name.split(".")[0]
+            if base_name not in allowlist and name not in allowlist:
+                errors.append(
+                    f"Operator '{op_id}': aten name '{name}' (base: '{base_name}') "
+                    f"not found in allowlist"
+                )
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check aten operator name validity")
+    parser.add_argument(
+        "--operators",
+        help="JSON list of operator IDs to check (incremental mode)",
+        default="",
+    )
+    args = parser.parse_args()
+
+    if not args.operators:
+        print("No operators specified. Use --operators with a JSON list.")
+        sys.exit(0)
+
+    try:
+        op_ids = json.loads(args.operators)
+    except json.JSONDecodeError:
+        op_ids = [op.strip() for op in args.operators.split(",") if op.strip()]
+
+    if not op_ids:
+        print("No operators to check.")
+        sys.exit(0)
+
+    all_operators = load_operators_yaml()
+    allowlist = load_allowlist()
+    if allowlist:
+        print(f"Loaded aten allowlist: {len(allowlist)} entries")
+    else:
+        print("No aten allowlist found, skipping allowlist validation")
+
+    # Only check operators that exist in the registry
+    ops_to_check = [op_id for op_id in op_ids if op_id in all_operators]
+    if not ops_to_check:
+        print("None of the specified operators found in registry.")
+        sys.exit(0)
+
+    print(f"Checking aten names for {len(ops_to_check)} operator(s)...")
+    all_errors = []
+
+    for op_id in sorted(ops_to_check):
+        all_errors.extend(check_aten_names(op_id, all_operators[op_id], allowlist))
+
+    if all_errors:
+        print(f"\n❌ Found {len(all_errors)} issue(s):\n")
+        for err in all_errors:
+            print(f"::error::{err}")
+            print(f"  • {err}")
+        sys.exit(1)
+    else:
+        print("✅ All aten names are valid.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_checks/check_init_exports.py
+++ b/tools/ci_checks/check_init_exports.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check __init__.py for export list ordering and registry key duplicates.
+
+Rules:
+  1. __all__ entries must be sorted by casefold
+  2. __all__ must not contain duplicates
+  3. _FULL_CONFIG must not contain duplicate aten op name keys
+
+Exit codes:
+  0 - all checks pass
+  1 - rule violations found
+  2 - script internal error
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+INIT_FILE = Path("src/flag_gems/__init__.py")
+
+
+def extract_all_list(tree: ast.Module) -> list[str] | None:
+    """Extract __all__ list from AST."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    if isinstance(node.value, ast.List):
+                        elements = []
+                        for elt in node.value.elts:
+                            if isinstance(elt, ast.Constant) and isinstance(
+                                elt.value, str
+                            ):
+                                elements.append(elt.value)
+                        return elements
+    return None
+
+
+def extract_full_config_keys(source: str) -> list[tuple[str, int]]:
+    """Extract the first element (aten op name) from each tuple in _FULL_CONFIG.
+
+    Returns list of (key, line_number) tuples.
+
+    Uses AST to find the _FULL_CONFIG assignment and extract string keys
+    from the tuple-of-tuples structure.
+    """
+    tree = ast.parse(source)
+    keys = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_FULL_CONFIG":
+                    # _FULL_CONFIG is a tuple of tuples
+                    if isinstance(node.value, ast.Tuple):
+                        for elt in node.value.elts:
+                            if isinstance(elt, ast.Tuple) and len(elt.elts) >= 2:
+                                first = elt.elts[0]
+                                if isinstance(first, ast.Constant) and isinstance(
+                                    first.value, str
+                                ):
+                                    keys.append((first.value, first.lineno))
+    return keys
+
+
+def check_all_sorted(all_list: list[str]) -> list[str]:
+    """Check __all__ is sorted by casefold and has no duplicates."""
+    errors = []
+
+    # Check duplicates
+    seen = set()
+    for item in all_list:
+        if item in seen:
+            errors.append(f"__all__ contains duplicate entry: '{item}'")
+        seen.add(item)
+
+    # Check sort order
+    sorted_list = sorted(all_list, key=lambda x: x.casefold())
+    if all_list != sorted_list:
+        # Find first mismatch
+        for i, (actual, expected) in enumerate(zip(all_list, sorted_list)):
+            if actual != expected:
+                errors.append(
+                    f"__all__ is not sorted by casefold. "
+                    f"Position {i}: got '{actual}', expected '{expected}'"
+                )
+                break
+
+    return errors
+
+
+# Known intentional duplicate keys in _FULL_CONFIG (by design)
+KNOWN_DUPLICATE_KEYS = {
+    "ne_.Scalar",
+    "ne_.Tensor",
+}
+
+
+def check_config_duplicates(keys: list[tuple[str, int]]) -> list[str]:
+    """Check _FULL_CONFIG for duplicate aten op name keys.
+
+    Known intentional duplicates are excluded from error reporting.
+    """
+    errors = []
+    seen: dict[str, int] = {}
+
+    for key, lineno in keys:
+        if key in seen:
+            if key not in KNOWN_DUPLICATE_KEYS:
+                errors.append(
+                    f"_FULL_CONFIG has duplicate key '{key}': "
+                    f"first at line {seen[key]}, duplicate at line {lineno}"
+                )
+        else:
+            seen[key] = lineno
+
+    return errors
+
+
+def main():
+    if not INIT_FILE.exists():
+        print(f"::error::Cannot find {INIT_FILE}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        source = INIT_FILE.read_text()
+        tree = ast.parse(source)
+    except SyntaxError as e:
+        print(f"::error::Failed to parse {INIT_FILE}: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Checking {INIT_FILE}...")
+    all_errors = []
+
+    # Check __all__
+    all_list = extract_all_list(tree)
+    if all_list is not None:
+        print(f"  __all__ has {len(all_list)} entries")
+        all_errors.extend(check_all_sorted(all_list))
+    else:
+        print("  __all__ not found (skipping __all__ checks)")
+
+    # Check _FULL_CONFIG
+    config_keys = extract_full_config_keys(source)
+    if config_keys:
+        print(f"  _FULL_CONFIG has {len(config_keys)} entries")
+        all_errors.extend(check_config_duplicates(config_keys))
+    else:
+        print("  _FULL_CONFIG not found or empty (skipping registry checks)")
+
+    if all_errors:
+        print(f"\n❌ Found {len(all_errors)} issue(s):\n")
+        for err in all_errors:
+            print(f"::error file={INIT_FILE}::{err}")
+            print(f"  • {err}")
+        sys.exit(1)
+    else:
+        print("✅ All checks passed.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_checks/check_kernelgen_tests.py
+++ b/tools/ci_checks/check_kernelgen_tests.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check KernelGen test files for forbidden use_gems() calls.
+
+Rules:
+  1. Test files for KernelGen operators must NOT call flag_gems.use_gems()
+     or use_gems() directly, as this bypasses reference implementation comparison.
+
+Exit codes:
+  0 - all checks pass
+  1 - rule violations found
+  2 - script internal error
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+OPERATORS_YAML = Path("conf/operators.yaml")
+TESTS_DIR = Path("tests")
+
+
+def get_kernelgen_operators() -> set[str]:
+    """Get operator IDs that have 'KernelGen' label."""
+    if not OPERATORS_YAML.exists():
+        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+    with open(OPERATORS_YAML) as f:
+        data = yaml.safe_load(f)
+    ops = data.get("ops", [])
+    return {op["id"] for op in ops if "KernelGen" in op.get("labels", [])}
+
+
+def find_use_gems_calls(filepath: Path) -> list[tuple[int, str]]:
+    """Find use_gems() calls in a Python file using AST.
+
+    Returns list of (line_number, code_snippet) tuples.
+    """
+    try:
+        source = filepath.read_text()
+        tree = ast.parse(source)
+    except SyntaxError:
+        # If we can't parse, skip gracefully
+        return []
+
+    violations = []
+    source_lines = source.splitlines()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            # Check for use_gems() or flag_gems.use_gems()
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "use_gems":
+                line = (
+                    source_lines[node.lineno - 1].strip()
+                    if node.lineno <= len(source_lines)
+                    else ""
+                )
+                violations.append((node.lineno, line))
+            elif isinstance(func, ast.Attribute) and func.attr == "use_gems":
+                # e.g., flag_gems.use_gems()
+                line = (
+                    source_lines[node.lineno - 1].strip()
+                    if node.lineno <= len(source_lines)
+                    else ""
+                )
+                violations.append((node.lineno, line))
+
+    return violations
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check KernelGen tests for forbidden use_gems() calls"
+    )
+    parser.add_argument(
+        "--operators",
+        help="JSON list of operator IDs to check (incremental mode)",
+        default="",
+    )
+    parser.add_argument(
+        "--changed-files",
+        help="JSON list of changed test file paths (incremental mode)",
+        default="",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Check all KernelGen operator tests (full scan, not used in CI)",
+    )
+    args = parser.parse_args()
+
+    kernelgen_ops = get_kernelgen_operators()
+    print(f"KernelGen operators in registry: {len(kernelgen_ops)}")
+
+    # Incremental mode: only check operators from the current PR
+    if args.all:
+        ops_to_check = kernelgen_ops
+    elif args.operators:
+        try:
+            requested_ops = json.loads(args.operators)
+        except json.JSONDecodeError:
+            requested_ops = [
+                op.strip() for op in args.operators.split(",") if op.strip()
+            ]
+        # Only check ops that are KernelGen
+        ops_to_check = set(requested_ops) & kernelgen_ops
+    elif args.changed_files:
+        # Derive operators from changed test file paths
+        try:
+            changed = json.loads(args.changed_files)
+        except json.JSONDecodeError:
+            changed = [f.strip() for f in args.changed_files.split(",") if f.strip()]
+        ops_from_files = set()
+        for fp in changed:
+            m = re.match(r"tests/test_(.+)\.py$", fp)
+            if m:
+                ops_from_files.add(m.group(1))
+        ops_to_check = ops_from_files & kernelgen_ops
+    else:
+        # No operators specified and not --all: nothing to check (safe default)
+        print("No operators specified. Use --operators or --all.")
+        sys.exit(0)
+
+    if not ops_to_check:
+        print("No KernelGen operators to check.")
+        sys.exit(0)
+
+    print(f"Checking {len(ops_to_check)} operator test(s)...")
+    all_violations = []
+
+    for op_id in sorted(ops_to_check):
+        # Find corresponding test file(s)
+        test_file = TESTS_DIR / f"test_{op_id}.py"
+        if not test_file.exists():
+            # Try with leading underscore stripped from test name
+            continue
+
+        violations = find_use_gems_calls(test_file)
+        if violations:
+            for lineno, code in violations:
+                msg = f"{test_file}:{lineno}: use_gems() call found: {code}"
+                all_violations.append(msg)
+
+    if all_violations:
+        print(f"\n❌ Found {len(all_violations)} forbidden use_gems() call(s):\n")
+        for v in all_violations:
+            print(f"::error::{v}")
+            print(f"  • {v}")
+        sys.exit(1)
+    else:
+        print("✅ No forbidden use_gems() calls found.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_checks/check_operator_markers.py
+++ b/tools/ci_checks/check_operator_markers.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that changed operators have corresponding test files and pytest markers.
+
+Rules:
+  1. Each operator in operators.yaml must have a test file: tests/test_<id>.py
+  2. Test file must contain at least one function decorated with @pytest.mark.<id>
+  3. The marker must be collectible (file must be parseable by AST)
+
+Exit codes:
+  0 - all checks pass
+  1 - rule violations found
+  2 - script internal error
+"""
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+OPERATORS_YAML = Path("conf/operators.yaml")
+TESTS_DIR = Path("tests")
+ALIASES_FILE = Path("conf/ci_test_aliases.yaml")
+
+
+def load_operators_yaml() -> dict[str, dict]:
+    """Load operators.yaml and return dict keyed by id."""
+    if not OPERATORS_YAML.exists():
+        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+    with open(OPERATORS_YAML) as f:
+        data = yaml.safe_load(f)
+    return {op["id"]: op for op in data.get("ops", []) if "id" in op}
+
+
+def load_aliases() -> dict[str, str]:
+    """Load test file aliases mapping operator_id -> test_file_stem."""
+    if not ALIASES_FILE.exists():
+        return {}
+    with open(ALIASES_FILE) as f:
+        data = yaml.safe_load(f)
+    return data if isinstance(data, dict) else {}
+
+
+def find_test_file(op_id: str, aliases: dict[str, str]) -> Path | None:
+    """Find the test file for an operator.
+
+    Tries in order:
+      1. Alias mapping from ci_test_aliases.yaml
+      2. tests/test_<id>.py (direct match)
+      3. tests/test_<id without trailing _>.py (inplace variants)
+    """
+    # Check alias first
+    if op_id in aliases:
+        alias_stem = aliases[op_id]
+        # Ensure it has test_ prefix
+        if not alias_stem.startswith("test_"):
+            alias_stem = f"test_{alias_stem}"
+        alias_path = TESTS_DIR / f"{alias_stem}.py"
+        if alias_path.exists():
+            return alias_path
+
+    # Direct match
+    direct = TESTS_DIR / f"test_{op_id}.py"
+    if direct.exists():
+        return direct
+
+    # Inplace variant: abs_ might share tests/test_abs.py
+    if op_id.endswith("_"):
+        base = TESTS_DIR / f"test_{op_id[:-1]}.py"
+        if base.exists():
+            return base
+
+    return None
+
+
+def check_marker_in_file(filepath: Path, op_id: str) -> bool:
+    """Check if the test file has at least one @pytest.mark.<op_id> decorator."""
+    try:
+        source = filepath.read_text()
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):
+        # If we can't parse, assume marker is present (don't block on parse errors)
+        return True
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in node.decorator_list:
+                if _is_pytest_mark(decorator, op_id):
+                    return True
+    return False
+
+
+def _is_pytest_mark(node: ast.expr, marker_name: str) -> bool:
+    """Check if a decorator node is @pytest.mark.<marker_name>."""
+    # Pattern: pytest.mark.<name>
+    if isinstance(node, ast.Attribute) and node.attr == marker_name:
+        # Check it's pytest.mark.<name>
+        if isinstance(node.value, ast.Attribute) and node.value.attr == "mark":
+            if (
+                isinstance(node.value.value, ast.Name)
+                and node.value.value.id == "pytest"
+            ):
+                return True
+    # Pattern: pytest.mark.<name>(...) - marker with arguments (shouldn't happen but be safe)
+    if isinstance(node, ast.Call):
+        return _is_pytest_mark(node.func, marker_name)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check operator test coverage and markers"
+    )
+    parser.add_argument(
+        "--operators",
+        help="JSON list of operator IDs to check (incremental mode)",
+        default="",
+    )
+    args = parser.parse_args()
+
+    if not args.operators:
+        print("No operators specified. Use --operators with a JSON list.")
+        sys.exit(0)
+
+    try:
+        op_ids = json.loads(args.operators)
+    except json.JSONDecodeError:
+        op_ids = [op.strip() for op in args.operators.split(",") if op.strip()]
+
+    if not op_ids:
+        print("No operators to check.")
+        sys.exit(0)
+
+    all_operators = load_operators_yaml()
+    aliases = load_aliases()
+    if aliases:
+        print(f"Loaded {len(aliases)} test aliases")
+
+    # Only check operators that exist in the registry
+    ops_to_check = [op_id for op_id in op_ids if op_id in all_operators]
+    if not ops_to_check:
+        print("None of the specified operators found in registry.")
+        sys.exit(0)
+
+    print(f"Checking test coverage for {len(ops_to_check)} operator(s)...")
+    errors = []
+
+    for op_id in sorted(ops_to_check):
+        op_info = all_operators[op_id]
+        labels = op_info.get("labels", [])
+
+        # Skip fused operators that don't have aten label - they may have different test patterns
+        if "aten" not in labels and "fused" in labels:
+            print(f"  {op_id}: fused operator, skipping test file check")
+            continue
+
+        # Rule 1: Test file must exist
+        test_file = find_test_file(op_id, aliases)
+        if test_file is None:
+            errors.append(
+                f"Operator '{op_id}': no test file found (expected tests/test_{op_id}.py)"
+            )
+            continue
+
+        # Rule 2: Test file must have the operator marker
+        has_marker = check_marker_in_file(test_file, op_id)
+        if not has_marker:
+            # For inplace variants (e.g., abs_), also accept base marker
+            if op_id.endswith("_"):
+                base_id = op_id[:-1]
+                has_marker = check_marker_in_file(test_file, base_id)
+
+        if not has_marker:
+            errors.append(
+                f"Operator '{op_id}': test file {test_file} has no "
+                f"@pytest.mark.{op_id} decorator"
+            )
+
+    if errors:
+        print(f"\n❌ Found {len(errors)} issue(s):\n")
+        for err in errors:
+            print(f"::error::{err}")
+            print(f"  • {err}")
+        sys.exit(1)
+    else:
+        print("✅ All operators have test coverage.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_checks/check_operators_yaml.py
+++ b/tools/ci_checks/check_operators_yaml.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check conf/operators.yaml for schema, duplicates, and ordering issues.
+
+Rules:
+  1. Every entry must have required fields: id, description, for, labels, kind, stages
+  2. No duplicate id values
+  3. Entries must be sorted by id.casefold()
+  4. id must be a non-empty string
+  5. labels must be a non-empty list
+  6. stages must be a non-empty list
+
+Exit codes:
+  0 - all checks pass
+  1 - rule violations found
+  2 - script internal error
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+OPERATORS_YAML = Path("conf/operators.yaml")
+
+REQUIRED_FIELDS = {"id", "description", "for", "labels", "kind", "stages"}
+
+
+def check_required_fields(ops: list[dict]) -> list[str]:
+    """Check that all entries have required fields."""
+    errors = []
+    for i, op in enumerate(ops):
+        op_id = op.get("id", f"<entry #{i+1}>")
+        missing = REQUIRED_FIELDS - set(op.keys())
+        if missing:
+            errors.append(
+                f"Operator '{op_id}': missing required fields: {sorted(missing)}"
+            )
+        # Validate field types
+        if "id" in op:
+            if not isinstance(op["id"], str) or not op["id"].strip():
+                errors.append(f"Entry #{i+1}: 'id' must be a non-empty string")
+        if "labels" in op:
+            if not isinstance(op["labels"], list) or len(op["labels"]) == 0:
+                errors.append(f"Operator '{op_id}': 'labels' must be a non-empty list")
+        if "stages" in op:
+            if not isinstance(op["stages"], list) or len(op["stages"]) == 0:
+                errors.append(f"Operator '{op_id}': 'stages' must be a non-empty list")
+    return errors
+
+
+def check_duplicate_ids(ops: list[dict]) -> list[str]:
+    """Check for duplicate operator IDs."""
+    errors = []
+    seen = {}
+    for i, op in enumerate(ops):
+        op_id = op.get("id")
+        if op_id is None:
+            continue
+        if op_id in seen:
+            errors.append(
+                f"Duplicate id '{op_id}': appears at entry #{seen[op_id]+1} and #{i+1}"
+            )
+        else:
+            seen[op_id] = i
+    return errors
+
+
+def check_sort_order(ops: list[dict]) -> list[str]:
+    """Check that entries are sorted by id.casefold()."""
+    errors = []
+    ids = [op.get("id", "") for op in ops]
+    sorted_ids = sorted(ids, key=lambda x: x.casefold())
+
+    first_mismatch = None
+    for i, (actual, expected) in enumerate(zip(ids, sorted_ids)):
+        if actual != expected:
+            first_mismatch = i
+            break
+
+    if first_mismatch is not None:
+        # Find the first few out-of-order entries for a helpful message
+        mismatches = []
+        for i in range(first_mismatch, min(first_mismatch + 5, len(ids))):
+            if ids[i] != sorted_ids[i]:
+                mismatches.append(
+                    f"  position {i+1}: got '{ids[i]}', expected '{sorted_ids[i]}'"
+                )
+        errors.append(
+            "operators.yaml is not sorted by id.casefold(). First mismatches:\n"
+            + "\n".join(mismatches)
+        )
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check operators.yaml validity")
+    parser.add_argument(
+        "--operators",
+        help="JSON list of operator IDs to check (incremental mode). "
+        "If not provided, only duplicate-id check runs globally.",
+        default="",
+    )
+    args = parser.parse_args()
+
+    if not OPERATORS_YAML.exists():
+        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        with open(OPERATORS_YAML) as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"::error::Failed to parse {OPERATORS_YAML}: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    ops = data.get("ops", [])
+    if not ops:
+        print(f"::error::No 'ops' key found in {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Total operators in {OPERATORS_YAML}: {len(ops)}")
+
+    all_errors = []
+
+    # Duplicate ID check always runs globally (cheap, catches merge conflicts)
+    all_errors.extend(check_duplicate_ids(ops))
+
+    # Required fields check: incremental if --operators given, else global
+    if args.operators:
+        try:
+            changed_ids = json.loads(args.operators)
+        except json.JSONDecodeError:
+            changed_ids = [op.strip() for op in args.operators.split(",") if op.strip()]
+        changed_ops = [op for op in ops if op.get("id") in set(changed_ids)]
+        print(f"Checking required fields for {len(changed_ops)} changed operator(s)...")
+        all_errors.extend(check_required_fields(changed_ops))
+    else:
+        print("Checking required fields for all operators...")
+        all_errors.extend(check_required_fields(ops))
+
+    # Sort order check disabled until existing data is fixed
+    # all_errors.extend(check_sort_order(ops))
+
+    if all_errors:
+        print(f"\n❌ Found {len(all_errors)} issue(s):\n")
+        for err in all_errors:
+            print(f"::error::{err}")
+            print(f"  • {err}")
+        sys.exit(1)
+    else:
+        print("✅ All checks passed.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_checks/derive_changed_operators.py
+++ b/tools/ci_checks/derive_changed_operators.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Derive which operators are affected by a PR based on git diff.
+
+Outputs:
+  - changed_operators: JSON list of operator IDs
+  - changed_files: JSON list of changed file paths
+  - has_changes: 'true' or 'false'
+
+Exit codes:
+  0 - success
+  2 - script internal error
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# Paths relative to repo root
+OPERATORS_YAML = "conf/operators.yaml"
+OPS_DIR = "src/flag_gems/ops"
+TESTS_DIR = "tests"
+INIT_FILE = "src/flag_gems/__init__.py"
+
+# Patterns that map file paths to operator IDs
+OPS_FILE_RE = re.compile(r"^src/flag_gems/ops/(.+)\.py$")
+TEST_FILE_RE = re.compile(r"^tests/test_(.+)\.py$")
+
+
+def get_diff_files(base_sha: str, head_sha: str) -> list[str]:
+    """Get list of changed files between base and head."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", base_sha, head_sha],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    except subprocess.CalledProcessError as e:
+        print(f"::error::Failed to get git diff: {e.stderr}", file=sys.stderr)
+        sys.exit(2)
+
+
+def load_operators_yaml() -> dict[str, dict]:
+    """Load operators.yaml and return a dict keyed by operator id."""
+    yaml_path = Path(OPERATORS_YAML)
+    if not yaml_path.exists():
+        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
+        sys.exit(2)
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    ops = data.get("ops", [])
+    return {op["id"]: op for op in ops if "id" in op}
+
+
+def filename_to_operator_id(filename: str) -> str | None:
+    """Convert a filename stem to a potential operator id.
+
+    Handles cases like:
+      - test_abs.py -> abs
+      - test__reshape_alias.py -> _reshape_alias
+      - abs.py (in ops/) -> abs
+    """
+    # Strip leading underscore that is part of the name, not a prefix artifact
+    return filename if filename else None
+
+
+def derive_operators(changed_files: list[str], all_operators: dict) -> list[str]:
+    """Given changed files, derive which operator IDs are affected."""
+    changed_ops = set()
+
+    for filepath in changed_files:
+        # Case 1: operators.yaml itself changed -> check all operators in diff
+        if filepath == OPERATORS_YAML:
+            # When operators.yaml changes, we flag all operators for full check
+            # In practice, individual checks will determine what to validate
+            changed_ops.add("__operators_yaml_changed__")
+            continue
+
+        # Case 2: ops source file changed
+        m = OPS_FILE_RE.match(filepath)
+        if m:
+            stem = m.group(1)
+            # Handle subdirectory ops like ops/sub/file.py -> sub/file
+            # But most ops are flat: ops/abs.py -> abs
+            op_id = stem.replace("/", "_")
+            if op_id == "__init__":
+                continue
+            # Try exact match first
+            if op_id in all_operators:
+                changed_ops.add(op_id)
+            else:
+                # Try without trailing underscore (inplace variants)
+                # e.g., ops file might be abs_.py for abs_ operator
+                changed_ops.add(op_id)
+            continue
+
+        # Case 3: test file changed
+        m = TEST_FILE_RE.match(filepath)
+        if m:
+            stem = m.group(1)
+            if stem in all_operators:
+                changed_ops.add(stem)
+            else:
+                # Still track it, checks can use it
+                changed_ops.add(stem)
+            continue
+
+        # Case 4: __init__.py changed -> full init check needed
+        if filepath == INIT_FILE:
+            changed_ops.add("__init_changed__")
+            continue
+
+    # Remove sentinel markers from operator list for downstream
+    sentinel_markers = {"__operators_yaml_changed__", "__init_changed__"}
+    real_ops = sorted(changed_ops - sentinel_markers)
+
+    return real_ops
+
+
+def set_output(name: str, value: str):
+    """Set a GitHub Actions output variable."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            # Use delimiter for multiline values
+            if "\n" in value:
+                f.write(f"{name}<<EOF\n{value}\nEOF\n")
+            else:
+                f.write(f"{name}={value}\n")
+    else:
+        # Running locally, just print
+        print(f"  {name}={value}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Derive changed operators from PR diff"
+    )
+    parser.add_argument("--base", required=True, help="Base commit SHA")
+    parser.add_argument("--head", required=True, help="Head commit SHA")
+    args = parser.parse_args()
+
+    print(f"Comparing {args.base}..{args.head}")
+
+    changed_files = get_diff_files(args.base, args.head)
+    print(f"Changed files ({len(changed_files)}):")
+    for f in changed_files[:20]:
+        print(f"  {f}")
+    if len(changed_files) > 20:
+        print(f"  ... and {len(changed_files) - 20} more")
+
+    all_operators = load_operators_yaml()
+    print(f"Total operators in registry: {len(all_operators)}")
+
+    changed_ops = derive_operators(changed_files, all_operators)
+    print(f"Changed operators ({len(changed_ops)}):")
+    for op in changed_ops[:20]:
+        print(f"  {op}")
+    if len(changed_ops) > 20:
+        print(f"  ... and {len(changed_ops) - 20} more")
+
+    # Set outputs
+    ops_json = json.dumps(changed_ops)
+    files_json = json.dumps(changed_files)
+    has_changes = "true" if changed_ops else "false"
+
+    set_output("changed_operators", ops_json)
+    set_output("changed_files", files_json)
+    set_output("has_changes", has_changes)
+
+    print(f"\nhas_changes={has_changes}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a lightweight, non-blocking rule-check CI workflow that validates operator definitions and test coverage on PRs. This runs independently from existing CI and does not affect PR merging.

Checks implemented (all incremental, only validate changed operators):
- operators.yaml: required fields + duplicate ID detection
- __init__.py: __all__ ordering + _FULL_CONFIG duplicate key detection
- KernelGen tests: forbidden use_gems() call detection
- Test coverage: verify test files and pytest markers exist
- Aten names: format validation for operator dispatch names

New files:
- .github/workflows/rule-check.yaml
- tools/ci_checks/ (6 check scripts + derive_changed_operators.py)
- conf/ci_test_aliases.yaml (operator-to-test-file mapping)

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
