### PR TITLE
fix: support fp64 accumulation in conv2d kernels

### DIFF
--- a/src/flag_gems/ops/conv2d.py
+++ b/src/flag_gems/ops/conv2d.py
@@ -105,6 +105,7 @@ def conv2d_forward_kernel(
     BLOCK_NI_HO_WO: tl.constexpr,
     BLOCK_CI: tl.constexpr,
     BLOCK_CO: tl.constexpr,
+    ACCUM_DTYPE: tl.constexpr,
 ):
     pid_ni_ho_wo = tl.program_id(0)
     pid_co = tl.program_id(1)
@@ -129,7 +130,7 @@ def conv2d_forward_kernel(
         + weight_n_stride * pid_group * out_per_group_c
     )[None, :]
 
-    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
+    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=ACCUM_DTYPE)
     BLOCK_CI_COUNT = (weight_c + BLOCK_CI - 1) // BLOCK_CI
     for hwc in range(weight_height * weight_width * BLOCK_CI_COUNT):
         c = (hwc % BLOCK_CI_COUNT) * BLOCK_CI
@@ -180,7 +181,7 @@ def conv2d_forward_kernel(
         None, :
     ]
     mask_bias = (output_c_offset < out_per_group_c)[None, :]
-    bias = tl.load(bias_pointer, mask_bias).to(tl.float32)
+    bias = tl.load(bias_pointer, mask_bias).to(ACCUM_DTYPE)
     accum += bias
     output_pointer += (
         (output_n_stride * in_n_point_value)[:, None]
@@ -252,6 +253,7 @@ def conv2d_backward_kernel_weight(
     BLOCK_NO: tl.constexpr,
     BLOCK_CI_HK_WK: tl.constexpr,
     BLOCK_CO: tl.constexpr,
+    ACCUM_DTYPE: tl.constexpr,
 ):
     # load out_grad n (groups out_c)  ho wo
     # load weight (groups out_c) ci h w
@@ -290,7 +292,7 @@ def conv2d_backward_kernel_weight(
     )[None, :]
 
     # calculate the values of the input based on the width and height of the output by looping
-    accum = tl.zeros((BLOCK_CI_HK_WK, BLOCK_CO), dtype=tl.float32)
+    accum = tl.zeros((BLOCK_CI_HK_WK, BLOCK_CO), dtype=ACCUM_DTYPE)
     for h in range(0, out_height):
         for w in range(0, out_width):
             for n in range(0, in_n, BLOCK_NO):
@@ -424,6 +426,11 @@ class Conv2d(torch.autograd.Function):
             dtype=output_dtype,
         )
 
+        # tl.dot accumulates in fp32 for fp16/bf16/fp32 inputs but must use fp64
+        # for fp64 inputs, otherwise Triton rejects the loop-carried accum
+        # (issue #2345: "has initial type fp32 but is re-assigned to fp64").
+        accum_dtype = tl.float64 if output_dtype == torch.float64 else tl.float32
+
         # BLOCK_NI_HO_WO along the in_n, out_height, and out_width dimensions,
         # BLOCK_CO along the out_c,
         # one group per cat
@@ -461,6 +468,7 @@ class Conv2d(torch.autograd.Function):
             dilation_height,
             dilation_width,
             groups=groups,
+            ACCUM_DTYPE=accum_dtype,
         )
 
         # Save ORIGINAL (unpadded) tensors for backward
@@ -495,6 +503,7 @@ class Conv2d(torch.autograd.Function):
 
         device = ctx.device
         groups = ctx.groups
+        accum_dtype = tl.float64 if out_grad.dtype == torch.float64 else tl.float32
 
         stride_height, stride_width = ctx.stride
         dilation_height, dilation_width = ctx.dilation
@@ -545,7 +554,7 @@ class Conv2d(torch.autograd.Function):
             weight_c * groups,
             input_height,
             input_width,
-            dtype=torch.float32,
+            dtype=out_grad.dtype,
             device=device,
         )
 
@@ -606,6 +615,7 @@ class Conv2d(torch.autograd.Function):
             dilation_height,
             dilation_width,
             groups=groups,
+            ACCUM_DTYPE=accum_dtype,
         )
 
         weight_back = torch.zeros(
@@ -646,6 +656,7 @@ class Conv2d(torch.autograd.Function):
             padding_width,
             dilation_height,
             dilation_width,
+            ACCUM_DTYPE=accum_dtype,
         )
         if bias is not None:
             bias_grad = out_grad.sum(dim=(0, 2, 3))

--- a/tests/test_conv2d.py
+++ b/tests/test_conv2d.py
@@ -39,6 +39,12 @@ else:
         ((32, 8, 8, 8), (32, 8, 2, 2), 1),
     ]
     FLOAT_DTYPES = [torch.float16, torch.float32]
+    # Issue #2345: fp64 inputs previously failed to compile because the kernel
+    # accumulator was hardcoded to fp32. Keep fp64 in the dtype list so this
+    # regression stays covered (only when the device supports fp64).
+    FLOAT_DTYPES = FLOAT_DTYPES + (
+        [torch.float64] if utils.fp64_is_supported else []
+    )
     STRIDES = [1, 2]
     PADDINGS = [0, 1]
     DILATIONS = [1]  # original: [1, 2], dilation=2 commented out to reduce CI timeout


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [ ] Test
- [ ] CI/CD

### Description
The conv2d Triton kernels hardcoded the accumulator (and bias) to `tl.float32`. For `torch.float64` inputs the loop-carried `accum` was re-assigned as fp64 inside the kernel, so Triton rejected compilation with:

```
value ... has initial type fp32 but is re-assigned to fp64
```

(issue #2345)

This PR adds an `ACCUM_DTYPE` constexpr parameter to `conv2d_forward_kernel` and `conv2d_backward_kernel_weight`. The accumulator and bias are cast to `tl.float64` for fp64 inputs and stay at `tl.float32` for fp16/bf16/fp32, so existing precision is unchanged. The backward weight-grad workspace also switches from a hardcoded `dtype=torch.float32` to `out_grad.dtype`, and `torch.float64` is added to the dtype list of `tests/test_conv2d.py` (guarded by `fp64_is_supported`) so the regression stays covered.

### Issue
Resolves #2345

### Progress
- [x] Support fp64 accumulation in conv2d forward and backward kernels
- [x] Keep fp32 accumulation for fp16/bf16/fp32 inputs (no behavior change)
- [x] Add fp64 dtype coverage to test_conv2d.py

### Test Plan
`pytest tests/test_conv2d.py -v` on NVIDIA H100 - fp64 cases are auto-enabled when the device supports fp64; fp16/fp32 accuracy is unchanged.
