### PR TITLE
build: tolerate post-release tags in version derivation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,7 @@ flaggems-flagtune-compare = "flag_gems.flagtune.cli.compare:main"
 
 [tool.setuptools_scm]
 write_to = "src/flag_gems/_version.py"
-version_scheme = "no-guess-dev"
+version_scheme = "only-version"
 
 [tool.uv]
 


### PR DESCRIPTION
## Problem

Every PR is currently failing at the `setup-flaggems` step (e.g. [run 33478083014](https://github.com/flagos-ai/FlagGems/actions/runs/33478083014)):

```
ValueError: 5.4.0rc0.post1 already is a post release, refusing to guess the update
```

The FlagOS 2.2 rc0 tag `v5.4.0-rc0.post1` was created at the `5.4.0-rc0` branch cut point, which is a commit on `master`'s history. It became the nearest tag `git describe` finds from master and from every PR branch. `no-guess-dev` derives dev versions by appending `.post1.devN` to the nearest tag, and refuses when the tag is already a post release.

The tag has been removed as an immediate stopgap (nearest tag falls back to `v5.3.5`), but it will be re-created on the release branch per the FlagOS 2.2 release process, and `.postN` validation tags are the org-wide convention — so the scheme needs to tolerate them.

## Change

One line: `version_scheme = "no-guess-dev"` → `"only-version"`. The nearest tag is used as-is, the vLLM/PyTorch pattern and the same scheme vllm-plugin-FL uses.

Resulting versions (verified locally with setuptools-scm 9.2.2, within the `>=8,<10` pin, against this repo's actual history):

| scenario | no-guess-dev (before) | only-version (after) |
|---|---|---|
| exact GA/rc tag, clean tree | `5.3.5` | `5.3.5` (unchanged) |
| commits past a GA tag | `5.3.5.post1.devN+g<sha>` | `5.3.5+g<sha>.d<date>` |
| commits past a post-release tag | **ValueError (CI down)** | `5.4.0rc0.post1+g<sha>.d<date>` |

Trade-off: dev builds lose the `.postN.devN` distance counter in the public version and carry it in the local segment instead. Released/tagged builds are byte-identical.

Note on verification sequencing: because the tag was already deleted as the stopgap, this PR's CI no longer hits the crash condition — it only shows the scheme change is regression-free. The post-tag scenario itself was verified locally against this repo's history (cloned before the deletion), and will be re-exercised in CI once the tag is re-created on the release branch.
