### PR TITLE
Align operators.yaml

### DIFF
--- a/benchmark/test_special_i1e.py
+++ b/benchmark/test_special_i1e.py
@@ -29,3 +29,16 @@ def test_special_i1e():
         op_name="special_i1e", torch_op=torch.special.i1e, dtypes=consts.FLOAT_DTYPES
     )
     bench.run()
+
+
+@pytest.mark.special_i1e_out
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_special_i1e_out():
+    bench = base.UnaryPointwiseOutBenchmark(
+        op_name="special_i1e_out",
+        torch_op=torch.special.i1e,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5019,7 +5019,7 @@ ops:
   - id: geometric
     description: Draws random numbers from a geometric distribution.
     for:
-      - geometric.float
+      - geometric
     labels:
       - aten
     kind:
@@ -5029,7 +5029,7 @@ ops:
   - id: geometric_
     description: Fills self tensor with elements drawn from the geometric distribution.
     for:
-      - geometric_.float
+      - geometric_
     labels:
       - aten
     kind:
@@ -5109,7 +5109,7 @@ ops:
   - id: greater_out
     description: A variant of `greater` that saves the output to the specified `out`.
     for:
-      - greater.out
+      - greater.Tensor_out
     labels:
       - aten
     kind:
@@ -7149,7 +7149,7 @@ ops:
     description: |
       Performs int8 weight-only quantized matrix multiplication with per-channel scales.
     for:
-      - weight_int8pack_mm
+      - _weight_int8pack_mm
     labels:
       - aten
       - KernelGen
@@ -11265,7 +11265,7 @@ ops:
       A variant of `special_chebyshev_polynomial_w()` with output saved to
       provided `out`.
     for:
-      - special.chebyshev_polynomial_w.out
+      - special_chebyshev_polynomial_w.out
     labels:
       - aten
       - KernelGen
@@ -11537,6 +11537,19 @@ ops:
       of order 1, i1e(x) = i1(x) * exp(-|x|), for each element in the input tensor.
     for:
       - special_i1e
+    labels:
+      - aten
+      - pointwise
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
+  - id: special_i1e_out
+    description: |
+      A variant of `special_i1e()` that saves the output to the provided `out` tensor.
+    for:
+      - special_i1e.out
     labels:
       - aten
       - pointwise

--- a/tests/test_hardswish.py
+++ b/tests/test_hardswish.py
@@ -48,7 +48,7 @@ def test_hardswish(shape, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
-@pytest.mark.hardswish
+@pytest.mark.hardswish_out
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_hardswish_out(shape, dtype):

--- a/tests/test_special_i1e.py
+++ b/tests/test_special_i1e.py
@@ -32,3 +32,23 @@ def test_special_i1e(shape, dtype, caplog):
             res_out = torch.special.i1e(inp)
     assert "GEMS SPECIAL_I1E" in caplog.text
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.special_i1e_out
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_special_i1e_out(shape, dtype, caplog):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.empty_like(ref_inp)
+    torch.ops.aten.special_i1e.out(ref_inp, out=ref_out)
+
+    out = torch.empty_like(inp)
+    with caplog.at_level("DEBUG", logger="flag_gems.ops.special_i1e"):
+        with flag_gems.use_gems():
+            res_out = torch.ops.aten.special_i1e.out(inp, out=out)
+
+    assert "GEMS SPECIAL_I1E_OUT" in caplog.text
+    assert res_out is out
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## PR Category
CI/CD

## Type of Change
Bug Fix

## Description

- Update `for` fields in `conf/operators.yaml` to match the real registered names
- Add `special_i1e_out` with test and benchmark coverage.
- Add the missing `@pytest.mark.hardswish_out`

## Issue

## Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

## Performance