### PR TITLE
fix(libentry): self-heal poisoned ConfigCache entries on compile failure

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -232,6 +232,9 @@ class ConfigCache(Cache):
     ) -> None:
         return self.model.put_config(self.table_name, key, config)
 
+    def __delitem__(self, key: Tuple[Union[int, float, str], ...]) -> None:
+        self.model.delete_config(self.table_name, key)
+
 
 class BenchmarkCache(Cache):
     def __init__(
@@ -978,114 +981,145 @@ class LibTuner(triton.runtime.Autotuner):
         # so please make sure the orders of `arg_names` and `args` match.
         self.nargs = dict(zip(self.arg_names, args))
         used_cached_result = True
-        if len(self.configs) > 1 or bypass_config_cache:
-            all_args = {**self.nargs, **kwargs}
-            _args = {k: v for k, v in all_args.items() if k in self.arg_names}
-            config_key = self.get_key(_args)
-            benchmark_key = self.get_benchmark_key(_args)
-            if bypass_config_cache or config_key not in self.cache:
-                cache: BenchmarkCache = libcache[
-                    self.benchmark_table_name, benchmark_key
-                ]
-                # prune configs
-                used_cached_result = False
-                pruned_configs = self.prune_configs(kwargs)
-                bench_start = time.time()
+        retune_from_scratch = False
+        while True:
+            config_from_cache = False
+            if len(self.configs) > 1 or bypass_config_cache:
+                all_args = {**self.nargs, **kwargs}
+                _args = {k: v for k, v in all_args.items() if k in self.arg_names}
+                config_key = self.get_key(_args)
+                benchmark_key = self.get_benchmark_key(_args)
+                if bypass_config_cache or config_key not in self.cache:
+                    cache: BenchmarkCache = libcache[
+                        self.benchmark_table_name, benchmark_key
+                    ]
+                    # prune configs
+                    used_cached_result = False
+                    pruned_configs = self.prune_configs(kwargs)
+                    bench_start = time.time()
 
-                def bench(config: triton.Config) -> List[float]:
-                    ret = cache.get(config)
-                    if ret is None:
-                        try:
-                            ret = self._bench(*args, config=config, **kwargs)
-                        except RuntimeError as e:
-                            # A config whose COMPILE raises a plain RuntimeError
-                            # is outside triton's autotuner catch list
-                            # (OutOfResources / CompileTimeAssertionFailure /
-                            # PTXASError) and would kill the whole process. Some
-                            # backend compilers do this — e.g. cambricon MLU
-                            # AutoTileForTritonPass raises "PassManager::run
-                            # failed" on a tensor.expand_shape it cannot tile.
-                            # Treat such a config as a non-candidate (inf) so
-                            # tuning continues and a working config is selected.
-                            print(f"[libentry] config {config} failed to compile: {e}")
-                            ret = (float("inf"), float("inf"), float("inf"))
-                        # Some Triton backends (e.g. tsingmicro with
-                        # use_cuda_graph=True) return a scalar float from
-                        # _bench instead of the standard (p50, p20, p80) tuple.
-                        # Normalize to a 3-element tuple for compatibility with
-                        # SQLPersistantModel.put_benchmark and other consumers.
-                        if isinstance(ret, (int, float)):
-                            ret = (ret, ret, ret)
-                        if ret and all(math.isfinite(float(value)) for value in ret):
-                            self.benchmark_success_count += 1
-                        cache[config] = tuple(ret)
+                    def bench(config: triton.Config) -> List[float]:
+                        ret = cache.get(config)
+                        if ret is None or retune_from_scratch:
+                            try:
+                                ret = self._bench(*args, config=config, **kwargs)
+                            except RuntimeError as e:
+                                # A config whose COMPILE raises a plain RuntimeError
+                                # is outside triton's autotuner catch list
+                                # (OutOfResources / CompileTimeAssertionFailure /
+                                # PTXASError) and would kill the whole process. Some
+                                # backend compilers do this — e.g. cambricon MLU
+                                # AutoTileForTritonPass raises "PassManager::run
+                                # failed" on a tensor.expand_shape it cannot tile.
+                                # Treat such a config as a non-candidate (inf) so
+                                # tuning continues and a working config is selected.
+                                print(
+                                    f"[libentry] config {config} failed to compile: {e}"
+                                )
+                                ret = (float("inf"), float("inf"), float("inf"))
+                            # Some Triton backends (e.g. tsingmicro with
+                            # use_cuda_graph=True) return a scalar float from
+                            # _bench instead of the standard (p50, p20, p80) tuple.
+                            # Normalize to a 3-element tuple for compatibility with
+                            # SQLPersistantModel.put_benchmark and other consumers.
+                            if isinstance(ret, (int, float)):
+                                ret = (ret, ret, ret)
+                            if ret and all(
+                                math.isfinite(float(value)) for value in ret
+                            ):
+                                self.benchmark_success_count += 1
+                            cache[config] = tuple(ret)
+                        else:
+                            self.benchmark_cache_hit_count += 1
+                        return list(ret)
+
+                    if exhaustive_collection:
+                        best_config, timings = LibTuner.get("default").policy(
+                            self,
+                            bench,
+                            pruned_configs,
+                            args,
+                            kwargs,
+                        )
                     else:
-                        self.benchmark_cache_hit_count += 1
-                    return list(ret)
-
-                if exhaustive_collection:
-                    best_config, timings = LibTuner.get("default").policy(
-                        self,
-                        bench,
-                        pruned_configs,
-                        args,
-                        kwargs,
-                    )
+                        best_config, timings = self.policy(
+                            bench,
+                            pruned_configs,
+                            args,
+                            kwargs,
+                        )
+                    bench_end = time.time()
+                    self.bench_time = bench_end - bench_start
+                    if not bypass_config_cache:
+                        self.cache[config_key] = best_config
+                        config = self.cache[config_key]
+                    else:
+                        config = best_config
+                    full_nargs = {
+                        **self.nargs,
+                        **kwargs,
+                        **config.all_kwargs(),
+                    }
+                    self.pre_hook(full_nargs, reset_only=True)
+                    self.configs_timings = timings
                 else:
-                    best_config, timings = self.policy(
-                        bench,
-                        pruned_configs,
-                        args,
-                        kwargs,
-                    )
-                bench_end = time.time()
-                self.bench_time = bench_end - bench_start
-                if not bypass_config_cache:
-                    self.cache[config_key] = best_config
                     config = self.cache[config_key]
-                else:
-                    config = best_config
-                full_nargs = {
-                    **self.nargs,
+                    config_from_cache = True
+                if config.pre_hook is None:
+                    cached_kwargs = config.all_kwargs()
+                    for original_config in self.configs:
+                        if original_config.all_kwargs() == cached_kwargs:
+                            # Use the original config which has the pre_hook
+                            config = original_config
+                            break
+            else:
+                config = self.configs[0]
+            self.best_config = config
+            if (
+                os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1"
+                and not used_cached_result
+            ):
+                print(
+                    f"Triton autotuning for function {self.base_fn.__name__} finished after "
+                    f"{self.bench_time:.2f}s; config key: {config_key}, "
+                    f"benchmark key: {benchmark_key}, "
+                    f"best config selected: {self.best_config};"
+                )
+            full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
+            if (
+                hasattr(self, "shared_config_pre_hook")
+                and self.shared_config_pre_hook is not None
+            ):
+                self.shared_config_pre_hook(full_nargs)
+            elif config.pre_hook is not None:
+                config.pre_hook(full_nargs)
+            try:
+                ret = self.fn.run(
+                    *args,
                     **kwargs,
                     **config.all_kwargs(),
-                }
-                self.pre_hook(full_nargs, reset_only=True)
-                self.configs_timings = timings
-            else:
-                config = self.cache[config_key]
-            if config.pre_hook is None:
-                cached_kwargs = config.all_kwargs()
-                for original_config in self.configs:
-                    if original_config.all_kwargs() == cached_kwargs:
-                        # Use the original config which has the pre_hook
-                        config = original_config
-                        break
-        else:
-            config = self.configs[0]
-        self.best_config = config
-        if os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1" and not used_cached_result:
-            print(
-                f"Triton autotuning for function {self.base_fn.__name__} finished after "
-                f"{self.bench_time:.2f}s; config key: {config_key}, "
-                f"benchmark key: {benchmark_key}, "
-                f"best config selected: {self.best_config};"
-            )
-        full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
-        if (
-            hasattr(self, "shared_config_pre_hook")
-            and self.shared_config_pre_hook is not None
-        ):
-            self.shared_config_pre_hook(full_nargs)
-        elif config.pre_hook is not None:
-            config.pre_hook(full_nargs)
-        ret = self.fn.run(
-            *args,
-            **kwargs,
-            **config.all_kwargs(),
-        )
-        self.nargs = None
-        return ret
+                )
+            except RuntimeError as e:
+                if not config_from_cache:
+                    raise
+                # The cached best-config is poisoned: it was likely tuned in a
+                # different environment that shares this ConfigCache table (e.g.
+                # another compiler whose triton major/minor version matches ours)
+                # and no longer compiles here. Drop the entry and re-tune from
+                # scratch, ignoring stale cached latencies, instead of crashing
+                # the process. bench() treats compile failures as non-candidates
+                # (inf), so fresh tuning selects a working config. A config just
+                # selected by fresh tuning does not reach this branch, so the
+                # retry is bounded to a single pass.
+                print(
+                    f"[libentry] cached config {config} failed to compile: {e}; "
+                    "discarding config cache entry and retuning from scratch"
+                )
+                del self.cache[config_key]
+                retune_from_scratch = True
+                continue
+            self.nargs = None
+            return ret
 
 
 # ---- FlagTune Proposer Integration ----

--- a/src/flag_gems/utils/models/model.py
+++ b/src/flag_gems/utils/models/model.py
@@ -72,6 +72,11 @@ class PersistantModel(object):
         config: Union[triton.Config, Dict[str, Union[bool, int, float, str]]],
     ) -> None: ...
 
