### PR TITLE
Add conj_physical_ operator with contiguous-view Triton kernel

### DIFF
--- a/benchmark/test_conj_physical_.py
+++ b/benchmark/test_conj_physical_.py
@@ -1,0 +1,76 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+
+def _input_fn(shape, dtype, device):
+    if dtype.is_complex:
+        float_dtype = torch.float32 if dtype == torch.complex64 else torch.float64
+        real = torch.randn(shape, dtype=float_dtype, device=device)
+        imag = torch.randn(shape, dtype=float_dtype, device=device)
+        input_tensor = torch.complex(real, imag).to(dtype)
+    elif dtype.is_floating_point:
+        input_tensor = torch.randn(shape, dtype=dtype, device=device)
+    else:
+        input_tensor = torch.randn(shape, device=device).to(dtype)
+    yield (input_tensor,)
+
+
+class ConjPhysicalInplaceBenchmark(base.GenericBenchmarkExcluse3D):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def set_shapes(self, shape_file_path=None):
+        conj_physical_shapes = [
+            (256,),
+            (2048, 2048),
+            (128, 512, 256),
+            (32, 64),
+            (512, 1024),
+            (2, 3, 4),
+        ]
+        self.shapes = conj_physical_shapes
+
+    def set_more_shapes(self):
+        return None
+
+
+@pytest.mark.conj_physical_
+def test_conj_physical_():
+    if flag_gems.vendor_name == "ascend":
+        # Ascend NPU: kernel-mode event timing is unstable, use operator mode.
+        # Native conj_physical_ has no complex kernel on NPU, so complex
+        # dtypes are excluded from the baseline comparison.
+        from .conftest import Config
+
+        Config.mode = consts.BenchMode.OPERATOR
+        dtypes = consts.FLOAT_DTYPES + consts.INT_DTYPES
+    else:
+        dtypes = consts.FLOAT_DTYPES + consts.INT_DTYPES + consts.COMPLEX_DTYPES
+
+    bench = ConjPhysicalInplaceBenchmark(
+        input_fn=_input_fn,
+        op_name="conj_physical_",
+        torch_op=torch.conj_physical_,
+        dtypes=dtypes,
+    )
+
+    bench.set_gems(flag_gems.conj_physical_)
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2471,6 +2471,19 @@ ops:
       - LinearAlg
     stages:
       - beta: '5.3'
