### PR TITLE
tests: enable inplace erfc_ coverage for fp16/bf16

### DIFF
--- a/tests/test_special_erfc.py
+++ b/tests/test_special_erfc.py
@@ -43,14 +43,14 @@ def test_erfc_(shape, dtype):
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
     if dtype in (torch.float16, torch.bfloat16):
-        pytest.skip(
-            "Triton kernel out0=x incorrect for low-precision inplace; "
-            "non-inplace special_erfc covers kernel correctness — "
-            "https://github.com/flagos-ai/FlagGems/issues/4076"
-        )
+        # Compute the reference in fp32 and cast back, mirroring the
+        # non-inplace erfc tests. The inplace kernel writes through
+        # out0=x and is bitwise-identical to the non-inplace one, so
+        # low-precision dtypes are covered here too (issue #4076).
+        ref_out = torch.ops.aten.erfc_(ref_x.float()).to(dtype)
     else:
         ref_out = torch.ops.aten.erfc_(ref_x)
     with flag_gems.use_gems():
         act_out = torch.ops.aten.erfc_(x)
     utils.gems_assert_close(act_out, ref_out, dtype, equal_nan=True)
-    utils.gems_assert_close(x, ref_x, dtype, equal_nan=True)
+    utils.gems_assert_close(x, ref_out, dtype, equal_nan=True)


### PR DESCRIPTION
### PR Category
Test

### Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [x] Test
- [ ] CI/CD

### Description
`test_erfc_` skipped float16/bfloat16 with a reference to issue #4076, which reported the inplace erfc kernel producing incorrect results through the pointwise `out0=x` path for low-precision dtypes.

The issue was filed while PR #4041 was under review; on the merged master the inplace path is verified correct:

- `erfc_` (inplace) is bitwise-identical to `erfc` (non-inplace) for fp16/bf16 over 1M elements spanning [-12, 12];
- both match the fp32 aten reference with zero absolute difference, so no accuracy gap exists anymore.

Remove the skip and cover fp16/bf16 in the inplace test. As with the non-inplace erfc tests, the reference is computed in fp32 and cast back to the target dtype; the final assertion compares the mutated input against the reference output since `erfc_` returns self.

### Issue
Closes #4076

### Progress
- [x] Remove the fp16/bf16 skip in test_erfc_
- [x] Verify inplace path matches aten for low-precision dtypes

### Test Plan
Standalone H100 verification: `erfc_` is bitwise-identical to `erfc` for fp16/bf16 over 1M elements spanning [-12, 12], and both match the fp32 aten reference with zero absolute difference; the updated `tests/test_special_erfc.py` passes with the new dtypes enabled.
