### PR TITLE
fix(vector_norm): exclude masked padding lanes for negative finite orders

### DIFF
--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -302,7 +302,9 @@ def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexp
         mask = row_mask & col_mask
 
         a = tl.load(X + cols, mask, other=0.0).to(acc_dtype)
-        _sum += pow(tl.abs(a), ord)
+        # Masked lanes load as 0.0; for negative orders pow(0, ord) is +inf
+        # and would corrupt the reduction (issue #4600), so exclude them.
+        _sum += tl.where(mask, pow(tl.abs(a), ord), 0.0)
     sum = tl.sum(_sum, axis=1)
     out = pow(sum, 1 / ord)[:, None]
     tl.store(Out, out, row_mask)
@@ -323,7 +325,9 @@ def l1_norm_kernel_1(X, Mid, ord, M, BLOCK_SIZE: tl.constexpr):
     else:
         acc_dtype = tl.float32
     x = tl.load(X, mask=mask, other=0.0).to(acc_dtype)
-    mid = tl.sum(pow(tl.abs(x), ord))
+    # Masked lanes load as 0.0; for negative orders pow(0, ord) is +inf
+    # and would corrupt the reduction (issue #4600), so exclude them.
+    mid = tl.sum(tl.where(mask, pow(tl.abs(x), ord), 0.0))
     tl.store(Mid, mid)
 
 

--- a/tests/test_vector_norm.py
+++ b/tests/test_vector_norm.py
@@ -31,7 +31,7 @@ else:
     FLOAT_DTYPES = utils.ALL_FLOAT_DTYPES
     DIM_LIST = [0, 1, [0, 1], [1, 0]]
     KEEP_DIM = [True, False]
-    ORD_LIST = [2, float("inf"), -float("inf"), 0, 1]
+    ORD_LIST = [2, float("inf"), -float("inf"), 0, 1, -1, -2]
 
 
 def _get_reduce_dim(shape, dim):


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [ ] Test
- [ ] CI/CD

### Description
torch.norm / torch.linalg.vector_norm with a negative finite order (e.g. p=-1, -2, -3) silently returned 0 whenever the reduction extent was smaller than BLOCK_N (the common case). `v_norm_kernel` and `l1_norm_kernel_1` load masked lanes as 0.0 and then accumulate `pow(|x|, ord)`; for negative ord, `pow(0, ord)` is +inf, so the padding lanes poisoned the sum and the final `pow(sum, 1/ord)` collapsed to 0. Non-negative and infinite orders were unaffected.

Guard both accumulations with `tl.where(mask, ..., 0.0)` so padding lanes contribute exactly 0 regardless of the sign of ord. Real zero elements keep their previous behaviour, which matches PyTorch.

The accuracy test `ORD_LIST` only covered [2, inf, -inf, 0, 1], which is why CI missed this; add the negative finite orders -1 and -2 to the list.

### Issue
Fixes #4600

### Progress
- [x] mask padding lanes in v_norm_kernel and l1_norm_kernel_1 accumulations
- [x] extend ORD_LIST with -1 and -2

### Test Plan
The new negative-order cases reproduce the 0-result on master and pass with the fix; `tests/test_vector_norm.py` 672 passed on H100.
