### PR TITLE
fix(utils): add pure-triton normcdfinv fallback for non-CUDA backends

### DIFF
--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -91,6 +91,29 @@ def _fallback_erfinv(x):
 
 
 @triton.jit
+def _fallback_normcdfinv(p):
+    # Inverse of the standard normal CDF, used when a backend's libdevice lacks
+    # a native normcdfinv (e.g. the hip-based hygon fork).  Composed from
+    # _fallback_erfinv via ndtri(p) = sqrt(2) * erfinv(2p - 1), then polished
+    # with Newton iterations on Phi(x) = 0.5 * (1 + erf(x / sqrt(2))).
+    # special_ndtri.py notes the unpolished composition drifts to ~1.3e-05 abs
+    # error in float32; the refinement below brings it back near libdevice
+    # accuracy.  phi -> 0 as |x| -> inf, so the Newton step degenerates (0/0)
+    # for lanes where p is at/near 0 or 1 -- keep the erfinv estimate there.
+    x = 1.4142135623730951 * _fallback_erfinv(2.0 * p - 1.0)
+    # _fallback_erfinv hits 0/0 (-> nan) at the exact endpoints, where
+    # erfinv(+-1) is infinite; restore the exact values PyTorch/libdevice give.
+    x = tl.where(p == 0.0, float("-inf"), x)
+    x = tl.where(p == 1.0, float("inf"), x)
+    for _ in range(3):
+        phi = 0.3989422804014327 * tl.exp(-0.5 * x * x)  # 1 / sqrt(2*pi)
+        cdf = 0.5 * (1.0 + tl.math.erf(0.7071067811865476 * x))
+        step = tl.where((phi > 0.0) & (cdf == cdf), (cdf - p) / phi, 0.0)
+        x = x - step
+    return x
+
+
+@triton.jit
 def _fallback_floor(x):
     trunc = x.to(tl.int32).to(x.dtype)
     needs_adjust = (x < 0.0) & (x != trunc)
@@ -1250,6 +1273,7 @@ _FALLBACK_SYMBOLS = {
     "j1": _fallback_j1,
     "log2": _fallback_log2,
     "nextafter": _fallback_nextafter,
+    "normcdfinv": _fallback_normcdfinv,
     "sinpi": _fallback_sinpi,
     "y0": _fallback_y0,
     "y1": _fallback_y1,
@@ -1309,6 +1333,7 @@ tl_extra_shim = _patch_missing_symbols(
         "log",
         "log2",
         "nextafter",
+        "normcdfinv",
         "pow",
         "rint",
         "rsqrt",


### PR DESCRIPTION
Fixes #5862

`special_ndtri` (added in #5319) resolves `tl_extra_shim.normcdfinv` at import time, which crashes `import flag_gems` on the hygon fork whose hip libdevice lacks `normcdfinv`. Same class of bug as the y0 (#5553), j0, and erfc fallbacks.

### Changes
- Add `_fallback_normcdfinv`: composes `ndtri(p) = sqrt(2) * erfinv(2p - 1)` from the existing `_fallback_erfinv`, then polishes with 3 Newton iterations on `Phi(x)`. The unpolished composition drifts to ~1.3e-05 abs error in float32 (as noted in special_ndtri.py); the refined version measures 1.2e-07.
- Restore exact `-inf`/`+inf` at `p == 0`/`p == 1`, where `_fallback_erfinv` degenerates to 0/0.
- Register it in `_FALLBACK_SYMBOLS` and the `_patch_missing_symbols` names list.

### Validation
- Math-level check against scipy `ndtri`: float32 max abs error 1.19e-07 (test tolerance atol=1e-4), float64 2.2e-15.
- Edge values `[0, 1, 0.5, -0.1, 1.1, nan]` map to `[-inf, inf, 0, nan, nan, nan]`, matching the reference exactly.
- Wiring verified: missing symbol gets patched, existing symbol untouched.