### PR TITLE
fix(cambricon): broadcast scalar max_virtual_index in paged load_from_kvcache

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/ops/flash_kernel.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/flash_kernel.py
@@ -1233,16 +1233,16 @@ def load_from_kvcache(
     k_offset = tl.arange(0, BLOCK_K)[:, None] + cache_offset[None, :]
     v_offset = tl.arange(0, BLOCK_K)[None, :] + cache_offset[:, None]
     if d == BLOCK_K:
-        bK_mask = virtual_index[None, :] < max_virtual_index[None, :]
-        bV_mask = virtual_index[:, None] < max_virtual_index[:, None]
+        bK_mask = virtual_index[None, :] < max_virtual_index
+        bV_mask = virtual_index[:, None] < max_virtual_index
         bK = tl.load(k_ptr_base + k_offset, mask=bK_mask, other=0.0)
         bV = tl.load(v_ptr_base + v_offset, mask=bV_mask, other=0.0)
     else:
         bK_mask = (tl.arange(0, BLOCK_K)[:, None] < d) & (
-            virtual_index[None, :] < max_virtual_index[None, :]
+            virtual_index[None, :] < max_virtual_index
         )
         bV_mask = (tl.arange(0, BLOCK_K)[None, :] < d) & (
-            virtual_index[:, None] < max_virtual_index[:, None]
+            virtual_index[:, None] < max_virtual_index
         )
         bK = tl.load(k_ptr_base + k_offset, mask=bK_mask, other=0.0)
         bV = tl.load(v_ptr_base + v_offset, mask=bV_mask, other=0.0)


### PR DESCRIPTION
Fixes #5785

`load_from_kvcache` receives `max_virtual_index` as a 0-d scalar (`k_len` from `tl.load(seqused_k_ptr + bid)` on the paged path), but the mask expressions index it with two subscripts:

```python
bK_mask = virtual_index[None, :] < max_virtual_index[None, :]
bV_mask = virtual_index[:, None] < max_virtual_index[:, None]
```

That makes the Triton compiler raise `IndexError: list index out of range` when lowering the comparison, so the kernel never compiles. Drop the subscripts and let the scalar broadcast against `virtual_index`.
