### PR TITLE
fix(instance_norm): recover unbiased running_var from rstd

### DIFF
--- a/src/flag_gems/fused/instance_norm.py
+++ b/src/flag_gems/fused/instance_norm.py
@@ -311,8 +311,11 @@ def update_running_stats_kernel(
         rstd = tl.load(rstd_ptr + bid * C + cid[None, :], mask=mask, other=0.0).to(
             tl.float32
         )
+        # rstd = rsqrt(var_biased + eps), so 1 / rstd**2 - eps == var_biased.
+        # Subtract eps (not add) and clamp at 0 so subtractive cancellation on
+        # a near-constant channel can never produce a negative running_var.
         var = (
-            (1 / (rstd * rstd) + eps) * N / (N - 1)
+            tl.maximum(1 / (rstd * rstd) - eps, 0.0) * N / (N - 1)
         )  # NOTE: use unbiased var to update running_var
 
         new_mean += tl.sum(mean, axis=0)

--- a/tests/test_instance_norm.py
+++ b/tests/test_instance_norm.py
@@ -147,3 +147,73 @@ def test_instance_norm(
             utils.gems_assert_close(
                 res_bias_grad, ref_bias_grad, dtype, reduce_dim=B * N
             )
+
+
+# Regression tests for issue #4885: the running-stats update kernel recovered
+# the biased variance from rstd as (1 / rstd**2 + eps), but 1 / rstd**2 is
+# already var + eps (rstd = rsqrt(var + eps)), so running_var was updated with
+# (var + 2 * eps) instead of var. The default eps=1e-5 keeps the error below
+# the accuracy tolerance, so these tests use a large eps to expose it. The
+# shapes span all three forward kernels that store rstd: N <= 128 (multiline
+# persistent), 128 < N <= 4096 (persistent) and N > 4096 (loop).
+INSTANCE_NORM_RUNNING_STATS_EPS = [0.1, 1.0]
+INSTANCE_NORM_RUNNING_STATS_SHAPES = [
+    (4, 16, 8, 8),  # N=64, multiline persistent kernel
+    (2, 3, 1024),  # N=1024, persistent kernel
+    (2, 3, 128, 128),  # N=16384, loop kernel
+]
+
+
+@pytest.mark.instance_norm_running_stats
+@pytest.mark.parametrize("shape", INSTANCE_NORM_RUNNING_STATS_SHAPES)
+@pytest.mark.parametrize("eps", INSTANCE_NORM_RUNNING_STATS_EPS)
+def test_instance_norm_running_var_recovery(shape, eps):
+    torch.manual_seed(0)
+    x = torch.randn(shape, device=device)
+    C = shape[1]
+    momentum = 0.1
+
+    ref_running_mean = torch.zeros(C)
+    ref_running_var = torch.ones(C)
+    torch.nn.functional.instance_norm(
+        x.cpu(),
+        running_mean=ref_running_mean,
+        running_var=ref_running_var,
+        use_input_stats=True,
+        momentum=momentum,
+        eps=eps,
+    )
+
+    running_mean = torch.zeros(C, device=device)
+    running_var = torch.ones(C, device=device)
+    flag_gems.instance_norm(
+        x,
+        running_mean=running_mean,
+        running_var=running_var,
+        use_input_stats=True,
+        momentum=momentum,
+        eps=eps,
+    )
+
+    utils.gems_assert_close(running_mean.cpu(), ref_running_mean, torch.float32)
+    utils.gems_assert_close(running_var.cpu(), ref_running_var, torch.float32)
+
+
+@pytest.mark.instance_norm_running_stats
+@pytest.mark.parametrize("shape", [(2, 3, 16), (2, 3, 64)])
+def test_instance_norm_running_var_non_negative(shape):
+    """Near-constant channels: subtractive cancellation must not go negative."""
+    torch.manual_seed(1)
+    x = torch.ones(shape, device=device) + torch.randn(shape, device=device) * 1e-6
+    C = shape[1]
+    running_mean = torch.zeros(C, device=device)
+    running_var = torch.ones(C, device=device)
+    flag_gems.instance_norm(
+        x,
+        running_mean=running_mean,
+        running_var=running_var,
+        use_input_stats=True,
+        momentum=0.1,
+        eps=1e-5,
+    )
+    assert bool(torch.all(running_var >= 0)), "running_var must stay non-negative"


### PR DESCRIPTION
### PR Category
OP Test / Bug Fix

### Type of Change
Bug Fix

### Description
Fix the `instance_norm` running-var accumulation bug. The kernel previously updated `running_var` as `rstd^{-2} + eps` (adding epsilon), so the running variance drifts upward by `2 * eps * momentum` on every update and is wrong even on a near-constant channel.

The correct recovery is `running_var = 1 / rstd^2 - eps` (clamped at 0) with the Bessel-corrected unbiased estimate `* N / (N - 1)`.

### Issue
- Resolves #4885

### Reproduction
With `momentum=0.1` and `eps=1.0`, after a single forward pass `running_var` differed from the reference by ~`2 * eps * momentum`; with the default `eps=1e-5` the drift was masked inside the float tolerance of the original test.

### Root Cause
`rstd = rsqrt(var_biased + eps)` implies `1 / rstd^2 - eps == var_biased`. The old code stored `+eps`, producing `(var + 2*eps) * N / (N-1)`.

### Fix
```python
var = (
    tl.maximum(1 / (rstd * rstd) - eps, 0.0) * N / (N - 1)
)  # NOTE: use unbiased var to update running_var
```

### Verification
- Added `test_instance_norm_running_var_recovery` (eps in [0.1, 1.0] x 3 shapes covering all forward kernels) and `test_instance_norm_running_var_non_negative`.
- Full `tests/test_instance_norm.py` suite: 248 passed.
- Repro script diff reduced to exactly 0 after the fix.
- black/isort/flake8 clean.

### Progress
- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
No performance regression; the change is a single fused arithmetic fix inside the existing kernel.