### PR TITLE
test: add median_out operator coverage

### DIFF
--- a/tests/test_median_out.py
+++ b/tests/test_median_out.py
@@ -1,0 +1,37 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.median_out
+@pytest.mark.parametrize("shape", [(17,), (3, 17)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES)
+def test_median_out(shape, dtype):
+    inp = torch.arange(
+        torch.Size(shape).numel(), device=flag_gems.device, dtype=torch.int64
+    )
+    inp = inp.reshape(shape).to(dtype)
+    ref = torch.median(utils.to_reference(inp))
+    out = torch.empty((), dtype=dtype, device=flag_gems.device)
+
+    result = flag_gems.median_out(inp, out=out)
+
+    assert result is out
+    utils.gems_assert_equal(result, ref)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
Add a dedicated median_out accuracy test file so the operator-specific pytest marker selects real coverage. The cases cover one- and two-dimensional inputs, supported floating-point and integer dtypes, numerical accuracy, and output-buffer identity.

Validation:
- Targeted collection: 12 tests collected
- H20 targeted execution: 12 passed after applying a temporary local compatibility guard for the unsupported PyTorch 2.13 environment; the repository pins NVIDIA builds to PyTorch 2.10/2.11
- Operator marker check: passed
- KernelGen test convention check: passed
- Pre-commit: passed

### Issue
Resolves #5098

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
N/A (test-only change).