### PR TITLE
fix(index): use int64 offsets to avoid int32 overflow for large tensors

### DIFF
--- a/src/flag_gems/ops/index.py
+++ b/src/flag_gems/ops/index.py
@@ -188,7 +188,9 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.newline()
     code.writeline("from flag_gems.utils import libentry, libtuner")
     code.writeline("from flag_gems import runtime")
-    code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline(
+        "from flag_gems.utils.shape_utils import can_use_int32_index, volume"
+    )
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -259,6 +261,11 @@ def generate_index_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        # cur_index * input_stride exceeds int32 when the tensor's element
+        # range does (issue #4153); promote to int64 before offset math.
+        code.newline()
+        for i in range(indices_len):
+            code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -446,6 +453,7 @@ def generate_index_linearized_kernel(
             "N,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
+            "INT32_OFFSET: tl.constexpr,",
         ]
         code.writelines(args)
     code.writeline("):")
@@ -454,6 +462,14 @@ def generate_index_linearized_kernel(
         code.writeline("pid_p = tl.program_id(axis=0)")
         code.writeline("pid_m = tl.program_id(axis=1)")
         code.writeline("pid_n = tl.program_id(axis=2)")
+        # Element offsets can exceed int32 for tensors with more than
+        # INT32_MAX elements (issue #4153); promote program ids so every
+        # downstream offset computation runs in int64 when required.
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            code.writeline("pid_p = pid_p.to(tl.int64)")
+            code.writeline("pid_m = pid_m.to(tl.int64)")
+            code.writeline("pid_n = pid_n.to(tl.int64)")
         code.newline()
 
         code.writeline(
@@ -469,6 +485,11 @@ def generate_index_linearized_kernel(
             code.writeline(
                 f"raw{i} = tl.load(indices{i}_ptr + index_offsets, mask=index_mask, other=0)"
             )
+            # raw + dim and idx * stride overflow int32 for large element
+            # ranges; promote before any arithmetic when int64 is required.
+            code.writeline("if not INT32_OFFSET:")
+            with code.indent():
+                code.writeline(f"raw{i} = raw{i}.to(tl.int64)")
             code.writeline(f"idx{i} = tl.where(raw{i} < 0, raw{i} + {dim}, raw{i})")
         code.newline()
 
@@ -516,6 +537,11 @@ def generate_index_linearized_wrapper(
 ):
     prefix_size = _volume(inp_shape[:start_dim])
     suffix_size = _volume(inp_shape[start_dim + indices_len :])
+    # raw + dim stays below 2**31 only for indexed dims < 2**30.
+    int32_dims_ok = all(
+        2 * int(dim) <= 2**31 - 1
+        for dim in inp_shape[start_dim : start_dim + indices_len]
+    )
 
     code.writeline(f"def {wrapper_name}(input, start_dim, indices, out):")
     with code.indent():
@@ -531,12 +557,24 @@ def generate_index_linearized_wrapper(
             code.writeline("triton.cdiv(N, meta['BLOCK_SIZE1']),")
         code.writeline(")")
         code.newline()
+        # int32 offsets are safe only when every provable bound stays
+        # within int32: element ranges of input, indices and out.
+        if int32_dims_ok:
+            code.writeline(
+                "int32_offset = can_use_int32_index(input) "
+                "and all(can_use_int32_index(i) for i in indices) "
+                "and can_use_int32_index(out)"
+            )
+        else:
+            code.writeline("int32_offset = False")
+        code.newline()
         code.writeline(f"{kernel_name}[grid](")
         with code.indent():
             args = ["input,"]
             args += [f"indices[{i}]," for i in range(indices_len)]
             args += ["out,", "M,", "N,"]
             code.writelines(args)
+            code.writeline("INT32_OFFSET=int32_offset,")
         code.writeline(")")
         code.writeline("return input")
     code.newline()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -322,3 +322,37 @@ def test_index_error_too_many_indices(dtype):
 
     with pytest.raises(IndexError, match="too many indices"):
         flag_gems.index(inp, indices)
+
+
+@pytest.mark.index
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_index_int32_offset_overflow():
+    """Regression for issue #4153: int64 offsets for large element ranges.
+
+    A (2**28 + 1, 8) int8 tensor holds 2**31 + 8 elements, so the int32
+    index value 2**28 produces element offsets >= 2**31. These used to
+    overflow int32 arithmetic in the generated kernels and caused
+    out-of-bounds reads ("illegal memory access").
+    """
+    free_bytes, _ = torch.cuda.mem_get_info(flag_gems.device)
+    if free_bytes < 3 * 2**30:
+        pytest.skip("not enough free device memory for the int32-offset case")
+
+    rows = 2**28 + 1
+    inp = torch.zeros((rows, 8), dtype=torch.int8, device=flag_gems.device)
+    idx = torch.tensor([2**28], dtype=torch.int32, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_idx = utils.to_reference(idx)
+
+    # Contiguous input takes the linearized adjacent-index kernel.
+    ref_out = torch.ops.aten.index(ref_inp, [ref_idx])
+    out = flag_gems.index(inp, [idx])
+    utils.gems_assert_close(out, ref_out, torch.int8)
+
+    # Transposed view takes the generic (code-generated) kernel.
+    ref_out_t = torch.ops.aten.index(ref_inp.t(), [None, ref_idx])
+    out_t = flag_gems.index(inp.t(), [None, idx])
+    utils.gems_assert_close(out_t, ref_out_t, torch.int8)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [ ] Test
- [ ] CI/CD

### Description
The index op computed element offsets in int32. For large inputs (e.g. [20000, 8, 128, 128] bf16, stride0=131072) multiplying an int32 index value by the row stride overflows 2**31 and produces wrong addresses, causing illegal memory access.

- generic kernel: promote loaded index values to int64 before computing offsets (pid is already int64 via ext.program_id)
- linearized kernel: add an INT32_OFFSET constexpr dual path, same pattern as scatter.py; the wrapper enables int32 offsets only when `can_use_int32_index` passes for input, indices and output, and when the indexed dims are statically guaranteed to fit in int32
- add regression test `test_index_int32_offset_overflow` covering both the linearized (contiguous) and generic (transposed view) paths

### Issue
Fixes #4153

### Progress
- [x] int64 offsets in the generic kernel
- [x] INT32_OFFSET dual path for the linearized kernel with conservative enablement
- [x] regression test for both paths

### Test Plan
New test `test_index_int32_offset_overflow` reproduces the wrong-address failure on master and passes with the fix (both contiguous and transposed-view paths); the full `tests/test_index.py` suite passes on H100 unchanged.
