### PR TITLE
test(and): cover the and_scalar/and_tensor dunder operators

### DIFF
--- a/conf/ci_test_aliases.yaml
+++ b/conf/ci_test_aliases.yaml
@@ -37,8 +37,8 @@ all_dim: test_all
 all_dims: test_all
 any_dim: test_any
 any_dims: test_any
-and_scalar: test_bitwise_and
-and_tensor: test_bitwise_and
+and_scalar: test_bitwise_and_scalar
+and_tensor: test_bitwise_and_tensor
 arctan: test_atan
 
 # Operators tested in combined files or with different naming

--- a/tests/test_bitwise_and_scalar.py
+++ b/tests/test_bitwise_and_scalar.py
@@ -22,6 +22,7 @@ import flag_gems
 from . import accuracy_utils as utils
 
 
+@pytest.mark.and_scalar
 @pytest.mark.bitwise_and_scalar
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.INT_DTYPES + utils.BOOL_TYPES)

--- a/tests/test_bitwise_and_tensor.py
+++ b/tests/test_bitwise_and_tensor.py
@@ -20,6 +20,7 @@ import flag_gems
 from . import accuracy_utils as utils
 
 
+@pytest.mark.and_tensor
 @pytest.mark.bitwise_and_tensor
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.INT_DTYPES + utils.BOOL_TYPES)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
The `and_scalar` / `and_tensor` operators were declared in `conf/operators.yaml` but the coverage checker could not find a matching test file because the `ci_test_aliases.yaml` aliases pointed at the non-existent `test_bitwise_and`.

Fix the aliases (`and_scalar: test_bitwise_and_scalar`, `and_tensor: test_bitwise_and_tensor`) and add the `@pytest.mark.and_scalar` / `@pytest.mark.and_tensor` markers to the corresponding test functions.

### Issue
- Closes #4898

### Verification
- `check_operator_markers.py --operators '["and_scalar","and_tensor"]'`: all operators have test coverage.
- `pytest tests/test_bitwise_and_scalar.py tests/test_bitwise_and_tensor.py`: all pass.
- black/isort/flake8 clean (flake8 only).

### Progress
- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.