### PR TITLE
[NVIDIA] Fix Hopper MM split-K accumulation precision

### DIFF
--- a/src/flag_gems/runtime/backend/_metax/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/mm.py
@@ -805,6 +805,106 @@ def mm_kernel_splitk_partial(
 
 @libentry()
 @triton.jit
+def mm_kernel_small_n_partial(
+    A,
+    B,
+    P,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    SPLIT_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_nk = tl.program_id(1)
+    pid_n = pid_nk % N
+    pid_k = pid_nk // N
+
+    offsets_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask_m = offsets_m < M
+    total_k_iters = tl.cdiv(K, BLOCK_K)
+    k_per_split = tl.cdiv(total_k_iters, SPLIT_K)
+    k_start = pid_k * k_per_split
+    k_end = min((pid_k + 1) * k_per_split, total_k_iters)
+
+    acc = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    for k_iter in range(k_start, k_end):
+        offsets_k = k_iter * BLOCK_K + tl.arange(0, BLOCK_K)
+        mask_k = offsets_k < K
+        a = tl.load(
+            A + offsets_m[:, None] * stride_am + offsets_k[None, :] * stride_ak,
+            mask=mask_m[:, None] & mask_k[None, :],
+            other=0.0,
+        )
+        b = tl.load(
+            B + offsets_k * stride_bk + pid_n * stride_bn,
+            mask=mask_k,
+            other=0.0,
+        )
+        acc += tl.sum(a.to(tl.float32) * b.to(tl.float32)[None, :], axis=1)
+
+    p_offsets = pid_k * M * N + offsets_m * N + pid_n
+    tl.store(P + p_offsets, acc, mask=mask_m)
+
+
+@libentry()
+@triton.jit
+def mm_kernel_small_n_dot_partial(
+    A,
+    B,
+    P,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    SPLIT_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    pid_m = pid // grid_n
+    pid_n = pid % grid_n
+
+    offsets_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offsets_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    total_k_iters = tl.cdiv(K, BLOCK_K)
+    k_per_split = tl.cdiv(total_k_iters, SPLIT_K)
+    k_start = pid_k * k_per_split
+    k_end = min((pid_k + 1) * k_per_split, total_k_iters)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k_iter in range(k_start, k_end):
+        offsets_k = k_iter * BLOCK_K + tl.arange(0, BLOCK_K)
+        a = tl.load(
+            A + offsets_m[:, None] * stride_am + offsets_k[None, :] * stride_ak,
+            mask=(offsets_m[:, None] < M) & (offsets_k[None, :] < K),
+            other=0.0,
+        )
+        b = tl.load(
+            B + offsets_k[:, None] * stride_bk + offsets_n[None, :] * stride_bn,
+            mask=(offsets_k[:, None] < K) & (offsets_n[None, :] < N),
+            other=0.0,
+        )
+        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+
+    p_offsets = pid_k * M * N + offsets_m[:, None] * N + offsets_n[None, :]
+    mask = (offsets_m < M)[:, None] & (offsets_n < N)[None, :]
+    tl.store(P + p_offsets, acc, mask=mask)
+
+
+@libentry()
+@triton.jit
 def mm_kernel_splitk_reduce(
     P,
     C,
@@ -835,6 +935,15 @@ _TWO_STEP_TARGET_SM_NUMERATOR = 3
 _TWO_STEP_TARGET_SM_DENOMINATOR = 4
 _TWO_STEP_WORKSPACE_L2_NUMERATOR = 1
 _TWO_STEP_WORKSPACE_L2_DENOMINATOR = 4
+_GENERIC_TWO_STEP_MAX_SPLITS = 32
+_GENERIC_TWO_STEP_WORKSPACE_L2_DENOMINATOR = 8
+_GENERIC_SPLITK_DENSE_OUTPUT_L2_DENOMINATOR = 64
+_SMALL_N_DOT_BLOCK_N = 16
+_SMALL_N_DOT_BLOCK_K = 64
+_SMALL_N_MAX_SPLITS = 32
+_SMALL_N_ELEMENTWISE_MAX_M = 8
+_SMALL_N_ELEMENTWISE_MAX_BLOCK_K = 1024
+_SMALL_N_ELEMENTWISE_TILE_ELEMENTS = 4096
 
 
 @functools.lru_cache(maxsize=1)
@@ -907,15 +1016,88 @@ def _two_step_split_k(M, N, K):
     return max(1, split_k), output_tiles
 
 
+def _generic_two_step_split_k(M, N, K):
+    reference_tile = _two_step_reference_tile(N)
+    if reference_tile is None:
+        return 1
+
+    block_m, _, block_k = reference_tile
+    k_iters = triton.cdiv(K, block_k)
+    max_k_split = _floor_power_of_two(k_iters // _TWO_STEP_MIN_K_ITERS_PER_SPLIT)
+    split_k = min(max_k_split, _TWO_STEP_MAX_SPLITS)
+
+    extended_split_k = min(max_k_split, _GENERIC_TWO_STEP_MAX_SPLITS)
+    extended_workspace_bytes = extended_split_k * M * N * torch.float32.itemsize
+    extended_workspace_budget = max(
+        1,
+        get_l2_cache_size() // _GENERIC_TWO_STEP_WORKSPACE_L2_DENOMINATOR,
+    )
+    if (
+        extended_split_k > split_k
+        and M <= block_m
+        and extended_workspace_bytes <= extended_workspace_budget
+    ):
+        split_k = extended_split_k
+
+    return max(1, split_k)
+
+
+def _small_n_mm_config(M, N, K):
+    if M <= _SMALL_N_ELEMENTWISE_MAX_M:
+        block_m = _ceil_power_of_two(M)
+        block_k = min(
+            _SMALL_N_ELEMENTWISE_MAX_BLOCK_K,
+            _SMALL_N_ELEMENTWISE_TILE_ELEMENTS // block_m,
+        )
+        base_programs = triton.cdiv(M, block_m) * N
+        occupancy_split_k = _floor_power_of_two(max(1, get_sm_count() // base_programs))
+        max_k_split = _floor_power_of_two(triton.cdiv(K, block_k))
+        split_k = min(
+            occupancy_split_k,
+            max_k_split,
+            _SMALL_N_MAX_SPLITS,
+        )
+        return "elementwise", max(1, split_k), block_m, block_k, 1
+
+    block_m = 32 if M <= 32 else 64
+    num_warps = 2 if block_m == 32 else 4
+    output_tiles = triton.cdiv(M, block_m) * triton.cdiv(N, _SMALL_N_DOT_BLOCK_N)
+    required_splits = triton.cdiv(get_sm_count(), output_tiles)
+    occupancy_split_k = _ceil_power_of_two(required_splits)
+    k_iters = triton.cdiv(K, _SMALL_N_DOT_BLOCK_K)
+    max_k_split = _floor_power_of_two(k_iters // _TWO_STEP_MIN_K_ITERS_PER_SPLIT)
+    split_k = min(
+        occupancy_split_k,
+        max_k_split,
+        _SMALL_N_MAX_SPLITS,
+    )
+    return "dot", max(1, split_k), block_m, _SMALL_N_DOT_BLOCK_K, num_warps
+
+
+def _launch_splitk_reduce(partials, c, M, N, split_k):
+    n_elements = M * N
+    small_output = n_elements <= 256
+    block_size = 64 if small_output else 256
+    num_warps = 1 if small_output else 4
+    mm_kernel_splitk_reduce[(triton.cdiv(n_elements, block_size),)](
+        partials,
+        c,
+        M,
+        N,
+        c.stride(0),
+        c.stride(1),
+        SPLIT_K=split_k,
+        BLOCK_SIZE=block_size,
+        num_warps=num_warps,
+    )
+
+
 def _launch_splitk_mm_two_step(a, b, c, M, N, K, split_k):
     partials = torch.empty((split_k, M, N), device=a.device, dtype=torch.float32)
     partial_grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
         split_k,
     )
-    reduce_block_size = 256
-    reduce_grid = (triton.cdiv(M * N, reduce_block_size),)
-
     with torch_device_fn.device(a.device):
         mm_kernel_splitk_partial[partial_grid](
             a,
@@ -930,17 +1112,7 @@ def _launch_splitk_mm_two_step(a, b, c, M, N, K, split_k):
             b.stride(1),
             SPLIT_K=split_k,
         )
-        mm_kernel_splitk_reduce[reduce_grid](
-            partials,
-            c,
-            M,
-            N,
-            c.stride(0),
-            c.stride(1),
-            SPLIT_K=split_k,
-            BLOCK_SIZE=reduce_block_size,
-            num_warps=4,
-        )
+        _launch_splitk_reduce(partials, c, M, N, split_k)
     return c
 
 
@@ -948,6 +1120,55 @@ def splitk_mm_two_step(a, b, c, M, N, K, split_k=None):
     if split_k is None:
         split_k, _ = _two_step_split_k(M, N, K)
     return _launch_splitk_mm_two_step(a, b, c, M, N, K, split_k)
+
+
+def small_n_mm(a, b, c, M, N, K):
+    kernel, split_k, block_m, block_k, num_warps = _small_n_mm_config(M, N, K)
+    partials = torch.empty((split_k, M, N), device=a.device, dtype=torch.float32)
+
+    with torch_device_fn.device(a.device):
+        if kernel == "elementwise":
+            grid = (triton.cdiv(M, block_m), N * split_k)
+            mm_kernel_small_n_partial[grid](
+                a,
+                b,
+                partials,
+                M,
+                N,
+                K,
+                a.stride(0),
+                a.stride(1),
+                b.stride(0),
+                b.stride(1),
+                SPLIT_K=split_k,
+                BLOCK_M=block_m,
+                BLOCK_K=block_k,
+                num_warps=num_warps,
+            )
+        else:
+            grid = (
+                triton.cdiv(M, block_m) * triton.cdiv(N, _SMALL_N_DOT_BLOCK_N),
+                split_k,
+            )
+            mm_kernel_small_n_dot_partial[grid](
+                a,
+                b,
+                partials,
+                M,
+                N,
+                K,
+                a.stride(0),
+                a.stride(1),
+                b.stride(0),
+                b.stride(1),
+                SPLIT_K=split_k,
+                BLOCK_M=block_m,
+                BLOCK_N=_SMALL_N_DOT_BLOCK_N,
+                BLOCK_K=block_k,
+                num_warps=num_warps,
+            )
+        _launch_splitk_reduce(partials, c, M, N, split_k)
+    return c
 
 
 _ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32]
@@ -1078,6 +1299,24 @@ def splitk_mm_scenario(M, N, K):
     )
 
 
+def _small_n_mm_scenario(a, b, c, N, K):
+    return (
+        1 < N < _SMALL_N_DOT_BLOCK_N
+        and K >= 2048
+        and a.dtype == b.dtype == c.dtype
+        and c.dtype in (torch.float16, torch.bfloat16)
+    )
+
+
+def _prefer_dense_nt_over_generic_splitk(M, N, K):
+    fp32_output_bytes = M * N * torch.float32.itemsize
+    output_threshold = max(
+        1,
+        get_l2_cache_size() // _GENERIC_SPLITK_DENSE_OUTPUT_L2_DENOMINATOR,
+    )
+    return K <= 2 * N and fp32_output_bytes >= output_threshold
+
+
 def _splitk_mm_two_step_scenario(M, N, K):
     if K < 2048:
         return False
@@ -1177,19 +1416,35 @@ def mm(a, b):
     # allocates output
     c_dtype = get_higher_dtype(a.dtype, b.dtype)
     c = torch.empty((M, N), device=device, dtype=c_dtype)
+    if M == 0 or N == 0:
+        return c
     if N == 1:
         if _gemv_k_parallel_scenario(M, K):
             return gemv_mm_k_parallel(a, b, c, M, K)
         return gemv_mm(a, b, c, M, K)
+    if _small_n_mm_scenario(a, b, c, N, K):
+        return small_n_mm(a, b, c, M, N, K)
     two_step_split_k = _select_two_step_split_k(M, N, K)
     if two_step_split_k is not None:
         return splitk_mm_two_step(a, b, c, M, N, K, two_step_split_k)
-    if splitk_mm_scenario(M, N, K):
-        c.zero_()
-        return splitk_mm(a, b, c, M, N, K)
+    nt_scenario = nt_mm_scenario(a, b, c, M, N, K)
+    prefer_dense_nt = (
+        c.dtype in (torch.float16, torch.bfloat16)
+        and nt_scenario
+        and _prefer_dense_nt_over_generic_splitk(M, N, K)
+    )
+    if splitk_mm_scenario(M, N, K) and not prefer_dense_nt:
+        if (
+            c.dtype == torch.float32
+            and not torch.are_deterministic_algorithms_enabled()
+        ):
+            c.zero_()
+            return splitk_mm(a, b, c, M, N, K)
+        split_k = _generic_two_step_split_k(M, N, K)
+        return splitk_mm_two_step(a, b, c, M, N, K, split_k)
     if nn_mm_scenario(a, b, c, M, N, K):
         return general_mm_nn(a, b, c, M, N, K)
-    if nt_mm_scenario(a, b, c, M, N, K):
+    if nt_scenario:
         return general_mm_nt(a, b, c, M, N, K)
     return general_mm(a, b, c, M, N, K)
 
@@ -1207,18 +1462,34 @@ def mm_out(a, b, *, out):
     _, N = b.shape
     # allocates output
     c = out
+    if M == 0 or N == 0:
+        return c
     if N == 1:
         if _gemv_k_parallel_scenario(M, K):
             return gemv_mm_k_parallel(a, b, c, M, K)
         return gemv_mm(a, b, c, M, K)
+    if _small_n_mm_scenario(a, b, c, N, K):
+        return small_n_mm(a, b, c, M, N, K)
     two_step_split_k = _select_two_step_split_k(M, N, K)
     if two_step_split_k is not None:
         return splitk_mm_two_step(a, b, out, M, N, K, two_step_split_k)
-    if splitk_mm_scenario(M, N, K):
-        c.zero_()
-        return splitk_mm(a, b, c, M, N, K)
+    nt_scenario = nt_mm_scenario(a, b, c, M, N, K)
+    prefer_dense_nt = (
+        c.dtype in (torch.float16, torch.bfloat16)
+        and nt_scenario
+        and _prefer_dense_nt_over_generic_splitk(M, N, K)
+    )
+    if splitk_mm_scenario(M, N, K) and not prefer_dense_nt:
+        if (
+            c.dtype == torch.float32
+            and not torch.are_deterministic_algorithms_enabled()
+        ):
+            c.zero_()
+            return splitk_mm(a, b, c, M, N, K)
+        split_k = _generic_two_step_split_k(M, N, K)
+        return splitk_mm_two_step(a, b, c, M, N, K, split_k)
     if nn_mm_scenario(a, b, c, M, N, K):
         return general_mm_nn(a, b, c, M, N, K)
-    if nt_mm_scenario(a, b, c, M, N, K):
+    if nt_scenario:
         return general_mm_nt(a, b, c, M, N, K)
     return general_mm(a, b, c, M, N, K)

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/mm_hopper_expand.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/mm_hopper_expand.yaml
@@ -165,6 +165,39 @@ mm_splitk:
      K: default
      stride_am: default
      stride_bk: default
+mm_splitk_two_step:
+  - config:
+    include_default_configs: true
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        BLOCK_K: block_k
+      num_stages: stages
+      num_warps: warps
+    block_m:
+      - 16
+    block_n:
+      - 16
+      - 32
+      - 64
+      - 128
+    block_k:
+      - 64
+      - 128
+    stages:
+      - 2
+      - 3
+      - 4
+    warps:
+      - 2
+      - 4
+  - strategy:
+     M: default
+     N: default
+     K: default
+     stride_am: default
+     stride_bk: default
 gemv:
   - config:
     param_map:

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import os
 from typing import Optional
@@ -1118,7 +1119,7 @@ def tma_transposed_direct_tuned_mm(a, b, c, M, N, K):
     return c
 
 
-def tma_transposed_mm(a, b, c, M, N, K, config):
+def tma_transposed_mm(a, b, c, M, N, K, config, reduce_block=None):
     block_m, block_k, split_k, num_stages, num_warps = config
     block_n = _TMA_TRANSPOSE_BLOCK_N
     logger.debug(
@@ -1159,7 +1160,8 @@ def tma_transposed_mm(a, b, c, M, N, K, config):
             num_warps=num_warps,
             num_stages=num_stages,
         )
-        reduce_block = 256 if split_k == 8 else 512
+        if reduce_block is None:
+            reduce_block = 256 if split_k == 8 else 512
         mm_kernel_tma_splitk_reduce[(triton.cdiv(M * N, reduce_block),)](
             partials,
             c,
@@ -1399,24 +1401,8 @@ def splitk_gemv_mm(a, b, c, M, N, K):
     return c
 
 
-@libentry()
-@libtuner(
-    configs=runtime.get_tuned_config("mm_splitk"),
-    key=["M", "N", "K", "stride_am", "stride_bk"],
-    reset_to_zero=["C"],
-    strategy=["align32", "align32", "align32", "align32", "align32"],
-    warmup=5,
-    rep=10,
-    policy="flagtune",
-    flagtune_op_name="mm",
-    flagtune_expand_op_name="mm_splitk",
-    flagtune_op_id="flaggems/mm",
-    flagtune_variant="splitk",
-    flagtune_yaml_path=EXPAND_CONFIG_FILENAME,
-    flagtune_pre_hook=None,
-)
 @triton.jit
-def mm_kernel_splitk(
+def _mm_kernel_splitk(
     A,
     B,
     C,
@@ -1429,10 +1415,12 @@ def mm_kernel_splitk(
     stride_bn,
     stride_cm,
     stride_cn,
+    stride_cs,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    STORE_PARTIALS: tl.constexpr,
 ):
     tile_m: tl.constexpr = 16 if BLOCK_M < 16 else BLOCK_M
     tile_n: tl.constexpr = 16 if BLOCK_N < 16 else BLOCK_N
@@ -1472,9 +1460,188 @@ def mm_kernel_splitk(
 
     offs_cm = offset_am + tl.arange(0, tile_m)
     offs_cn = offset_bn + tl.arange(0, tile_n)
-    c_ptrs = C + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
     mask = (offs_cm < M)[:, None] & (offs_cn < N)[None, :]
-    tl.atomic_add(c_ptrs, acc, mask=mask)
+    c_ptrs = C + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
+    if STORE_PARTIALS:
+        tl.store(c_ptrs + pid_k * stride_cs, acc, mask=mask)
+    else:
+        tl.atomic_add(c_ptrs, acc, mask=mask)
+
+
+mm_kernel_splitk = libentry()(
+    libtuner(
+        configs=runtime.get_tuned_config("mm_splitk"),
+        key=["M", "N", "K", "stride_am", "stride_bk"],
+        reset_to_zero=["C"],
+        strategy=["align32", "align32", "align32", "align32", "align32"],
+        warmup=5,
+        rep=10,
+        policy="flagtune",
+        flagtune_op_name="mm",
+        flagtune_expand_op_name="mm_splitk",
+        flagtune_op_id="flaggems/mm",
+        flagtune_variant="splitk",
+        flagtune_yaml_path=EXPAND_CONFIG_FILENAME,
+        flagtune_pre_hook=None,
+    )(_mm_kernel_splitk)
+)
+
+
+def _prune_mm_splitk_two_step_configs(configs, named_args, **kwargs):
+    del kwargs
+    block_ns = (16, 32) if named_args["N"] <= 32 else (64, 128)
+    pruned_configs = [
+        config for config in configs if config.kwargs["BLOCK_N"] in block_ns
+    ]
+    return pruned_configs or list(configs)
+
+
+mm_kernel_splitk_partials = libentry()(
+    libtuner(
+        configs=runtime.get_tuned_config("mm_splitk_two_step"),
+        key=["M", "N", "K", "stride_am", "stride_bk"],
+        strategy=["default", "default", "default", "default", "default"],
+        prune_configs_by={"early_config_prune": _prune_mm_splitk_two_step_configs},
+        warmup=5,
+        rep=10,
+        flagtune_op_name="mm",
+        flagtune_expand_op_name="mm_splitk_two_step",
+        flagtune_yaml_path=EXPAND_CONFIG_FILENAME,
+    )(_mm_kernel_splitk)
+)
+
+
+@triton.jit
+def mm_kernel_splitk_reduce_strided(
+    partials,
+    output,
+    M,
+    N,
+    stride_cm,
+    stride_cn,
+    partial_stride,
+    SPLIT_K: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < M * N
+    accumulator = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    for split_id in range(SPLIT_K):
+        accumulator += tl.load(
+            partials + split_id * partial_stride + offsets,
+            mask=mask,
+            other=0.0,
+        )
+    offsets_m = offsets // N
+    offsets_n = offsets % N
+    output_ptrs = output + offsets_m * stride_cm + offsets_n * stride_cn
+    tl.store(output_ptrs, accumulator, mask=mask)
+
+
+_TWO_STEP_MAX_SPLITS = 32
+_TWO_STEP_MIN_K_ITERS_PER_SPLIT = 2
+_TWO_STEP_MULTI_WAVE_MIN_OUTPUT_TILES = 12
+
+
+def _floor_power_of_two(value):
+    if value < 1:
+        return 0
+    return 1 << (int(value).bit_length() - 1)
+
+
+def _ceil_power_of_two(value):
+    if value <= 1:
+        return 1
+    return 1 << int(value - 1).bit_length()
+
+
+@functools.lru_cache(maxsize=1)
+def _splitk_two_step_tile_candidates():
+    candidates = {
+        (
+            config.kwargs["BLOCK_M"],
+            config.kwargs["BLOCK_N"],
+            config.kwargs["BLOCK_K"],
+        )
+        for config in runtime.get_tuned_config("mm_splitk_two_step")
+    }
+    expand_config = runtime.get_expand_config(
+        "mm_splitk_two_step", yaml_path=EXPAND_CONFIG_FILENAME
+    )
+    if expand_config != -1:
+        ranges = expand_config["ranges"]
+        candidates.update(
+            (block_m, block_n, block_k)
+            for block_m in ranges.get("BLOCK_M", ())
+            for block_n in ranges.get("BLOCK_N", ())
+            for block_k in ranges.get("BLOCK_K", ())
+        )
+    return tuple(sorted(candidates))
+
+
+def _splitk_two_step_reference_tile(N):
+    block_ns = (16, 32) if N <= 32 else (64, 128)
+    candidates = tuple(
+        candidate
+        for candidate in _splitk_two_step_tile_candidates()
+        if candidate[1] in block_ns
+    )
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda tile: (tile[0] * tile[1], tile[0], tile[1], tile[2]),
+    )
+
+
+def _splitk_two_step_split_k(a, M, N, K):
+    reference_tile = _splitk_two_step_reference_tile(N)
+    if reference_tile is None:
+        return 1
+    block_m, block_n, block_k = reference_tile
+    output_tiles = triton.cdiv(M, block_m) * triton.cdiv(N, block_n)
+    k_iters = triton.cdiv(K, block_k)
+    max_k_split = _floor_power_of_two(k_iters // _TWO_STEP_MIN_K_ITERS_PER_SPLIT)
+    if N <= 32:
+        if output_tiles <= 1:
+            occupancy_split_k = 32
+        elif output_tiles <= 16:
+            occupancy_split_k = 16
+        else:
+            occupancy_split_k = 8
+        return max(1, min(occupancy_split_k, max_k_split, _TWO_STEP_MAX_SPLITS))
+
+    sm_count = _get_sm_count_for_tensor(a)
+    if output_tiles < _TWO_STEP_MULTI_WAVE_MIN_OUTPUT_TILES:
+        target_programs = max(1, 3 * sm_count // 4)
+    else:
+        target_programs = max(1, 3 * sm_count // 2)
+    occupancy_split_k = _ceil_power_of_two(triton.cdiv(target_programs, output_tiles))
+    return max(1, min(occupancy_split_k, max_k_split, _TWO_STEP_MAX_SPLITS))
+
+
+def _tma_splitk_two_step_config(a, b, c, M, N, K):
+    if N < 64 or N % 64 or K % 128:
+        return None
+    if not _tma_transposed_runtime_eligible(a, b, c, M, N, K):
+        return None
+
+    block_m = 16
+    m_tiles = triton.cdiv(M, block_m)
+    n_tiles = triton.cdiv(N, _TMA_TRANSPOSE_BLOCK_N)
+    output_tiles = m_tiles * n_tiles
+    deep_k = triton.cdiv(K, 128) > 32
+
+    if output_tiles <= 1:
+        block_k = 128
+        split_k = 16
+    elif deep_k and n_tiles >= 6 and output_tiles < 16:
+        block_k = 64
+        split_k = 16
+    else:
+        block_k = 128
+        split_k = 8
+    return block_m, block_k, split_k, 3, 4
 
 
 def splitk_mm(a, b, c, M, N, K, op_name="mm"):
@@ -1504,7 +1671,75 @@ def splitk_mm(a, b, c, M, N, K, op_name="mm"):
             b.stride(1),
             c.stride(0),
             c.stride(1),
+            0,
+            STORE_PARTIALS=False,
         )
+    return c
+
+
+def splitk_mm_two_step(a, b, c, M, N, K, op_name="mm"):
+    split_k = _splitk_two_step_split_k(a, M, N, K)
+    logger.debug(
+        "GEMS_NVIDIA MM_HOPPER, [op]: %s, [mm scenario]: two-step splitk, "
+        "[shape info]: [-, %s, %s, %s](batch, M, N, K), split_k=%s",
+        op_name,
+        M,
+        N,
+        K,
+        split_k,
+    )
+    partials = torch.empty((split_k, M, N), device=a.device, dtype=torch.float32)
+    partial_grid = lambda META: (
+        triton.cdiv(M, max(META["BLOCK_M"], 16))
+        * triton.cdiv(N, max(META["BLOCK_N"], 16)),
+        split_k,
+    )
+    n_elements = M * N
+    reduce_block = 32 if n_elements <= 32 else 256
+    reduce_warps = 1 if n_elements <= 32 else 4
+    reduce_grid = (triton.cdiv(n_elements, reduce_block),)
+
+    with torch_device_fn.device(a.device):
+        mm_kernel_splitk_partials[partial_grid](
+            a,
+            b,
+            partials,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            partials.stride(1),
+            partials.stride(2),
+            partials.stride(0),
+            SPLIT_K=split_k,
+            STORE_PARTIALS=True,
+        )
+        if c.is_contiguous():
+            mm_kernel_tma_splitk_reduce[reduce_grid](
+                partials,
+                c,
+                n_elements,
+                partials.stride(0),
+                SPLIT_K=split_k,
+                BLOCK_SIZE=reduce_block,
+                num_warps=reduce_warps,
+            )
+        else:
+            mm_kernel_splitk_reduce_strided[reduce_grid](
+                partials,
+                c,
+                M,
+                N,
+                c.stride(0),
+                c.stride(1),
+                partials.stride(0),
+                SPLIT_K=split_k,
+                BLOCK_SIZE=reduce_block,
+                num_warps=reduce_warps,
+            )
     return c
 
 
@@ -1531,7 +1766,7 @@ def streamk_scenario(a, b, M, N, K):
 
 
 def splitk_scenario(a, b, M, N, K):
-    if M >= 2048 or N >= 2048 or K < 4096:
+    if M <= 0 or N <= 0 or M >= 2048 or N >= 2048 or K < 4096:
         return False
     output_ctas = triton.cdiv(M, 16) * triton.cdiv(N, 32)
     sm_count = min(_get_sm_count_for_tensor(a), _H20_SM_COUNT)
@@ -2530,6 +2765,8 @@ def mm(a, b):
     # allocates output
     c_dtype = get_higher_dtype(a.dtype, b.dtype)
     c = torch.empty((M, N), device=device, dtype=c_dtype)
+    if M == 0 or N == 0:
+        return c
 
     # Optimize for N=1 case (matrix-vector multiplication)
     if N == 1:
@@ -2555,8 +2792,19 @@ def mm(a, b):
     #         return cluster_remote_mm(a, b, c, M, N, K)
     # Use splitk for small M
     if splitk_scenario(a, b, M, N, K):
-        c.zero_()
-        return splitk_mm(a, b, c, M, N, K)
+        tma_splitk_config = _tma_splitk_two_step_config(a, b, c, M, N, K)
+        if tma_splitk_config is not None:
+            return tma_transposed_mm(
+                a, b, c, M, N, K, tma_splitk_config, reduce_block=512
+            )
+        if (
+            c.dtype == torch.float32
+            and not torch.are_deterministic_algorithms_enabled()
+        ):
+            c.zero_()
+            return splitk_mm(a, b, c, M, N, K)
+        if c.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            return splitk_mm_two_step(a, b, c, M, N, K)
     return general_mm(a, b, c, M, N, K)
 
 
@@ -2570,6 +2818,8 @@ def mm_out(a, b, *, out):
     assert a.shape[1] == b.shape[0], "incompatible dimensions"
     M, K = a.shape
     _, N = b.shape
+    if M == 0 or N == 0:
+        return out
 
     # Optimize for N=1 case (matrix-vector multiplication)
     if N == 1:
@@ -2595,8 +2845,19 @@ def mm_out(a, b, *, out):
     #         return cluster_remote_mm(a, b, out, M, N, K)
     # Use splitk for small M
     if splitk_scenario(a, b, M, N, K):
-        out.zero_()
-        return splitk_mm(a, b, out, M, N, K)
+        tma_splitk_config = _tma_splitk_two_step_config(a, b, out, M, N, K)
+        if tma_splitk_config is not None:
+            return tma_transposed_mm(
+                a, b, out, M, N, K, tma_splitk_config, reduce_block=512
+            )
+        if (
+            out.dtype == torch.float32
+            and not torch.are_deterministic_algorithms_enabled()
+        ):
+            out.zero_()
+            return splitk_mm(a, b, out, M, N, K)
+        if out.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            return splitk_mm_two_step(a, b, out, M, N, K)
     return general_mm(a, b, out, M, N, K)
 
 
@@ -2607,8 +2868,12 @@ def router_gemm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     M, K = x.shape
     N = weight.shape[0]
     c = torch.empty((M, N), device=x.device, dtype=torch.float32)
+    if M == 0 or N == 0:
+        return c
     b = weight.t()
     if splitk_scenario(x, b, M, N, K):
-        c.zero_()
-        return splitk_mm(x, b, c, M, N, K, op_name="router_gemm")
+        if not torch.are_deterministic_algorithms_enabled():
+            c.zero_()
+            return splitk_mm(x, b, c, M, N, K, op_name="router_gemm")
+        return splitk_mm_two_step(x, b, c, M, N, K, op_name="router_gemm")
     return general_mm(x, b, c, M, N, K, op_name="router_gemm")

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/tune_configs.yaml
@@ -315,6 +315,49 @@ mm_splitk:
       SPLIT_K: 8
     num_stages: 3
     num_warps: 4
+mm_splitk_two_step:
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 16
+      BLOCK_K: 64
+    num_stages: 2
+    num_warps: 2
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 16
+      BLOCK_K: 64
+    num_stages: 3
+    num_warps: 2
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 16
+      BLOCK_K: 64
+    num_stages: 4
+    num_warps: 2
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 32
+      BLOCK_K: 64
+    num_stages: 2
+    num_warps: 2
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 64
+      BLOCK_K: 64
+    num_stages: 3
+    num_warps: 4
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 64
+      BLOCK_K: 128
+    num_stages: 2
+    num_warps: 4
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 128
+      BLOCK_K: 64
+    num_stages: 3
+    num_warps: 4
 sqrt:
   - META:
       BLOCK_SIZE: 512

--- a/src/flag_gems/runtime/configs_loader.py
+++ b/src/flag_gems/runtime/configs_loader.py
@@ -335,13 +335,15 @@ class TunedConfigLoader(object):
             ]
 
         if op_name == "mm_splitk_two_step":
+            has_pipeline = "PIPELINE" in ranges
+            pipelines = ranges.get("PIPELINE", [None])
             return [
                 triton.Config(
                     {
                         "BLOCK_M": block_m,
                         "BLOCK_N": block_n,
                         "BLOCK_K": block_k,
-                        "pipeline": pipeline,
+                        **({"pipeline": pipeline} if has_pipeline else {}),
                     },
                     num_stages=s,
                     num_warps=w,
@@ -350,7 +352,7 @@ class TunedConfigLoader(object):
                 for block_m in ranges["BLOCK_M"]
                 for block_n in ranges["BLOCK_N"]
                 for block_k in ranges["BLOCK_K"]
-                for pipeline in ranges["PIPELINE"]
+                for pipeline in pipelines
                 for s in ranges["s"]
                 for w in ranges["w"]
             ]


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

Fix the precision issue in the Hopper MM split-K path.

The previous one-step split-K implementation accumulated partial results directly into the final BF16/FP16 output buffer with atomic adds. This introduced repeated low-precision rounding and non-deterministic accumulation order.

This change:

- stores split-K partial results in an FP32 workspace;
- performs a second FP32 reduction before converting to the output dtype;
- keeps the one-step atomic path only for FP32 output when deterministic algorithms are disabled;
- uses the existing TMA two-step path for eligible layouts and a tuned generic two-step path otherwise;
- adds default and expanded tuning configurations for the two-step kernel;
- makes the compiler-specific `PIPELINE` field optional in `configs_loader.py`, while preserving it for backends that provide it.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

The MM correctness suite passes with the precision-safe split-K path. Multi-model BF16 expand tuning is used to verify that replacing low-precision atomic accumulation does not introduce a performance regression.
