### PR TITLE
[AMD] Add CDNA3 split softmax

### DIFF
--- a/src/flag_gems/runtime/backend/_amd/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/__init__.py
@@ -35,6 +35,7 @@ LDS, so the RDNA4 candidates would be a poor fit for them.
 """
 
 ARCH_MAP = {
+    "gfx942": "cdna3",
     "gfx1200": "rdna4",
     "gfx1201": "rdna4",
 }

--- a/src/flag_gems/runtime/backend/_amd/cdna3/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna3/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/flag_gems/runtime/backend/_amd/cdna3/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna3/ops/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Only names bound here are picked up: the arch loader collects every function in
+# this namespace with inspect.getmembers and overwrites the same-named generic op,
+# so helpers must not be re-exported from here.
+from .softmax import softmax, softmax_out
+
+__all__ = [
+    "softmax",
+    "softmax_out",
+]

--- a/src/flag_gems/runtime/backend/_amd/cdna3/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna3/ops/softmax.py
@@ -1,0 +1,258 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CDNA3 softmax: split the reduction across workgroups when rows are scarce.
+
+The generic softmax_kernel_inner launches grid (M, 1, 1), one workgroup per row,
+so parallelism is bounded by the row count rather than by the size of the
+reduction. A 1-D input collapses to M=1, which leaves all but one of the 304 CUs
+idle no matter how large N is, so a single long row runs at a small fraction of
+what the part can sustain.
+
+Here each row is split across NUM_BLOCKS workgroups. Pass 1 reduces one chunk
+per workgroup into a partial (max, sum-of-exp) pair; pass 2 combines the partials
+with the online-softmax identity and writes the normalized output. The grid
+becomes (NUM_BLOCKS, M), so parallelism no longer depends on how many rows there
+are. Traffic stays at two reads plus one write, the same as the generic loop
+path, and the combine costs a few KB out of cache instead of a third launch.
+
+Only the starved regime is taken over; softmax_out falls through to the generic
+implementation everywhere else, which already fills the card once there are
+enough rows to go around.
+"""
+
+import logging
+from functools import lru_cache
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.softmax import softmax_out as generic_softmax_out
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+# Warp count is not sensitive: sweeping it from 1 to 16 moves the median by less
+# than the run-to-run spread, because these kernels are bound by how many
+# workgroups are in flight rather than by how wide each one is.
+#
+# TILE_N is sensitive, and the useful range has a hard ceiling. Two fp32
+# accumulators live across the reduction loop, so a tile costs 8 * TILE_N bytes of
+# register state per workgroup; the top of the swept range spills and the kernel
+# collapses. The rung just below that cliff was not enough faster than 2048 to pay
+# for sitting next to it, so 2048 keeps two rungs of margin.
+_TILE_N = 2048
+_NUM_WARPS = 8
+
+# Two blocks per CU: more than that measured no better across the shape set, and
+# the grids it admits are the ones that stayed well behaved throughout the sweep.
+_BLOCKS_PER_CU = 2
+
+# Eligibility: a shortest reduction, a smallest useful number of chunks per row,
+# and a row budget that depends on element width.
+#
+# The length limit is set by host cost, not by the GPU: two launches plus the
+# partials allocation put a fixed floor on this path, so the split only pays once
+# the generic kernel spends more than that floor on the reduction itself. It is
+# measured end to end with the ops registered, because GPU-only timing does not
+# charge the split for the floor and makes shorter lengths look like wins. The
+# limit is the same for every element width.
+#
+# The chunk minimum is sharp: over both lengths and all three dtypes, every shape
+# getting four or more chunks per row won and every shape that got two lost.
+#
+# The row budget is where element width matters. num_blocks is
+# prev_pow2(_BLOCKS_PER_CU * CU / M), so a row count decides how many chunks it is
+# cut into; a wide element measured poorly at exactly four, so its budget stops
+# below every row count that would land there. Narrow elements are clean in that
+# band and take the looser budget. half_to_float widens the store to fp32, so
+# those calls take the wide budget too.
+_MIN_SPLIT_N = 64 * 1024
+_MIN_BLOCKS_PER_ROW = 4
+_NARROW_MAX_ITEMSIZE = 2
+_NARROW_MIN_CUS_PER_ROW = 2
+_WIDE_MIN_CUS_PER_ROW = 4
+
+
+@lru_cache(maxsize=8)
+def _cu_count(device_index):
+    return torch_device_fn.get_device_properties(device_index).multi_processor_count
+
+
+def _prev_power_of_2(n):
+    return 1 << (n.bit_length() - 1) if n >= 1 else 1
+
+
+def _split_plan(m, n, itemsize, device_index):
+    """Workgroups per row, or None to leave this shape to the generic kernel."""
+    if itemsize <= _NARROW_MAX_ITEMSIZE:
+        cus_per_row = _NARROW_MIN_CUS_PER_ROW
+    else:
+        cus_per_row = _WIDE_MIN_CUS_PER_ROW
+    cu = _cu_count(device_index)
+    if m > cu // cus_per_row or n < _MIN_SPLIT_N:
+        return None
+    target_blocks = _BLOCKS_PER_CU * cu
+    num_blocks = _prev_power_of_2(max(1, target_blocks // m))
+    # Cap so every workgroup still gets at least one whole tile.
+    num_blocks = min(num_blocks, _prev_power_of_2(n // _TILE_N))
+    return num_blocks if num_blocks >= _MIN_BLOCKS_PER_ROW else None
+
+
+@libentry()
+@triton.jit
+def softmax_split_reduce_kernel(
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+    row = inp_ptr + pid_m * N
+
+    m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
+    z = tl.zeros([TILE_N], dtype=tl.float32)
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        m_new = tl.maximum(m, inp)
+        # An all -inf window must keep z at 0 rather than accumulate exp(nan).
+        all_neg_inf = m_new == float("-inf")
+        z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+        m = m_new
+
+    m_reduced = tl.max(m, 0)
+    # Lanes still at -inf would give exp(-inf - -inf) = exp(nan) when the whole
+    # chunk is -inf, so select the scale instead of computing it.
+    scale = tl.where(m == float("-inf"), 0.0, tl.exp(m - m_reduced))
+    z_reduced = tl.sum(z * scale, 0)
+
+    tl.store(partial_max_ptr + pid_m * NUM_BLOCKS + pid_b, m_reduced)
+    tl.store(partial_sum_ptr + pid_m * NUM_BLOCKS + pid_b, z_reduced)
+
+
+@libentry()
+@triton.jit
+def softmax_split_normalize_kernel(
+    out_ptr,
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+    TILE_B: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+
+    # Every workgroup redoes the combine over the NUM_BLOCKS partials. That is a
+    # few KB already in cache, and it avoids both a third launch and passing the
+    # row scalars through memory.
+    b_offsets = tl.arange(0, TILE_B)
+    b_mask = b_offsets < NUM_BLOCKS
+    partial_offset = pid_m * NUM_BLOCKS + b_offsets
+    partial_max = tl.load(
+        partial_max_ptr + partial_offset, mask=b_mask, other=-float("inf")
+    )
+    partial_sum = tl.load(partial_sum_ptr + partial_offset, mask=b_mask, other=0.0)
+
+    row_max = tl.max(partial_max, 0)
+    scale = tl.where(partial_max == float("-inf"), 0.0, tl.exp(partial_max - row_max))
+    row_sum = tl.sum(partial_sum * scale, 0)
+
+    row_in = inp_ptr + pid_m * N
+    row_out = out_ptr + pid_m * N
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row_in + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        out = tl.exp(inp - row_max) / row_sum
+        tl.store(row_out + n_offsets, out.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def softmax_out(self, dim, half_to_float=False, *, out):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dim = dim % self.ndim
+    N = self.shape[dim]
+    M = 1
+    for i in range(dim):
+        M *= self.shape[i]
+    K = self.numel() // M // N if self.numel() else 0
+
+    # half_to_float widens the store to fp32, so the plan sees the wider element.
+    itemsize = 4 if half_to_float else self.element_size()
+    plan = (
+        _split_plan(M, N, itemsize, self.device.index)
+        if K == 1 and self.numel()
+        else None
+    )
+    if plan is None:
+        return generic_softmax_out(self, dim, half_to_float, out=out)
+
+    logger.debug("GEMS_CDNA3 SOFTMAX_OUT SPLIT M=%d N=%d blocks=%d", M, N, plan)
+
+    self = self.contiguous()
+    dtype = torch.float32 if half_to_float else self.dtype
+    if tuple(out.shape) != tuple(self.shape):
+        out.resize_(self.shape)
+    if out.dtype != dtype:
+        raise RuntimeError(f"_softmax.out: expected out dtype {dtype}, got {out.dtype}")
+
+    # One allocation for both partials; the two rows stay contiguous.
+    partials = torch.empty((2, M * plan), dtype=torch.float32, device=self.device)
+    grid = (plan, M, 1)
+
+    with torch_device_fn.device(self.device):
+        softmax_split_reduce_kernel[grid](
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            num_warps=_NUM_WARPS,
+        )
+        softmax_split_normalize_kernel[grid](
+            out,
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            TILE_B=triton.next_power_of_2(plan),
+            num_warps=_NUM_WARPS,
+        )
+    return out
+
+
+def softmax(self, dim, half_to_float=False):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dtype = torch.float32 if half_to_float else self.dtype
+    out = torch.empty_like(self, dtype=dtype)
+    return softmax_out(self, dim, half_to_float, out=out)

--- a/tests/test_cdna3_softmax.py
+++ b/tests/test_cdna3_softmax.py
@@ -1,0 +1,398 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the CDNA3-specific split softmax.
+
+The generic softmax test file only uses shapes with either many rows or a short
+reduction, so none of them reach the split path; these cover the regime the arch
+override exists for. The arch loader imports the override under the top-level
+name "cdna3.ops.softmax", so that is where the gate function has to be read from
+to be sure the module under test is the one actually installed.
+"""
+
+import math
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+ARCH_SOFTMAX = sys.modules.get("cdna3.ops.softmax")
+INSTALLED = ARCH_SOFTMAX is not None and ARCH_SOFTMAX.softmax is flag_gems.softmax
+
+pytestmark = pytest.mark.skipif(
+    not INSTALLED,
+    reason="CDNA3 split softmax is not the installed softmax on this device",
+)
+
+# (shape, dim) pairs the gate is expected to take over at every float width. A 1-D
+# input is the case that motivated the override: M collapses to 1, so the generic
+# kernel runs the whole reduction on a single workgroup. Row counts stay inside the
+# row budget and lengths clear the minimum, so these engage regardless of dtype.
+SPLIT_SHAPES = (
+    [([262144], 0)]
+    if cfg.QUICK_MODE
+    else [
+        ([262144], 0),
+        ([1048576], 0),
+        ([4, 262144], 1),
+        ([2, 2, 65536], 2),
+        # Not a multiple of the tile, so the masked tail of every chunk is live.
+        ([1, 65537], 1),
+    ]
+)
+
+# Shapes the gate must leave alone at every float width: reduction too short to pay
+# for the second launch, too many rows to be starved, or a non-inner reduction.
+GENERIC_SHAPES = (
+    [([1, 256], 1)]
+    if cfg.QUICK_MODE
+    else [
+        ([1, 256], 1),
+        ([8192], 0),
+        # One element short of the minimum, so the length limit is pinned live.
+        ([1, 65535], 1),
+        ([4096, 4096], 1),
+        ([64, 512, 512], 1),
+    ]
+)
+
+FLOAT_DTYPES = [torch.float32] if cfg.QUICK_MODE else utils.FLOAT_DTYPES
+
+# Element widths the row budget treats differently, and the widths the suite has to
+# cover on both sides of that split.
+NARROW = ARCH_SOFTMAX._NARROW_MAX_ITEMSIZE if INSTALLED else 2
+WIDE = NARROW + 2
+ITEMSIZES = [NARROW, WIDE]
+
+
+def mnk(shape, dim):
+    n = shape[dim]
+    m = math.prod(shape[:dim])
+    return m, n, math.prod(shape) // m // n
+
+
+def itemsize_of(dtype):
+    return torch.finfo(dtype).bits // 8
+
+
+def split_plan(shape, dim, itemsize):
+    m, n, k = mnk(shape, dim)
+    if k != 1:
+        return None
+    return ARCH_SOFTMAX._split_plan(m, n, itemsize, 0)
+
+
+def row_budget(itemsize):
+    cus_per_row = (
+        ARCH_SOFTMAX._NARROW_MIN_CUS_PER_ROW
+        if itemsize <= NARROW
+        else ARCH_SOFTMAX._WIDE_MIN_CUS_PER_ROW
+    )
+    return ARCH_SOFTMAX._cu_count(0) // cus_per_row
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("itemsize", ITEMSIZES)
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
+def test_cdna3_softmax_gate_engages(shape, dim, itemsize):
+    m, n, _ = mnk(shape, dim)
+    plan = split_plan(shape, dim, itemsize)
+    assert plan is not None, f"expected the split path for M={m} N={n}"
+
+    cu = ARCH_SOFTMAX._cu_count(0)
+    assert plan >= ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    assert plan & (plan - 1) == 0, "workgroups per row must be a power of two"
+    # Every workgroup needs a whole tile, and the grid must not overshoot the
+    # block count the sweep found best.
+    assert plan * ARCH_SOFTMAX._TILE_N <= n
+    assert m * plan <= ARCH_SOFTMAX._BLOCKS_PER_CU * cu
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("itemsize", ITEMSIZES)
+@pytest.mark.parametrize("shape, dim", GENERIC_SHAPES)
+def test_cdna3_softmax_gate_defers(shape, dim, itemsize):
+    assert (
+        split_plan(shape, dim, itemsize) is None
+    ), f"{shape} dim={dim} should fall through to the generic implementation"
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("itemsize", ITEMSIZES)
+def test_cdna3_softmax_gate_row_budget(itemsize):
+    """Pin the row budget from both sides, for both element widths.
+
+    Written against the constants and the CU count rather than literals, so the
+    assertions keep describing the intended rule on a part with a different CU
+    count.
+    """
+    cap = row_budget(itemsize)
+    assert cap >= 1
+    # Long enough that only the row budget can be the deciding limit.
+    n = 8 * ARCH_SOFTMAX._MIN_SPLIT_N
+    assert ARCH_SOFTMAX._split_plan(cap, n, itemsize, 0) is not None
+    assert ARCH_SOFTMAX._split_plan(cap + 1, n, itemsize, 0) is None
+
+
+@pytest.mark.softmax
+def test_cdna3_softmax_row_budget_follows_element_width():
+    """A wider element has to get the tighter budget.
+
+    The row counts the narrow budget reaches and the wide one does not are the ones
+    cut into only four chunks per row, which is the configuration a wide element
+    measured poorly at. Pin the ordering and a row count only the narrow budget has
+    room for.
+    """
+    narrow_cap = row_budget(NARROW)
+    wide_cap = row_budget(WIDE)
+    assert narrow_cap > wide_cap, "narrow elements are the ones with room for rows"
+
+    n = 8 * ARCH_SOFTMAX._MIN_SPLIT_N
+    assert ARCH_SOFTMAX._split_plan(narrow_cap, n, NARROW, 0) is not None
+    assert ARCH_SOFTMAX._split_plan(narrow_cap, n, WIDE, 0) is None
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("itemsize", ITEMSIZES)
+def test_cdna3_softmax_length_limit_is_element_width_independent(itemsize):
+    """The length limit is the one limit that does not depend on element width.
+
+    It is set by the host cost of the second launch, which the element width does
+    not change, and all three dtypes measured the same break-even. Pinned so that a
+    retune which makes the length width-dependent has to say so here.
+    """
+    assert (
+        ARCH_SOFTMAX._split_plan(1, ARCH_SOFTMAX._MIN_SPLIT_N, itemsize, 0) is not None
+    )
+    assert (
+        ARCH_SOFTMAX._split_plan(1, ARCH_SOFTMAX._MIN_SPLIT_N - 1, itemsize, 0) is None
+    )
+
+
+@pytest.mark.softmax
+def test_cdna3_softmax_gate_needs_four_chunks_per_row():
+    """The chunk minimum is what the row sweep actually measured.
+
+    Every shape that got four or more chunks per row beat the generic kernel and
+    every shape that got two lost, with no exception across both lengths and all
+    three dtypes, so a shape must never be admitted with fewer than four.
+    """
+    cu = ARCH_SOFTMAX._cu_count(0)
+    assert ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW >= 4
+    n = 8 * ARCH_SOFTMAX._MIN_SPLIT_N
+
+    # On the narrow budget the chunk minimum is what binds first, so the largest
+    # admitted row count is the one landing exactly on it.
+    last = ARCH_SOFTMAX._BLOCKS_PER_CU * cu // ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    assert last <= row_budget(NARROW), "the narrow budget must not outrun the chunks"
+    assert (
+        ARCH_SOFTMAX._split_plan(last, n, NARROW, 0)
+        == ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    )
+    assert ARCH_SOFTMAX._split_plan(last + 1, n, NARROW, 0) is None
+
+    # A reduction long enough for the row budget but too short to be cut into the
+    # minimum number of whole tiles must be refused by the tile cap, not admitted.
+    short = (ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW - 1) * ARCH_SOFTMAX._TILE_N
+    assert ARCH_SOFTMAX._split_plan(1, short, NARROW, 0) is None
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("n", [65536, 131072, 262144, 1048576])
+def test_cdna3_softmax_wide_budget_avoids_four_chunk_rows(n):
+    """A wide element must never be admitted with only four chunks per row.
+
+    A wide element measured poorly once its rows were cut into exactly four chunks.
+    Raising the wide budget is therefore not a free knob: it is what keeps wide rows
+    off that band, so this pins the property over every row count the gate takes
+    rather than just the constant behind it.
+    """
+    for m in range(1, row_budget(WIDE) + 1):
+        plan = ARCH_SOFTMAX._split_plan(m, n, WIDE, 0)
+        if plan is None:
+            continue
+        assert (
+            plan > ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+        ), f"M={m} N={n} wide is admitted with only {plan} chunks per row"
+
+    # And that the budget is placed exactly at that edge rather than short of it:
+    # the first row count it refuses is the first one that would get four chunks.
+    beyond = row_budget(WIDE) + 1
+    chunks_beyond = ARCH_SOFTMAX._prev_power_of_2(
+        max(1, ARCH_SOFTMAX._BLOCKS_PER_CU * ARCH_SOFTMAX._cu_count(0) // beyond)
+    )
+    assert chunks_beyond == ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("itemsize", ITEMSIZES)
+@pytest.mark.parametrize("n", [32768, 65536, 262144, 1048576])
+def test_cdna3_softmax_never_exceeds_two_blocks_per_cu(n, itemsize):
+    """No admitted shape may reach four workgroups per CU.
+
+    Grids at or below two workgroups per CU are the ones that stayed well behaved
+    throughout the sweep. Raising _BLOCKS_PER_CU is therefore not a free knob, so
+    this asserts the bound over every row count the gate takes rather than just the
+    constant.
+    """
+    cu = ARCH_SOFTMAX._cu_count(0)
+    assert ARCH_SOFTMAX._BLOCKS_PER_CU <= 2
+    for m in range(1, row_budget(itemsize) + 1):
+        plan = ARCH_SOFTMAX._split_plan(m, n, itemsize, 0)
+        if plan is None:
+            continue
+        assert m * plan <= 2 * cu, f"M={m} N={n} asks for {m * plan} workgroups"
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES + GENERIC_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna3_softmax(shape, dim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+    utils.gems_assert_close(
+        res_out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim]
+    )
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna3_softmax_out(shape, dim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+    # Deliberately the wrong size, so the resize path is covered too.
+    out = torch.empty((1,), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        torch.ops.aten._softmax.out(inp, dim, False, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim])
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna3_softmax_half_to_float(dtype):
+    if dtype is torch.float32:
+        pytest.skip("half_to_float only applies to reduced-precision input")
+    shape, dim = SPLIT_SHAPES[0]
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten._softmax(inp, dim, True)
+
+    assert res_out.dtype is torch.float32
+    utils.gems_assert_close(
+        res_out, ref_out, torch.float32, equal_nan=True, reduce_dim=shape[dim]
+    )
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna3_softmax_neg_inf(dtype):
+    """Masked attention rows are the reason the combine needs an -inf guard.
+
+    A chunk that is entirely -inf must contribute a zero sum instead of exp(nan),
+    and a row that is entirely -inf has to come out the same as the single
+    workgroup version would produce.
+    """
+    shape, dim = SPLIT_SHAPES[0]
+    n = shape[dim]
+    tile = ARCH_SOFTMAX._TILE_N
+
+    rows = {
+        # Whole leading chunks masked out, so some workgroups see only -inf.
+        "leading_chunks": lambda t: t[..., : min(8 * tile, n // 2)].fill_(
+            float("-inf")
+        ),
+        # Only one finite element in the row, far from the first chunk.
+        "single_finite": lambda t: (
+            t.fill_(float("-inf")),
+            t[..., n // 2].fill_(1.0),
+        ),
+        # Every element masked: the reference is nan and the arch path must
+        # agree rather than producing a number.
+        "all_masked": lambda t: t.fill_(float("-inf")),
+    }
+
+    for name, mutate in rows.items():
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mutate(inp)
+        ref_inp = utils.to_reference(inp, True)
+
+        ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+        with flag_gems.use_gems():
+            res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+        assert split_plan(shape, dim, itemsize_of(dtype)) is not None, name
+        utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=n)
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna3_softmax_at_row_cap(dtype):
+    """Cover grid.y at the row cap: every row combines its own set of partials.
+
+    The shapes in SPLIT_SHAPES only reach M=4, so without this the widest grid the
+    split path ever runs with is a handful of rows.
+    """
+    m = row_budget(itemsize_of(dtype))
+    n = 2 * ARCH_SOFTMAX._MIN_SPLIT_N
+    if ARCH_SOFTMAX._split_plan(m, n, itemsize_of(dtype), 0) is None:
+        cu = ARCH_SOFTMAX._cu_count(0)
+        pytest.skip(f"the gate does not take M={m} N={n} on a {cu} CU device")
+
+    inp = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    # One fully masked row, so the all -inf guard is hit with live siblings.
+    inp[0].fill_(float("-inf"))
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=-1)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=-1)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=n)
+
+
+@pytest.mark.softmax
+def test_cdna3_softmax_non_contiguous():
+    shape, dim = SPLIT_SHAPES[0]
+    n = shape[dim]
+    base = torch.randn(
+        shape[:dim] + [2 * n], dtype=torch.float32, device=flag_gems.device
+    )
+    inp = base[..., ::2]
+    assert not inp.is_contiguous()
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+    utils.gems_assert_close(
+        res_out, ref_out, torch.float32, equal_nan=True, reduce_dim=n
+    )


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Performance Optimization

### Description

Brings the split softmax to CDNA3 (gfx942). The kernel is the same two-pass reduction as
#5327 and is carried over unchanged, as is the gate structure, `_TILE_N` at 2048 and the
warp count at 8; what differs is every gate limit, retuned for a 304 CU part.
`_NARROW_MIN_CUS_PER_ROW` goes from 4 to 2 and `_WIDE_MIN_CUS_PER_ROW` from 8 to 4,
admitting up to 152 rows for fp16/bf16 and 76 for fp32 on an MI300X. `_BLOCKS_PER_CU`
goes from 4 to 2, since grids at the higher density hit a placement cliff on this part.
The two width-keyed length thresholds collapse into a single `_MIN_SPLIT_N` at 64K, all
three dtypes having measured the same break-even, and the hardcoded minimum of 2 chunks
per row becomes a named `_MIN_BLOCKS_PER_ROW` at 4, since two chunks do not cover the
cost of the second launch here. Shapes outside the gate fall through to the generic
kernel untouched.

#### Results

Speedup over the generic kernel, with speedup over torch in brackets. bf16, gfx942 (MI300X, 304 CU), ROCm 7.2.3, torch 2.10.0+rocm7.2.3, triton 3.6.0+rocm7.2.3, idle card, `do_bench` median with the two FlagGems paths measured alternately per shape and the torch baseline taken before the ops are registered.

| rows  | N=65536       | N=131072      | N=262144      | N=1048576       |
| ----- | ------------- | ------------- | ------------- | --------------- |
| M=1   | 1.33x (0.89x) | 2.50x (1.60x) | 4.83x (3.00x) | 18.60x (11.34x) |
| M=16  | 1.33x (0.89x) | 2.51x (1.61x) | 5.48x (3.46x) | 10.26x (5.66x)  |
| M=64  | 1.54x (1.11x) | 2.66x (1.95x) | 2.64x (1.53x) | 2.78x (2.05x)   |
| M=96  | 1.57x (1.15x) | 1.55x (1.01x) | 1.55x (0.97x) | 1.16x (0.87x)   |
| M=128 | 1.48x (1.15x) | 1.43x (0.87x) | 1.42x (1.03x) | 1.42x (1.14x)   |
| M=152 | 1.40x (1.09x) | 1.39x (0.90x) | 1.36x (0.99x) | 1.37x (1.26x)   |

Across all 144 gated shapes (fp16/bf16/fp32) the median is 2.00x over generic and 1.62x over torch, worst case 1.16x over generic with nothing below it. fp32 admits fewer rows and gains 1.20x to 24.29x over generic across its own gated range. The 153 measured shapes outside the gate keep using the generic kernel, so they are unchanged. 22 of the 108 gated narrow shapes come in at 0.80x to 0.99x against torch, mostly at the short end of the length range; the generic kernel is further behind torch on every one of them, 0.75x at best, so the split still closes the gap there.

Correctness: `tests/test_cdna3_softmax.py` runs 92 passed, 1 skipped, covering both sides of the gate, each element width, `half_to_float`, non-inner dims, non-contiguous input and -inf rows including fully masked ones. It is a separate file rather than an extension of the RDNA one because the CDNA3 constant set is not a superset: the width-keyed length limits are gone and `_MIN_BLOCKS_PER_ROW` is new. Upstream `test_softmax.py`, `test_safe_softmax.py` and `test_scaled_softmax.py`: 258 passed, 160 skipped.

### Issue

### Progress
