### PR TITLE
add int8 tests for (un)pack_seq_triton

### DIFF
--- a/benchmark/test_pack_seq.py
+++ b/benchmark/test_pack_seq.py
@@ -137,6 +137,35 @@ def test_pack_seq():
     bench.run()
 
 
+# =============================================================================
+# Custom Benchmark class — pack_seq (INT8)
+# =============================================================================
+
+
+class PackSeqINT8Benchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = PACK_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        del cur_dtype
+        for config in self.shapes:
+            yield from self._int8_input_fn(config)
+
+    def _int8_input_fn(self, config):
+        N, D, B, lengths_list = config
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        x = torch.randint(-128, 128, (N, D), dtype=torch.int8, device=device)
+        # Explicit int pad_value (0) instead of the float default (-inf):
+        # a quantization-style int8 pad, and representative of the
+        # performance-relevant case (correctness edge cases are covered
+        # by tests/test_pack_seq.py instead).
+        yield x, lengths, 0
+
+
 @pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
     not (HAS_VLLM and CUDA_AVAILABLE),
@@ -147,6 +176,21 @@ def test_pack_seq_fp8():
         op_name="pack_seq_triton",
         torch_op=vllm_pack_seq,
         dtypes=[FP8_DTYPE],
+    )
+    bench.set_gems(pack_seq_triton)
+    bench.run()
+
+
+@pytest.mark.pack_seq_triton
+@pytest.mark.skipif(
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+def test_pack_seq_int8():
+    bench = PackSeqINT8Benchmark(
+        op_name="pack_seq_triton",
+        torch_op=vllm_pack_seq,
+        dtypes=[torch.int8],
     )
     bench.set_gems(pack_seq_triton)
     bench.run()

--- a/benchmark/test_unpack_seq.py
+++ b/benchmark/test_unpack_seq.py
@@ -153,3 +153,47 @@ def test_unpack_seq_fp8():
     )
     bench.set_gems(unpack_seq_triton)
     bench.run()
+
+
+# =============================================================================
+# Custom Benchmark class — unpack_seq (INT8)
+# =============================================================================
+
+
+class UnpackSeqINT8Benchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = UNPACK_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        del cur_dtype
+        for config in self.shapes:
+            yield from self._int8_input_fn(config)
+
+    def _int8_input_fn(self, config):
+        N, D, B, lengths_list = config
+        Lmax = max(lengths_list)
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        # unpack_seq_triton has no dtype-specific padding branch (pure
+        # load/store copy), so the padding region's contents don't matter
+        # for this benchmark -- only the valid-token copy is measured.
+        packed = torch.randint(-128, 128, (B, Lmax, D), dtype=torch.int8, device=device)
+        yield packed, lengths
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.skipif(
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+def test_unpack_seq_int8():
+    bench = UnpackSeqINT8Benchmark(
+        op_name="unpack_seq_triton",
+        torch_op=vllm_unpack_seq,
+        dtypes=[torch.int8],
+    )
+    bench.set_gems(unpack_seq_triton)
+    bench.run()

--- a/tests/test_pack_seq.py
+++ b/tests/test_pack_seq.py
@@ -313,3 +313,71 @@ def test_pack_seq_fp8_block_sizes(block_t, block_d):
         expected = x_fp8[b * 25 : b * 25 + 25].to(torch.float32)
         actual = result[b, :25].to(torch.float32)
         torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-2)
