### PR TITLE
fixbug: exponential_ operator accuracy failure

### DIFF
--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -40,11 +40,15 @@ def safe_fast_log_f32(x):
     bits = x.to(tl.int32, bitcast=True)
     exponent = (bits >> 23) - 127
     mantissa = (bits & 0x7FFFFF).to(tl.float32) * (1.0 / 8388608.0) + 1.0
-    m1 = mantissa - 1.0
-    return (
-        m1 * (1.0 + m1 * (-0.5 + m1 * (0.3333333333 - m1 * 0.25)))
-        + exponent.to(tl.float32) * 0.6931471805599453
-    )
+    t = mantissa - 1.0
+    # Degree-5 minimax polynomial for ln(1+t) on [0, 1)
+    p = 3.0102415366e-02
+    p = p * t - 1.3011859043e-01
+    p = p * t + 2.8330324636e-01
+    p = p * t - 4.8915625549e-01
+    p = p * t + 9.9901031459e-01
+    p = p * t + 2.2125781657e-05
+    return p + exponent.to(tl.float32) * 0.6931471805599453
 
 
 @triton.jit
@@ -78,7 +82,7 @@ def transform_exponential_f32_precise(u, inv_lambd, eps_minus):
 
 @triton.jit
 def transform_exponential_f32_fast(u, inv_lambd, eps_minus):
-    log = tl.where(u >= 1.0 + eps_minus, eps_minus, safe_fast_log_f32(u))
+    log = tl.where(u >= 1.0 - 1e-4, eps_minus, safe_fast_log_f32(u))
     # log = tl.log(tl.maximum(u, 1e-38))
     return -inv_lambd * log
 
@@ -115,7 +119,7 @@ def fused_exponential_kernel_f32_unroll8(
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
 
     pid = tl.program_id(0)
-    block_start = pid * BLOCK
+    block_start = pid * BLOCK * 2
     offsets = block_start + tl.arange(0, BLOCK)
 
     c0_first = c0 + offsets * 4

--- a/tests/test_exponential_.py
+++ b/tests/test_exponential_.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+from contextlib import nullcontext
+
 import pytest
 import torch
 
@@ -50,3 +53,46 @@ def test_exponential_fast(shape, dtype):
 
     assert torch.abs(mean_res - mean_ref) < mean_tol
     assert torch.abs(var_res - var_ref) < var_tol
+
+
+def _exponential_samples(backend, seed, size):
+    x = torch.empty(size, device=flag_gems.device, dtype=torch.float32)
+    generator = torch.Generator(device=flag_gems.device).manual_seed(seed)
+    context = (
+        flag_gems.use_gems(include=["exponential_"])
+        if backend == "flaggems"
+        else nullcontext()
+    )
+    with context:
+        x.exponential_(generator=generator)
+    return x
+
+
+@pytest.mark.exponential_
+@pytest.mark.parametrize("backend", ["torch", "flaggems"])
+@pytest.mark.parametrize("seed", [260828, 2026, 7])
+def test_exponential_lower_tail(backend, seed):
+    x = _exponential_samples(backend, seed, 1048576)
+    expected = 1 - math.exp(-0.1)
+    observed = (x <= 0.1).float().mean().item()
+    assert abs(observed - expected) < 0.005, (
+        f"{backend} seed={seed}: P(X<=0.1)={observed}, "
+        f"Exp(1) expected={expected}; tolerance=0.005"
+    )
+
+
+@pytest.mark.exponential_
+@pytest.mark.parametrize("backend", ["torch", "flaggems"])
+@pytest.mark.parametrize("seed", [260828, 2026, 7])
+def test_exponential_no_repeated_blocks(backend, seed):
+    x = _exponential_samples(backend, seed, 131072)
+    fractions = {}
+    for block in [64, 128, 256, 512]:
+        tiles = x.view(-1, 8 * block)
+        fractions[block] = (
+            (tiles[:-1, 4 * block :] == tiles[1:, : 4 * block]).float().mean().item()
+        )
+    assert max(fractions.values()) < 0.01, (
+        f"{backend} seed={seed}: repeated-block fractions={fractions}; "
+        "different output coordinates must not reuse entire random blocks"
+    )


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

Fix two bugs in the in-place `exponential_` operator (`fused_exponential_kernel_f32_unroll8`):

1. **Philox counter collision**: `block_start = pid * BLOCK` only advanced by `BLOCK` per pid, but each pid consumes `2 * BLOCK` counters (two `tl.philox` calls). This caused adjacent pids to share identical counters, producing 100% repeated random blocks at block_size=128. Fixed by changing to `pid * BLOCK * 2`.

2. **Inaccurate log approximation**: `safe_fast_log_f32` used a 4-term Taylor series for `ln(1+x)`, which has catastrophic error when x → 1 (e.g., 10900% relative error at u=0.999). Replaced with the degree-5 minimax polynomial already used in the out-of-place `exponential` kernel. Also aligned the boundary guard threshold to `u >= 1.0 - 1e-4` (consistent with the out-of-place version) to avoid polynomial edge-case overshoot.

### Issue

- Exponential distribution CDF check fails: `P(X<=0.1) = 0.0` instead of expected ~0.095
- Random block repetition at block_size=128 reaches 100%

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [√] Change is fully covered by a UT.

### Performance
<img width="848" height="142" alt="image" src="https://github.com/user-attachments/assets/e5a56e48-7011-4026-83bb-51520394167f" />


### Accuracy
<img width="851" height="287" alt="image" src="https://github.com/user-attachments/assets/71af571b-12d5-4484-ab37-4f41a60b268e" />





