### PR TITLE
feat(daily): persist failed operators and demote regressed ops

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -56,6 +56,8 @@ jobs:
       group: python-op-${{ needs.prepare.outputs.datetime }}
       cancel-in-progress: true
     runs-on: jiuding
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         continue-on-error: true
@@ -86,6 +88,29 @@ jobs:
         with:
           name: op-ut-coverage
           path: coverage/
+
+      - name: Record failed operators and adjust stages
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Persist the failed operators of this run (issue #4100) and
+          # demote operators that keep failing, then commit the result.
+          python3 tools/record_failures.py --run "${RUN_TAG}" \
+            --results accuracy_result.json \
+            --db .github/daily_failures.json
+          python3 tools/degrade_stages.py \
+            --db .github/daily_failures.json \
+            --yaml conf/operators.yaml
+          git add .github/daily_failures.json conf/operators.yaml || true
+          if git diff --cached --quiet -- .github/daily_failures.json conf/operators.yaml; then
+            echo "No failure-record or stage changes to commit"
+          else
+            git config user.name "flaggems-daily-bot"
+            git config user.email "flaggems-daily-bot@users.noreply.github.com"
+            git commit -m "chore(daily): record failed operators and adjust stages (${RUN_TAG})"
+            git push
+          fi
 
   examples:
     needs: prepare

--- a/tools/degrade_stages.py
+++ b/tools/degrade_stages.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Degrade operator maturity stages based on the recorded daily failures.
+
+Some operators only fail occasionally in the daily test workflow, which
+makes the failures hard to reproduce and easy to forget. To keep the
+declared operator maturity (the ``stages`` history in
+conf/operators.yaml) honest, this script reads the failure database
+maintained by tools/record_failures.py and demotes every operator that
+failed in at least --min-failures daily runs during the last
+--window-days days (issue #4100):
+
+    stable -> beta
+    beta   -> alpha
+
+The demotion appends a new stage entry ``- <stage>: '<version>'`` to the
+operator's ``stages`` history, keeping the file comments and formatting
+intact (the YAML is edited textually, not re-serialized). ``--version``
+defaults to the highest release version already present in the file,
+i.e. the current release.
+
+An operator is demoted by at most one level per release: if the last
+stage entry is already a demotion made by this tool at the current
+version, the operator is skipped until the next version bump. Operators
+already at ``alpha`` (or ``removed``/without stages) are never touched.
+
+The script only reports and edits conf/operators.yaml; committing and
+pushing the result is up to the caller (see .github/workflows/daily.yaml).
+
+Usage:
+    python tools/degrade_stages.py \
+        --db .github/daily_failures.json --yaml conf/operators.yaml
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Ordered from the most to the least mature stage; demotion moves right.
+STAGE_ORDER = ["removed", "stable", "beta", "alpha"]
+DEMOTION = {"stable": "beta", "beta": "alpha"}
+
+OP_ID_RE = re.compile(r"^  - id: (\S+)\s*$")
+STAGE_HEADER_RE = re.compile(r"^    stages:\s*$")
+STAGE_ENTRY_RE = re.compile(r"^      - ([A-Za-z]+): '([^']*)'\s*$")
+
+
+def version_key(version):
+    """Best-effort sort key for release strings like '5.4'."""
+    try:
+        return tuple(int(p) for p in str(version).split("."))
+    except ValueError:
+        return ()
+
+
+def parse_blocks(lines):
+    """Map operator id -> (block_start, block_end) line ranges."""
+    starts = [
+        (m.group(1), i)
+        for i, m in (
+            (line_no, OP_ID_RE.match(line)) for line_no, line in enumerate(lines)
+        )
+        if m
+    ]
+    blocks = {}
+    for pos, (op_id, start) in enumerate(starts):
+        end = starts[pos + 1][1] if pos + 1 < len(starts) else len(lines)
+        blocks[op_id] = (start, end)
+    return blocks
+
+
+def parse_stage_entries(lines, start, end):
+    """Return the (stage, version, line_no) entries of an operator block."""
+    entries = []
+    in_stages = False
+    for i in range(start, end):
+        line = lines[i]
+        if STAGE_HEADER_RE.match(line):
+            in_stages = True
+            continue
+        if in_stages:
+            m = STAGE_ENTRY_RE.match(line)
+            if m:
+                entries.append((m.group(1), m.group(2), i))
+            else:
+                break
+    return entries
+
+
+def current_stage(entries):
+    return entries[-1][0] if entries else None
+
+
+def already_demoted(entries, demote_version):
+    """True if the last entry is a demotion made by this tool in this release."""
+    if len(entries) < 2:
+        return False
+    prev_stage = entries[-2][0]
+    last_stage, last_version = entries[-1][0], entries[-1][1]
+    demoted_now = STAGE_ORDER.index(last_stage) > STAGE_ORDER.index(prev_stage)
+    return demoted_now and last_version == demote_version
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Degrade operator stages from recorded failures (issue #4100)"
+    )
+    parser.add_argument(
+        "--db",
+        default=str(ROOT / ".github" / "daily_failures.json"),
+        help="failure database written by tools/record_failures.py",
+    )
+    parser.add_argument(
+        "--yaml",
+        default=str(ROOT / "conf" / "operators.yaml"),
+        help="operators.yaml to edit in place",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=15,
+        help="count failures within this many days (default: 15)",
+    )
+    parser.add_argument(
+        "--min-failures",
+        type=int,
+        default=2,
+        help="demote operators failing in at least this many runs (default: 2)",
+    )
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="version recorded in the demotion entry "
+        "(default: highest version present in operators.yaml)",
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        print(f"[degrade_stages] failure database not found: {db_path}")
+        return 0
+    try:
+        db = json.loads(db_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        print(f"[degrade_stages] failed to parse {db_path}: {e}")
+        return 0
+
+    today = datetime.now(timezone.utc).date()
+    cutoff = (today - timedelta(days=args.window_days)).isoformat()
+    fail_runs = {}  # op id -> number of failing runs in the window
+    for run in db.get("runs", []):
+        if (run.get("date") or "") < cutoff:
+            continue
+        for op in run.get("failed_ops", {}):
+            fail_runs[op] = fail_runs.get(op, 0) + 1
+    if not fail_runs:
+        print(
+            f"[degrade_stages] no failing operator in the last "
+            f"{args.window_days} days, nothing to do"
+        )
+        return 0
+
+    yaml_path = Path(args.yaml)
+    lines = yaml_path.read_text(encoding="utf-8").splitlines()
+    blocks = parse_blocks(lines)
+
+    if args.version:
+        demote_version = args.version
+    else:
+        all_versions = []
+        for start, end in blocks.values():
+            all_versions.extend(v for _, v, _ in parse_stage_entries(lines, start, end))
+        known = [version_key(v) for v in all_versions if version_key(v)]
+        demote_version = (
+            ".".join(str(p) for p in max(known)) if known else today.strftime("%Y%m%d")
+        )
+
+    demotions = []  # (insert_at, op_id, from_stage, to_stage)
+    for op_id, fail_count in sorted(fail_runs.items()):
+        if fail_count < args.min_failures:
+            print(
+                f"[degrade_stages] {op_id}: failed in {fail_count} run(s), "
+                f"below the threshold of {args.min_failures}, skipped"
+            )
+            continue
+        if op_id not in blocks:
+            print(f"[degrade_stages] {op_id}: not found in operators.yaml, " "skipped")
+            continue
+        start, end = blocks[op_id]
+        entries = parse_stage_entries(lines, start, end)
+        stage = current_stage(entries)
+        target = DEMOTION.get(stage)
+        if target is None:
+            print(
+                f"[degrade_stages] {op_id}: stage '{stage}' cannot be "
+                "demoted, skipped"
+            )
+            continue
+        if already_demoted(entries, demote_version):
+            print(
+                f"[degrade_stages] {op_id}: already demoted to "
+                f"'{entries[-1][0]}' at version {demote_version}, skipped"
+            )
+            continue
+        demotions.append((entries[-1][2] + 1, op_id, stage, target))
+
+    for insert_at, op_id, from_stage, to_stage in sorted(
+        demotions, key=lambda d: d[0], reverse=True
+    ):
+        lines.insert(insert_at, f"      - {to_stage}: '{demote_version}'")
+        print(
+            f"[degrade_stages] {op_id}: {from_stage} -> {to_stage} "
+            f"at version {demote_version}"
+        )
+
+    if demotions:
+        yaml_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(
+            f"[degrade_stages] {len(demotions)} operator(s) demoted in " f"{yaml_path}"
+        )
+    else:
+        print("[degrade_stages] no operator demoted")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/record_failures.py
+++ b/tools/record_failures.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Record failed operators of a daily run into a structured JSON database.
+
+tests/conftest.py dumps the result of every test (together with the
+operator marks attached to it) into accuracy_result.json when the pytest
+session finishes. This script aggregates the failures of one daily run
+into .github/daily_failures.json (committed to the repository), so the
+occasional, hard-to-reproduce operator failures are persisted and can be
+tracked as the code base evolves (issue #4100).
+
+The database layout is::
+
+    {
+      "runs": [
+        {
+          "run": "20260831",                  # daily run tag
+          "date": "2026-08-31",               # ISO date of the run
+          "failed_ops": {"add": 2, ...},      # failures per operator mark
+          "failed_tests": {                   # failed test -> its op marks
+              "tests/test_binary.py::test_add[...](...)": ["add"]
+          }
+        },
+        ...
+      ]
+    }
+
+Re-recording the same run tag replaces its entry, so the step is safe to
+retry. Records older than --window-days are pruned to keep the database
+bounded (tools/degrade_stages.py looks at the same window).
+
+Usage:
+    python tools/record_failures.py --run 20260831
+    python tools/record_failures.py --run 20260831-manual \
+        --results accuracy_result.json --db .github/daily_failures.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RESULTS = ROOT / "accuracy_result.json"
+DEFAULT_DB = ROOT / ".github" / "daily_failures.json"
+
+
+def run_tag_to_date(run_tag):
+    """Derive the ISO date of the run from its tag (e.g. 20260831-manual)."""
+    m = re.match(r"^(\d{4})(\d{2})(\d{2})(?:-|$)", run_tag or "")
+    if m:
+        try:
+            return date(*(int(g) for g in m.groups())).isoformat()
+        except ValueError:
+            pass
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Record failed operators of a daily run (issue #4100)"
+    )
+    parser.add_argument(
+        "--run",
+        default="",
+        help="run tag of the daily job, e.g. 20260831 or 20260831-manual",
+    )
+    parser.add_argument(
+        "--results",
+        default=str(DEFAULT_RESULTS),
+        help="per-test results JSON written by tests/conftest.py",
+    )
+    parser.add_argument(
+        "--db",
+        default=str(DEFAULT_DB),
+        help="failure database to update",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=15,
+        help="prune records older than this many days (default: 15)",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="ISO date of the run (default: derived from --run, else today)",
+    )
+    args = parser.parse_args()
+
+    run_tag = args.run.strip() or datetime.now(timezone.utc).strftime("%Y%m%d")
+    run_date = args.date or run_tag_to_date(run_tag)
+    if run_date is None:
+        run_date = datetime.now(timezone.utc).date().isoformat()
+
+    results_path = Path(args.results)
+    if not results_path.exists():
+        print(
+            f"[record_failures] results file not found: {results_path}, "
+            "nothing to record"
+        )
+        return 0
+
+    try:
+        data = json.loads(results_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        print(f"[record_failures] failed to parse {results_path}: {e}")
+        return 0
+
+    failed_tests = {}
+    failed_ops = {}
+    for nodeid, info in data.items():
+        if not isinstance(info, dict) or info.get("result") != "failed":
+            continue
+        op_marks = sorted(set(info.get("opname") or []))
+        failed_tests[nodeid] = op_marks
+        for op in op_marks:
+            failed_ops[op] = failed_ops.get(op, 0) + 1
+
+    db_path = Path(args.db)
+    try:
+        db = json.loads(db_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        db = {}
+    runs = [r for r in db.get("runs", []) if r.get("run") != run_tag]
+    runs.append(
+        {
+            "run": run_tag,
+            "date": run_date,
+            "failed_ops": dict(sorted(failed_ops.items())),
+            "failed_tests": dict(sorted(failed_tests.items())),
+        }
+    )
+
+    cutoff = (
+        date.fromisoformat(run_date) - timedelta(days=args.window_days)
+    ).isoformat()
+    runs = [r for r in runs if (r.get("date") or "") >= cutoff]
+    runs.sort(key=lambda r: (r.get("date") or "", r.get("run") or ""))
+    db["runs"] = runs
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text(
+        json.dumps(db, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+
+    print(
+        f"[record_failures] run {run_tag} ({run_date}): "
+        f"{len(failed_tests)} failed tests, {len(failed_ops)} affected ops; "
+        f"database {db_path} holds {len(runs)} runs"
+    )
+    for op, count in sorted(failed_ops.items()):
+        print(f"[record_failures]   {op}: {count} failed test(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### PR Category
CI/CD

### Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [ ] Test
- [ ] CI/CD

### Description
Daily-run operator failures are occasional and often not reproducible, so they were lost once the job finished (issue #4100).

- `tools/record_failures.py` aggregates the per-test results that `tests/conftest.py` already dumps to `accuracy_result.json` into `.github/daily_failures.json` keyed by run tag; records older than 15 days are pruned automatically.
- `tools/degrade_stages.py` demotes operators that failed in at least two runs over the past 15 days by appending a stage entry to `conf/operators.yaml` (stable -> beta, beta -> alpha), at most one level per release.
- the daily workflow records the failures after the unit-test step and commits the updated database and `operators.yaml`.

### Issue
Closes #4100

### Progress
- [x] record_failures.py persistence with 15-day pruning
- [x] degrade_stages.py demotion logic
- [x] daily.yaml wiring (record + commit)

### Test Plan
Exercised both tools against synthetic accuracy_result.json inputs: the database is keyed by run tag, prunes entries older than 15 days, and operators failing twice in 15 days get exactly one stage demotion per release; the daily workflow steps were dry-run locally to confirm record + commit ordering.