+    @abstractmethod
+    def delete_config(
+        self, name: str, keys: Sequence[Union[bool, int, float, str]]
+    ) -> None: ...
+
     @overload
     def put_benchmark(
         self,

--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -337,6 +337,24 @@ class SQLPersistantModel(PersistantModel):
                 session.add(ConfigCls(**key_dict, **config))
                 session.commit()
 
+    def delete_config(
+        self, name: str, keys: Sequence[Union[bool, int, float, str]]
+    ) -> None:
+        # Detect if this table uses blob mode
+        use_blob_mode = len(keys) > self.key_count_limit
+        key_dict: Dict[str, Union[bool, int, float, str]] = (
+            SQLPersistantModel.get_key_dict(keys, use_blob_mode)
+        )
+        ConfigCls: Optional[Type[Base]] = self.get_sql_model(name, key_dict)
+        if ConfigCls is None:
+            return
+        with RollbackSession(self.engine) as session:
+            obj: Optional[Base] = session.get(ConfigCls, key_dict)
+            if obj is None:
+                return
+            session.delete(obj)
+            session.commit()
+
     def put_benchmark(
         self,
         name: str,

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -1329,6 +1329,158 @@ def test_benchmark_success_count_tracks_finite_uncached_benchmarks(monkeypatch):
     assert tuner._run_mode is LibTunerRunMode.NORMAL
 
 
+def test_cached_config_compile_failure_is_discarded_and_retuned(monkeypatch):
+    """Recover from a cached best-config that no longer compiles.
+
+    A best-config cached by another environment that shares the same
+    ConfigCache table (e.g. a different compiler whose triton major/minor
+    version matches ours) can fail to compile at launch. LibTuner must delete
+    the poisoned entry and re-tune from scratch — ignoring stale cached
+    latencies, which would otherwise re-select the same broken config —
+    instead of crashing the process.
+    """
+    configs = [
+        triton.Config({"BLOCK": 8}),
+        triton.Config({"BLOCK": 16}),
+        triton.Config({"BLOCK": 32}),
+    ]
+    poisoned = configs[2]  # BLOCK=32 fails to compile in the current env
+
+    class FakeConfigCache:
+        """Track best-config values and deletions without hitting SQLite."""
+
+        def __init__(self, values):
+            """Store one shape-to-best-config entry."""
+            self.values = values
+            self.delitem_count = 0
+
+        def __contains__(self, key):
+            """Perform a best-config membership query."""
+            return key in self.values
+
+        def __getitem__(self, key):
+            """Return the stored best config."""
+            return self.values[key]
+
+        def __setitem__(self, key, value):
+            """Persist one best config in memory."""
+            self.values[key] = value
+
+        def __delitem__(self, key):
+            """Record and drop one poisoned best config."""
+            self.delitem_count += 1
+            del self.values[key]
+
+    class FakeBenchmarkCache:
+        """Store per-config latency tuples for one synthetic shape."""
+
+        def __init__(self, values):
+            """Initialize the config-to-latency mapping."""
+            self.values = values
+
+        def get(self, config):
+            """Return a cached latency tuple when present."""
+            return self.values.get(config)
+
+        def __setitem__(self, config, value):
+            """Persist a newly measured latency tuple."""
+            self.values[config] = value
+
+    benchmark_cache = FakeBenchmarkCache({poisoned: (0.5, 0.6, 0.7)})
+
+    class FakeLibCache:
+        """Expose the single BenchmarkCache expected by the fake tuner."""
+
+        def __getitem__(self, key):
+            """Validate the benchmark table/key pair and return its cache."""
+            assert key == (
+                "fake_benchmark",
+                (32, "triton_do_bench", 5, 20),
+            )
+            return benchmark_cache
+
+    class FakeFn:
+        """Reject the poisoned config exactly as a failing launch would."""
+
+        @staticmethod
+        def run(*args, **kwargs):
+            """Raise on the broken block size and otherwise capture arguments."""
+            if kwargs["BLOCK"] == 32:
+                raise RuntimeError("PassManager::run failed")
+            return args, kwargs
+
+    class FakeTuner:
+        """Implement the minimal protocol consumed by ``LibTuner.run``."""
+
+        arg_names = ["M"]
+        benchmark_table_name = "fake_benchmark"
+        fn = FakeFn()
+        # Mirrors the default LibTuner sets in its ``__init__`` so ``run``
+        # follows the NORMAL path that can self-heal a poisoned cache entry.
+        _run_mode = LibTunerRunMode.NORMAL
+
+        @staticmethod
+        def get_key(_args):
+            """Return one stable synthetic shape key."""
+            return (32,)
+
+        @staticmethod
+        def get_benchmark_key(args):
+            """Return the exact shape plus benchmark protocol identity."""
+            return (args["M"], "triton_do_bench", 5, 20)
+
+        def prune_configs(self, _kwargs):
+            """Yield every active config without pruning."""
+            return iter(self.configs)
+
+        def policy(self, bench, candidates, _args, _kwargs):
+            """Track normal-policy calls, benchmark candidates, and minimize p50."""
+            self.policy_call_count = getattr(self, "policy_call_count", 0) + 1
+            timings = {config: bench(config)[1] for config in candidates}
+            return min(timings, key=timings.get), timings
+
+        def _bench(self, *args, config, **kwargs):
+            """Simulate a compiler that refuses to compile BLOCK=32 kernels."""
+            if config.kwargs["BLOCK"] == 32:
+                raise RuntimeError("PassManager::run failed")
+            block = float(config.kwargs["BLOCK"])
+            return [block - 1.0, block, block + 1.0]
+
+        @staticmethod
+        def pre_hook(_kwargs, reset_only=False):
+            """Accept LibTuner's reset hook without external side effects."""
+            return None
+
+    monkeypatch.delenv("TRITON_PRINT_AUTOTUNING", raising=False)
+    monkeypatch.setattr(libentry_mod, "libcache", FakeLibCache())
+    tuner = FakeTuner()
+    tuner.configs = configs
+    # The poisoned config is cached as best with a stale finite latency, exactly
+    # as a different compiler would have left it behind.
+    config_cache = FakeConfigCache({(32,): poisoned})
+    tuner.cache = config_cache
+
+    result = LibTuner.run(tuner, 32)
+
+    # The launch succeeded with a re-tuned, compilable config (minimal p50).
+    assert result[1]["BLOCK"] == 8
+    assert tuner.best_config.kwargs["BLOCK"] == 8
+    # The poisoned entry was deleted and the shape re-cached with a good config.
+    assert config_cache.delitem_count == 1
+    assert config_cache.values == {(32,): configs[0]}
+    # Only the retune pass invokes the policy; the cache-hit pass does not.
+    assert tuner.policy_call_count == 1
+    # Stale cached latencies were not trusted: both healthy configs were
+    # re-measured fresh and the broken one hit the inf fallback.
+    assert tuner.benchmark_success_count == 2
+    assert tuner.benchmark_cache_hit_count == 0
+    assert benchmark_cache.values[poisoned] == (float("inf"),) * 3
+
+    assert tuner._last_benchmark_args == (32,)
+    assert tuner._last_benchmark_meta == {}
+    assert tuner._run_mode is LibTunerRunMode.NORMAL
+
+
 def test_benchmark_key_preserves_raw_shape_and_scopes_timing_protocol(monkeypatch):
     """Keep ConfigCache bucketing while separating exact benchmark labels."""
 


### PR DESCRIPTION
## Summary

`LibTuner.run` crashes the whole process when the ConfigCache returns a best-config that no longer compiles in the current environment. This is caused by cross-environment cache pollution: the SQL ConfigCache database file name (`TunedConfig_{vendor}_triton_{major}_{minor}.db`) and the per-kernel table name (md5 of key names) carry **no compiler identity**, so two compilers whose triton major/minor versions match (e.g. FlagTree 3.6.0 and vendor triton 3.6.0) share the same cache table. When one environment tunes a config that the other cannot compile — observed in the field as a Metax backend raising `RuntimeError: PassManager::run failed` from a kernel whose `BLOCK_SIZE_M=8` the vendor triton MMA compiler rejects — the cache-hit path calls `self.fn.run(...)` with the poisoned config and dies.

## Fix

Self-heal instead of crashing. `LibTuner.run` now wraps the kernel launch: on `RuntimeError` where the config came from a ConfigCache hit, it deletes the poisoned entry, ignores stale cached latencies, and re-runs autotuning from scratch. `bench()` already treats compile failures as `(inf, inf, inf)` non-candidates, so fresh tuning selects a working config. The retry is bounded to a single pass because a config just selected by fresh tuning does not re-enter the recovery branch.

Changes:
- `src/flag_gems/utils/models/model.py`: add `PersistantModel.delete_config` abstract method
- `src/flag_gems/utils/models/sql.py`: implement `delete_config` on `SQLPersistantModel` (DELETE via `RollbackSession`, covering both column-mode and blob-mode key dicts)
- `src/flag_gems/utils/libentry.py`: add `ConfigCache.__delitem__`; wrap the kernel launch in `LibTuner.run`, discard poisoned entries and re-tune
- `tests/test_libentry.py`: add `test_cached_config_compile_failure_is_discarded_and_retuned`, a Fake-mode test that verifies the poisoned entry is deleted, stale cached latencies are not trusted, the re-tuned config is the working minimum-p50 one, and the process does not crash

## Design notes

- Recovery is gated on `config_from_cache` (a dedicated flag set only on the cache-hit path), not `used_cached_result`, which is also `False` on the fresh-tuning path and would wrongly suppress re-raises there.
- On the retune pass, `bench()` forces fresh measurement (`retune_from_scratch`) so stale latencies written by the other environment cannot re-select the poisoned config.
- A plain `RuntimeError` from the launch is re-raised when the config was freshly tuned (not from cache), preserving existing behavior for genuine kernel failures.

## Validation

- `tests/test_libentry.py`: **67 passed, 9 skipped** (skips are pre-existing: optional FlagTree FlagTune package, MUSA fork issue #2826)
- `tests/flagtune`: **26 passed, 59 skipped** (pre-existing environmental skips)
- Run on an H20 node in the FlagOS runtime image (`flagos-runtime-nvidia-cuda12.8:2.1.1`) against this branch's source with `PYTHONPATH=src`.

Resolves #5832

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
