### PR TITLE
test: mark MegaMoE staging accuracy tests

### DIFF
--- a/tests/test_stage_deepseek_v4_mega_moe_inputs.py
+++ b/tests/test_stage_deepseek_v4_mega_moe_inputs.py
@@ -15,10 +15,8 @@
 import pytest
 import torch
 
+import flag_gems
 import flag_gems.testing as fg_testing
-from flag_gems.fused.stage_deepseek_v4_mega_moe_inputs import (
-    stage_deepseek_v4_mega_moe_inputs,
-)
 
 
 def _supports_fp8e4nv():
@@ -89,6 +87,7 @@ def _make_inputs(num_tokens, hidden_size, top_k):
     return hidden_states, topk_weights, topk_ids
 
 
+@pytest.mark.stage_deepseek_v4_mega_moe_inputs
 @pytest.mark.parametrize("num_tokens, hidden_size, top_k", [(1, 128, 1), (7, 256, 8)])
 @pytest.mark.skipif(
     not _supports_fp8e4nv(), reason="requires cuda with fp8e4nv support"
@@ -104,7 +103,7 @@ def test_stage_deepseek_v4_mega_moe_inputs_accuracy(num_tokens, hidden_size, top
     topk_idx_out = torch.empty_like(ref_topk_idx)
     topk_weights_out = torch.empty_like(ref_topk_weights)
 
-    stage_deepseek_v4_mega_moe_inputs(
+    flag_gems.stage_deepseek_v4_mega_moe_inputs(
         hidden_states,
         topk_weights,
         topk_ids,
@@ -123,6 +122,7 @@ def test_stage_deepseek_v4_mega_moe_inputs_accuracy(num_tokens, hidden_size, top
     )
 
 
+@pytest.mark.stage_deepseek_v4_mega_moe_inputs
 @pytest.mark.skipif(
     not _supports_fp8e4nv(), reason="requires cuda with fp8e4nv support"
 )
@@ -135,7 +135,7 @@ def test_stage_deepseek_v4_mega_moe_inputs_rejects_bad_hidden_size():
     topk_weights_out = torch.empty((1, 1), device="cuda", dtype=torch.float32)
 
     with pytest.raises(ValueError, match="multiple of 128"):
-        stage_deepseek_v4_mega_moe_inputs(
+        flag_gems.stage_deepseek_v4_mega_moe_inputs(
             bad_hidden_states,
             topk_weights,
             topk_ids,


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
The existing stage_deepseek_v4_mega_moe_inputs accuracy and validation tests were not selected by the operator marker. This change adds the exact marker to both test functions and exercises the public flag_gems API.

Validated on NVIDIA H20:
- Targeted collection: 3 tests collected
- Targeted execution with CPU reference: 3 passed
- Pre-commit: passed

### Issue
Resolves #4901

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
N/A (test-discovery-only change).