+
+
+# =============================================================================
+# INT8 (exploratory -- currently NOT formally supported, see
+# pack_seq_triton_review.md). These tests probe the actual current
+# behavior of pack_seq_triton on int8 input rather than assuming support:
+# there is no dedicated PAD_IS_INT8 branch in pack_seq.py, so int8 output
+# falls into the same float32-padding path used for float dtypes.
+# =============================================================================
+
+
+@pytest.mark.pack_seq_triton
+@pytest.mark.parametrize("pad_value", [-128, -1, 0, 127])
+def test_pack_seq_int8_custom_padding(pad_value):
+    N, D = 20, 16
+    lengths_list = [10, 10]
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randint(-128, 128, (N, D), dtype=torch.int8, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths, pad_value=pad_value)
+
+    assert result.dtype == torch.int8
+    assert result.shape == (2, 10, D)
+
+    for b in range(2):
+        expected = x[b * 10 : b * 10 + 10]
+        actual = result[b, :10]
+        assert torch.equal(actual, expected), f"batch {b} valid region mismatch"
+
+    padded_data = result[:, 10:].to(torch.int32)
+    assert torch.all(padded_data == pad_value), (
+        f"int8 padding with pad_value={pad_value} produced "
+        f"{padded_data.unique().tolist()} instead"
+    )
+
+
+@pytest.mark.pack_seq_triton
+def test_pack_seq_int8_valid_region_with_default_padding():
+    """The valid-token copy must be correct regardless of the (currently
+    ill-defined) default `-inf` padding path for int8."""
+    N, D = 20, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randint(-128, 128, (N, D), dtype=torch.int8, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths)
+    assert result.dtype == torch.int8
+
+    for b in range(2):
+        expected = x[b * 10 : b * 10 + 10]
+        actual = result[b, :10]
+        assert torch.equal(actual, expected)
+
+
+@pytest.mark.pack_seq_triton
+def test_pack_seq_int8_out_of_range_padding_is_unvalidated():
+    """There is currently no range check for int8 pad_value. This test
+    documents that an out-of-range value (e.g. 200) is silently accepted
+    today instead of raising -- a gap called out in the review."""
+    N, D = 20, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randint(-128, 128, (N, D), dtype=torch.int8, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths, pad_value=200)
+    assert result.dtype == torch.int8
+    for b in range(2):
+        expected = x[b * 10 : b * 10 + 10]
+        actual = result[b, :10]
+        assert torch.equal(actual, expected)

--- a/tests/test_unpack_seq.py
+++ b/tests/test_unpack_seq.py
@@ -232,3 +232,22 @@ def test_pack_unpack_fp8_roundtrip():
             rtol=1e-3,
             atol=1e-3,
         )
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize(
+    "N, H, D, lengths_list",
+    [(6, 8, 4, [3, 3]), (10, 4, 8, [2, 4, 4]), (15, 8, 16, [7, 5, 3])],
+)
+def test_pack_unpack_int8_roundtrip(N, H, D, lengths_list):
+    """INT8 is not formally supported for pack_seq_triton's padding path,
+    but unpack_seq_triton never constructs padding at all -- it only
+    copies valid tokens back out -- so it should round-trip exactly
+    regardless of that gap."""
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randint(-128, 128, (N, H, D), dtype=torch.int8, device=flag_gems.device)
+    packed = _ref_pack_seq(x, lengths_list, pad_value=0)
+    unpacked = unpack_seq_triton(packed, lengths)
+    assert unpacked.shape == x.shape
+    assert unpacked.dtype == torch.int8
+    assert torch.equal(unpacked, x)


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

New Feature

### Description

This PR adds INT8 coverage for `pack_seq_triton` and `unpack_seq_triton` without changing kernel or runtime implementation.

It adds both correctness tests and benchmarks, aligning INT8 coverage with the existing floating-point and FP8 test coverage.

#### Accuracy tests

* `test_pack_seq_int8_custom_padding`: verifies exact valid-token copying and in-range INT8 padding values (`-128`, `-1`, `0`, `127`).
* `test_pack_seq_int8_valid_region_with_default_padding`: verifies the valid-token region with the default `pad_value=-inf`.
* `test_pack_seq_int8_out_of_range_padding_is_unvalidated`: documents the current lack of INT8 `pad_value` range validation.
* `test_pack_unpack_int8_roundtrip`: verifies exact INT8 equality after pack/unpack round trips.

#### Benchmarks

* Adds INT8 benchmarks for `pack_seq_triton` and `unpack_seq_triton` against the vLLM reference, following the existing benchmark structure and `--level` control.

All new tests were verified on NVIDIA Hopper and pass.

This PR only documents and tests the current INT8 behavior. Explicit INT8 padding semantics and range validation are left for separate implementation changes.

### Progress

* [x] Change is properly reviewed (1 reviewer required, 2 recommended).
* [ ] Change is responded to an issue.
* [x] Change is fully covered by a UT.

### Performance
#### unpack_seq_triton:
<img width="1534" height="1774" alt="image" src="https://github.com/user-attachments/assets/92a43ff2-3fff-480b-a16a-75d8347170ed" />

#### pack_seq_triton: 
<img width="1658" height="1776" alt="image" src="https://github.com/user-attachments/assets/39248841-f874-4162-8da5-af6b140328ad" />

