### PR TITLE
test: add median_dim operator coverage

### DIFF
--- a/tests/test_median_dim.py
+++ b/tests/test_median_dim.py
@@ -1,0 +1,38 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES)
+def test_median_dim(dim, keepdim, dtype):
+    shape = (3, 17)
+    inp = torch.arange(
+        torch.Size(shape).numel(), device=flag_gems.device, dtype=torch.int64
+    )
+    inp = inp.reshape(shape).to(dtype)
+    ref = torch.median(utils.to_reference(inp), dim=dim, keepdim=keepdim)
+
+    result = flag_gems.median_dim(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_equal(result.values, ref.values)
+    utils.gems_assert_equal(result.indices, ref.indices)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
Add a dedicated median_dim accuracy test file so the operator-specific pytest marker selects real coverage. The cases cover positive and negative dimensions, keepdim variants, and supported floating-point and integer dtypes while comparing both values and indices against PyTorch.

Validation:
- Targeted collection: 24 tests collected
- Operator marker check: passed
- KernelGen test convention check: passed
- Pre-commit: passed

### Issue
Resolves #5096

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
N/A (test-only change).