### PR TITLE
test(alias_copy): extend alias_copy_out coverage for edge cases

### DIFF
--- a/tests/test_alias_copy.py
+++ b/tests/test_alias_copy.py
@@ -47,3 +47,39 @@ def test_alias_copy_out(shape, dtype):
 
     assert res_out is out
     utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.alias_copy_out
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_alias_copy_out_non_contiguous(dtype):
+    # Non-contiguous input views must be copied correctly into the out tensor
+    # (issue #4897 regression coverage).
+    base = torch.randn(6, 8, dtype=dtype, device=flag_gems.device)
+    inp = base.t()  # [8, 6] transposed view, not contiguous
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.empty_like(ref_inp)
+    out = torch.empty_like(inp)
+
+    torch.ops.aten.alias_copy(ref_inp, out=ref_out)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.alias_copy(inp, out=out)
+
+    assert res_out is out
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.alias_copy_out
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_alias_copy_out_empty(dtype):
+    # Empty inputs must be handled without launching the kernel.
+    inp = torch.empty(0, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.empty_like(ref_inp)
+    out = torch.empty_like(inp)
+
+    torch.ops.aten.alias_copy(ref_inp, out=ref_out)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.alias_copy(inp, out=out)
+
+    assert res_out is out
+    utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
Extend `alias_copy_out` test coverage with two edge cases previously missing: non-contiguous input views (`base.t()`) and empty tensors, both verified via `torch.ops.aten.alias_copy(inp, out=out)` that `res_out is out` and values match.

### Issue
- Closes #4897

### Verification
- `pytest tests/test_alias_copy.py`: all pass.
- black/isort/flake8 clean.

### Progress
- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.