+  - id: conj_physical_
+    description: |
+      In-place version of `conj_physical`.
+      Computes the element-wise conjugate of the given `input` tensor in place.
+      If `input` has a non-complex dtype, this function just returns `input`.
+    for:
+      - conj_physical_
+    labels:
+      - aten
+    kind:
+      - LinearAlg
+    stages:
+      - alpha: '5.4'
   - id: constant_pad_nd
     description: |
       Pads the input tensor boundaries with a constant value.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -426,6 +426,7 @@ _FULL_CONFIG = (
     ("concat", concat),
     ("concatenate", concatenate),
     ("conj_physical", conj_physical),
+    ("conj_physical_", conj_physical_),
     ("constant_pad_nd", constant_pad_nd),
     # ("contiguous", contiguous),
     ("conv1d", conv1d),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -291,6 +291,7 @@ from flag_gems.ops.col2im import col2im
 from flag_gems.ops.concat import concat
 from flag_gems.ops.concatenate import concatenate
 from flag_gems.ops.conj_physical import conj_physical
+from flag_gems.ops.conj_physical_ import conj_physical_
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
@@ -1195,6 +1196,7 @@ __all__ = [
     "concat",
     "concatenate",
     "conj_physical",
+    "conj_physical_",
     "constant_pad_nd",
     "contiguous",
     "conv1d",

--- a/src/flag_gems/ops/conj_physical_.py
+++ b/src/flag_gems/ops/conj_physical_.py
@@ -1,0 +1,43 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def conj_physical__kernel(ptr, n_real_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_real_elements
+    x = tl.load(ptr + offsets, mask=mask)
+    # even offsets are real parts (kept), odd offsets are imag parts (negated)
+    y = tl.where((offsets % 2) == 1, -x, x)
+    tl.store(ptr + offsets, y, mask=mask)
+
+
+def conj_physical_(input: torch.Tensor) -> torch.Tensor:
+    logger.debug("GEMS CONJ_PHYSICAL_")
+    if not input.is_complex():
+        return input
+
+    if not input.is_contiguous():
+        raise RuntimeError(
+            "conj_physical_ only supports contiguous tensors. "
+            "Please call .contiguous() before this operation."
+        )
+
+    # view complex64/128 as a flat float32/64 buffer of 2 * numel elements
+    flat = torch.view_as_real(input).view(-1)
+    n = flat.numel()
+
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n, BLOCK_SIZE),)
+    conj_physical__kernel[grid](flat, n, BLOCK_SIZE=BLOCK_SIZE)
+
+    return input

--- a/tests/test_conj_physical_.py
+++ b/tests/test_conj_physical_.py
@@ -1,0 +1,71 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    CONJ_SHAPES = [(32, 64)]
+    CONJ_DTYPES = [torch.float32]
+else:
+    CONJ_SHAPES = [(256,), (32, 64), (2, 3, 4)]
+    CONJ_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+
+
+@pytest.mark.conj_physical_
+@pytest.mark.parametrize("shape", CONJ_SHAPES)
+@pytest.mark.parametrize("is_complex", [True, False])
+@pytest.mark.parametrize("dtype", CONJ_DTYPES)
+def test_conj_physical_(shape, is_complex, dtype):
+    device = flag_gems.device
+
+    if is_complex:
+        real = torch.randn(shape, dtype=torch.float32, device=device)
+        imag = torch.randn(shape, dtype=torch.float32, device=device)
+        input = torch.complex(real, imag)
+        out_dtype = input.dtype
+        # torch_npu has no native conj_physical_ kernel for complex tensors
+        # on NPU, so build the reference manually: conj(z) = (real, -imag).
+        # Negation is exact, so this reference is bitwise reliable.
+        # Route through to_reference so the reference lives on CPU, which
+        # is required by accuracy_utils when tests run with `--ref cpu`.
+        ref_real = utils.to_reference(real, True)
+        ref_imag = utils.to_reference(imag, True)
+        ref_out = torch.complex(ref_real, -ref_imag)
+    else:
+        input = torch.randn(shape, dtype=dtype, device=device)
+        out_dtype = dtype
+        ref_out = torch.conj_physical_(utils.to_reference(input, True))
+
+    with flag_gems.use_gems():
+        res_out = torch.conj_physical_(input)
+
+    # in-place semantics: the result must alias the input storage
+    assert res_out.data_ptr() == input.data_ptr()
+    if is_complex:
+        # aclnnIsClose does not support complex64 on NPU;
+        # compare the float views instead (bitwise-equivalent content)
+        utils.gems_assert_close(
+            torch.view_as_real(res_out),
+            torch.view_as_real(ref_out),
+            torch.float32,
+            reduce_dim=1,
+        )
+    else:
+        utils.gems_assert_close(res_out, ref_out, out_dtype, reduce_dim=1)


### PR DESCRIPTION
## Summary

Adds the in-place `conj_physical_` operator (`aten::conj_physical_`) to FlagGems, implemented with a Triton kernel. For non-complex (real/integer) tensors the physical conjugate is an identity operation, so the input tensor is returned directly with no kernel launch. For complex tensors, a single contiguous-access Triton kernel negates the imaginary parts **in place** and returns the same tensor (identical `data_ptr`).

## Implementation

- **Core logic**: `src/flag_gems/ops/conj_physical_.py`.
  - Non-complex input → return `input` directly (semantic no-op, zero kernel launch, zero memory traffic).
  - Complex input → `torch.view_as_real(input).view(-1)` produces a flat, contiguous float view of the interleaved `[real, imag]` pairs; the Triton kernel then negates only the odd-indexed lanes via `tl.where((offsets % 2) == 1, -x, x)`, reading and writing through a single pointer (in-place).
- **Portability-driven design**: the kernel uses a purely contiguous access pattern with an explicit `BLOCK_SIZE=1024` instead of an interleaved strided pattern (`base*2` / `base*2+1`). The strided variant fails to compile on the Ascend Triton backend (abort in `ttir_to_linalg`), while the contiguous pattern compiles and runs correctly on all six verified backends. A fixed block size also avoids relying on backend tuning configs, which are unavailable on several of the target platforms.
- **Guardrails**: non-contiguous complex input raises `RuntimeError`; non-complex input is untouched by this restriction.
- **Registration**: exported from `src/flag_gems/ops/__init__.py` and registered in `src/flag_gems/__init__.py` (`_FULL_CONFIG`) to intercept `aten::conj_physical_`.

## Testing

- **Accuracy**: `tests/test_conj_physical_.py` follows the structure of the existing `tests/test_conj_physical.py`: 18 cases = 3 shapes `(256,), (32, 64), (2, 3, 4)` × {complex, real} × dtypes `{float16, float32, bfloat16}`.
  - Complex inputs are built via `torch.complex(real, imag)` (complex `randn` is unavailable on some backends).
  - The complex reference is constructed manually as `torch.complex(real.clone(), -imag)` because some vendor torch builds lack a native `conj_physical_` kernel for complex dtypes.
  - Complex results are compared through `torch.view_as_real()` (some vendor `isclose` kernels do not support complex dtypes).
  - In-place semantics are explicitly verified with `res_out.data_ptr() == input.data_ptr()`.
- **Platform compatibility**: accuracy 18/18 passed and benchmark suite passed on all six platforms: **Ascend 910B (CANN 8.5.0)**, **Hygon BW1000 (DTK 25.04)**, **MetaX MC550**, **T-Head PPU**, **Iluvatar**, and **NVIDIA H20**.

## Performance

Benchmark: `benchmark/test_conj_physical_.py` (mirrors `benchmark/test_conj_physical.py`; shapes `(256,)`, `(2048, 2048)`, `(128, 512, 256)`, `(32, 64)`, `(512, 1024)`, `(2, 3, 4)`).

&gt; Note: for non-complex dtypes `conj_physical_` is semantically a no-op (identity), so both native torch and Gems return immediately and speedup ≈ 1.0 simply reflects dispatch overhead parity — no kernel is launched on either side. The `complex64` rows are where the actual Triton kernel is exercised.

### NVIDIA H20

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| float32 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| bfloat16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| int16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| int32 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| **complex64** | **1.019** | **1.030** | **1.046** | **1.006** | **1.000** | **1.034** |

complex64 detail (latency in ms):

| Shape | Torch | Gems | Speedup |
|---|---|---|---|
| [256] | 0.005088 | 0.004992 | 1.019 |
| [2048, 2048] | 0.022112 | 0.021472 | 1.030 |
| [128, 512, 256] | 0.071456 | 0.068288 | 1.046 |
| [32, 64] | 0.005120 | 0.005088 | 1.006 |
| [512, 1024] | 0.007584 | 0.007584 | 1.000 |
| [2, 3, 4] | 0.004928 | 0.004768 | 1.034 |

### Ascend 910B (CANN 8.5.0)

Benchmarked in operator mode (kernel-mode event timing is unstable on this backend). complex64 is excluded from the baseline because the native Ascend torch build has no `conj_physical_` kernel for complex dtypes.

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 1.049 | 1.029 | **1.477** | 1.016 | **1.448** | 1.063 |
| float32 | 1.054 | **1.495** | 1.043 | 1.043 | 0.990 | 0.958 |
| bfloat16 | 1.036 | 0.971 | 0.993 | 0.994 | 0.975 | 0.993 |
| int16 | 1.062 | 0.992 | 1.007 | 0.994 | 0.961 | 1.022 |
| int32 | 1.037 | 0.983 | 1.025 | 1.039 | 1.029 | **1.299** |

### Hygon BW1000 (DTK 25.04)

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 0.830 | **1.528** | 1.019 | 1.159 | 1.039 | 0.981 |
| float32 | 1.000 | 0.981 | 1.000 | 1.205 | 1.182 | 1.182 |
| bfloat16 | 1.000 | 1.000 | 1.178 | 1.019 | 1.000 | 0.991 |
| int16 | 0.978 | 1.000 | 1.000 | 1.000 | 0.981 | 0.830 |
| int32 | 1.010 | 0.830 | 0.981 | 0.978 | 1.000 | 1.205 |
| **complex64** | **1.417** | **1.103** | **1.106** | **1.000** | **1.268** | **1.000** |

complex64 detail (latency in ms):

| Shape | Torch | Gems | Speedup |
|---|---|---|---|
| [256] | 0.013600 | 0.009600 | 1.417 |
| [2048, 2048] | 0.061600 | 0.055840 | 1.103 |
| [128, 512, 256] | 0.230560 | 0.208481 | 1.106 |
| [32, 64] | 0.008160 | 0.008160 | 1.000 |
| [512, 1024] | 0.014400 | 0.011360 | 1.268 |
| [2, 3, 4] | 0.008160 | 0.008160 | 1.000 |

### MetaX MC550

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 1.054 | 1.027 | 0.987 | 1.000 | 1.000 | 1.000 |
| float32 | 0.974 | 1.027 | 1.000 | 0.949 | 1.000 | 1.000 |
| bfloat16 | 1.027 | 1.027 | 1.027 | 1.027 | 1.027 | 1.000 |
| int16 | 1.000 | 1.027 | 1.000 | 0.974 | 1.000 | 1.000 |
| int32 | 1.000 | 1.000 | 1.000 | 1.000 | 0.974 | 1.000 |
| **complex64** | **1.038** | **1.031** | **1.012** | **1.038** | **1.041** | **1.060** |

complex64 detail (latency in ms):

| Shape | Torch | Gems | Speedup |
|---|---|---|---|
| [256] | 0.013824 | 0.013312 | 1.038 |
| [2048, 2048] | 0.059136 | 0.057344 | 1.031 |
| [128, 512, 256] | 0.193280 | 0.190976 | 1.012 |
| [32, 64] | 0.013824 | 0.013312 | 1.038 |
| [512, 1024] | 0.019456 | 0.018688 | 1.041 |
| [2, 3, 4] | 0.013568 | 0.012800 | 1.060 |

### T-Head PPU

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| float32 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| bfloat16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| int16 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| int32 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
| **complex64** | **1.457** | 0.979 | 0.982 | 0.982 | 0.979 | **1.348** |

complex64 detail (latency in ms):

| Shape | Torch | Gems | Speedup |
|---|---|---|---|
| [256] | 0.002680 | 0.001840 | 1.457 |
| [2048, 2048] | 0.036120 | 0.036880 | 0.979 |
| [128, 512, 256] | 0.132840 | 0.135320 | 0.982 |
| [32, 64] | 0.002240 | 0.002280 | 0.982 |
| [512, 1024] | 0.007360 | 0.007520 | 0.979 |
| [2, 3, 4] | 0.002480 | 0.001840 | 1.348 |

### Iluvatar

| dtype | [256] | [2048,2048] | [128,512,256] | [32,64] | [512,1024] | [2,3,4] |
|---|---|---|---|---|---|---|
| float16 | 0.985 | 1.021 | 1.000 | 1.000 | 1.000 | 1.000 |
| float32 | 0.980 | 0.980 | 1.000 | 1.021 | 1.000 | 1.000 |
| bfloat16 | 1.000 | 1.021 | 1.000 | 1.000 | 1.000 | 1.000 |
| int16 | 0.980 | 1.000 | 1.000 | 1.000 | 0.980 | 1.000 |
| int32 | 1.000 | 1.000 | 1.000 | 1.021 | 1.021 | 1.000 |
| **complex64** | **1.063** | **1.419** | **1.415** | **1.488** | **1.362** | **1.052** |

complex64 detail (latency in ms):

| Shape | Torch | Gems | Speedup |
|---|---|---|---|
| [256] | 0.003596 | 0.003385 | 1.063 |
| [2048, 2048] | 0.168519 | 0.118769 | 1.419 |
| [128, 512, 256] | 0.649942 | 0.459462 | 1.415 |
| [32, 64] | 0.005808 | 0.003904 | 1.488 |
| [512, 1024] | 0.025615 | 0.018808 | 1.362 |
| [2, 3, 4] | 0.003500 | 0.003327 | 1.052 |

## Files Changed

- `src/flag_gems/ops/conj_physical_.py`: new — contiguous-view in-place Triton kernel and wrapper.
- `src/flag_gems/ops/__init__.py`: import and export `conj_physical_`.
- `src/flag_gems/__init__.py`: register `("conj_physical_", conj_physical_)` in `_FULL_CONFIG`.
- `tests/test_conj_physical_.py`: new — accuracy tests (18 cases) with in-place `data_ptr` verification.
- `benchmark/test_conj_physical_.py`: new — performance benchmark across 6 shapes and all supported dtypes.