### PR TITLE
fix _weight_norm: split underscore op tests into a dedicated mark

### DIFF
--- a/benchmark/test_weight_norm.py
+++ b/benchmark/test_weight_norm.py
@@ -52,9 +52,9 @@ def test_weight_norm_dim0():
     bench = base.GenericBenchmarkExcluse1D(
         op_name="weight_norm",
         input_fn=weight_norm_input_fn,
-        torch_op=torch.ops.aten._weight_norm.default,
-        dtypes=consts.FLOAT_DTYPES,
+        torch_op=torch._weight_norm,
     )
+    bench.set_gems(flag_gems.weight_norm)
     bench.run()
 
 
@@ -63,6 +63,34 @@ def test_weight_norm_dim0():
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
 def test_weight_norm_dim_last():
+    bench = base.GenericBenchmarkExcluse1D(
+        op_name="weight_norm",
+        input_fn=weight_norm_input_fn_last,
+        torch_op=torch._weight_norm,
+    )
+    bench.set_gems(flag_gems.weight_norm)
+    bench.run()
+
+
+@pytest.mark.underscore_weight_norm
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_underscore_weight_norm_dim0():
+    bench = base.GenericBenchmarkExcluse1D(
+        op_name="weight_norm",
+        input_fn=weight_norm_input_fn,
+        torch_op=torch.ops.aten._weight_norm.default,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.underscore_weight_norm
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_underscore_weight_norm_dim_last():
     bench = base.GenericBenchmarkExcluse1D(
         op_name="weight_norm",
         input_fn=weight_norm_input_fn_last,

--- a/benchmark/test_weight_norm.py
+++ b/benchmark/test_weight_norm.py
@@ -78,7 +78,7 @@ def test_weight_norm_dim_last():
 )
 def test_underscore_weight_norm_dim0():
     bench = base.GenericBenchmarkExcluse1D(
-        op_name="weight_norm",
+        op_name="_weight_norm",
         input_fn=weight_norm_input_fn,
         torch_op=torch.ops.aten._weight_norm.default,
         dtypes=consts.FLOAT_DTYPES,
@@ -92,7 +92,7 @@ def test_underscore_weight_norm_dim0():
 )
 def test_underscore_weight_norm_dim_last():
     bench = base.GenericBenchmarkExcluse1D(
-        op_name="weight_norm",
+        op_name="_weight_norm",
         input_fn=weight_norm_input_fn_last,
         torch_op=torch.ops.aten._weight_norm.default,
         dtypes=consts.FLOAT_DTYPES,

--- a/tests/test_weight_norm.py
+++ b/tests/test_weight_norm.py
@@ -54,6 +54,49 @@ def test_weight_norm(shape, dtype, dim):
 
     ref_v = utils.to_reference(v, True)
     ref_g = utils.to_reference(g, True)
+    ref_w_out = torch._weight_norm(ref_v, ref_g, dim)
+    res_w_out = flag_gems.weight_norm(v, g, dim)
+    utils.gems_assert_close(res_w_out, ref_w_out, dtype, reduce_dim=reduce_size)
+
+    res_w_grad = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_w_grad = utils.to_reference(res_w_grad, True)
+
+    ref_v_grad, ref_g_grad = torch.autograd.grad(
+        ref_w_out, (ref_v, ref_g), grad_outputs=ref_w_grad
+    )
+    res_v_grad, res_g_grad = torch.autograd.grad(
+        res_w_out, (v, g), grad_outputs=res_w_grad
+    )
+    utils.gems_assert_close(
+        res_v_grad, ref_v_grad, dtype, reduce_dim=reduce_size, equal_nan=True
+    )
+    utils.gems_assert_close(
+        res_g_grad, ref_g_grad, dtype, reduce_dim=reduce_size, equal_nan=True
+    )
+
+
+@pytest.mark.underscore_weight_norm
+# @pytest.mark.skip(reason="Issue #2860: fails assertion")
+@pytest.mark.parametrize("shape", WEIGHT_NORM_SHAPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_underscore_weight_norm(shape, dtype, dim):
+    if flag_gems.vendor_name == "cambricon":
+        torch.manual_seed(42)
+        torch.mlu.manual_seed_all(42)
+
+    dim = dim % len(shape)
+    v = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    g = torch.randn(
+        [1 if i != dim else shape[i] for i in range(v.ndim)],
+        dtype=dtype,
+        device=flag_gems.device,
+        requires_grad=True,
+    )
+    reduce_size = v.numel() // shape[dim]
+
+    ref_v = utils.to_reference(v, True)
+    ref_g = utils.to_reference(g, True)
     ref_w_out = torch.ops.aten._weight_norm(ref_v, ref_g, dim)
     with flag_gems.use_gems():
         res_w_out = torch.ops.aten._weight_norm(v, g, dim)


### PR DESCRIPTION
## Summary

Follow-up to #5080, fixing the pytest mark for the `_weight_norm` (underscore) operator.

#5080 registered the `_weight_norm` operator but kept the pytest mark as `@pytest.mark.weight_norm` (no underscore). That choice was unavoidable *literally* — pytest forbids mark names that start with an underscore (`AttributeError: Marker name must NOT start with underscore`), so `@pytest.mark._weight_norm` is not valid. But it left a real problem: the `_weight_norm` (ATen) entry point and the legacy `weight_norm` (fused) entry point now share the same `weight_norm` mark, so `-m weight_norm` can no longer select just one, and benchmark result aggregation (which keys on the first non-builtin mark) collapses both into `weight_norm`.