### PR TITLE
fix(isfinite): pure-triton fallback for finitef/isfinited on HIP libdevice

### DIFF
--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -1240,12 +1240,24 @@ def _fallback_erfc(x):
     return 1.0 - tl.math.erf(x)
 
 
+@triton.jit
+def _fallback_isfinite(x):
+    # IEEE identity: x-x is exactly 0 for any finite x and NaN for +-inf/NaN
+    # lanes, so (x - x) == 0.0 is isfinite.  Uses only core triton operators,
+    # so it lowers on every backend -- unlike borrowing CUDA's finitef extern,
+    # which compiles to None on backends whose libdevice lacks the symbol
+    # (e.g. HIP with the vendored triton 3.5.1).
+    return (x - x) == 0.0
+
+
 _FALLBACK_SYMBOLS = {
     "pow": _fallback_pow,
     "tanh": _fallback_tanh,
     "erfc": _fallback_erfc,
     "erfinv": _fallback_erfinv,
+    "finitef": _fallback_isfinite,
     "floor": _fallback_floor,
+    "isfinited": _fallback_isfinite,
     "j0": _fallback_j0,
     "j1": _fallback_j1,
     "log2": _fallback_log2,


### PR DESCRIPTION
Closes #5840

`torch.isfinite` from verl's optimizer_step dispatches to the flag_gems
isfinite op, which lowers to the finitef/isfinited libdevice symbols.
The vendored hip triton 3.5.1 libdevice lacks both, so
`_patch_missing_symbols` borrows the CUDA `__nv_finitef` extern — a symbol
that fails to lower on HIP, compiling to None and raising TypeError.

Register a pure-triton fallback for both symbols: `(x - x) == 0.0`, exactly
isfinite per the IEEE identity and lowerable on every backend. Follows
the fallback-first precedent in `_patch_missing_symbols`.

E2E on hygon 25 (DTK 26.04, vendored hip triton 3.5.1): verl-FL GRPO
passes both flagtree and triton paths.

This PR was written in part with the assistance of generative AI.
