### PR TITLE
[Operator] arm: add silu op + fix bmm masked-load NaN

### DIFF
--- a/src/flag_gems/runtime/backend/_arm/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_arm/ops/__init__.py
@@ -48,6 +48,7 @@ from .pow import (
 )
 from .quantile import quantile
 from .scatter import scatter
+from .silu import silu
 from .sort import sort
 from .sub import sub
 from .topk import topk
@@ -86,6 +87,7 @@ __all__ = [
     "remainder_",
     "scaled_dot_product_attention",
     "scatter",
+    "silu",
     "sort",
     "sub",
     "topk",

--- a/src/flag_gems/runtime/backend/_arm/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_arm/ops/bmm.py
@@ -109,8 +109,17 @@ def bmm_kernel(
             else:
                 mask_b = mask_k[:, None] & mask_n[None, :]
 
-        a = tl.load(a_ptrs, mask_a)
-        b = tl.load(b_ptrs, mask_b)
+        # masked-out lanes MUST be filled with 0 (not garbage) so tl.dot
+        # does not accumulate NaN when K is not divisible by TILE_K.
+        # `other` cannot be passed when mask is None, so branch on None.
+        if mask_a is not None:
+            a = tl.load(a_ptrs, mask_a, other=0.0)
+        else:
+            a = tl.load(a_ptrs)
+        if mask_b is not None:
+            b = tl.load(b_ptrs, mask_b, other=0.0)
+        else:
+            b = tl.load(b_ptrs)
 
         offs_k += TILE_K
         a_ptrs += TILE_K

--- a/src/flag_gems/runtime/backend/_arm/ops/silu.py
+++ b/src/flag_gems/runtime/backend/_arm/ops/silu.py
@@ -1,0 +1,50 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit(do_not_specialize=["n_elements"])
+def _silu_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    # silu(x) = x * sigmoid(x) = x / (1 + exp(-x)); compute in fp32 for stability
+    x_fp32 = x.to(tl.float32)
+    y = x_fp32 / (1.0 + tl.exp(-x_fp32))
+    tl.store(out_ptr + offsets, y.to(x.dtype), mask=mask)
+
+
+def silu(x):
+    # Raw-pointer elementwise kernel (NOT tl.make_block_ptr): the generic
+    # @pointwise_dynamic path crashes the triton-shared CPU backend on
+    # block-pointer lowering, so hand-roll the contiguous fast path like
+    # sub.py's _sub_contiguous_kernel.
+    if x.numel() == 0:
+        return torch.empty_like(x)
+    x = x.contiguous()
+    out = torch.empty_like(x)
+    n = x.numel()
+    BLOCK = 1024
+    grid = (triton.cdiv(n, BLOCK),)
+    _silu_kernel[grid](x, out, n, BLOCK_SIZE=BLOCK)
+    return out


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix + New Feature

### Description
arm 后端（triton-shared cpu backend）的两个改动，用于让 Qwen2.5-0.5B 模型前向在 riscv64 上走 Triton 而非 ATen fallback：

1. **bmm.py 修 NaN**（Bug Fix）：当 K 不整除 TILE_K 时，`tl.load` 的 masked-out lane 读未初始化内存（garbage），经 `tl.dot` 累加出 NaN。现在 `mask` 非 None 时补 `other=0.0`，masked lane 填 0。

2. **新增 silu.py**（New Feature）：elementwise SiLU 的裸指针 kernel。FlagGems 的 generic `@pointwise_dynamic` 路径在 triton-shared cpu 后端会走 `tl.make_block_ptr`，触发堆损坏；这里照 `sub.py` 的裸指针风格手写 contiguous 快路径，避免 block-ptr lowering。

3. **__init__.py**：导入 silu 并加入 `__all__`。

### Issue
（无）

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT. (`tests/test_silu.py` + `tests/test_bmm.py`)

### Performance
无性能数据（QEMU 模拟环境）；这两个算子让模型前向的 silu/bmm 不再落 ATen fallback，是「正确性」改动而非性能优化。