### PR TITLE
fix(flash_kernel): defer autotune config binding to avoid KeyError: '…

### DIFF
--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -753,6 +753,55 @@ def flash_fwd_kernel(
         tl.store(p_lse + row_idx, lse, mask=row_idx < seqlen_q)
 
 
+
+
+_flash_fwd_configs_refreshed = False
+
+
+def _refresh_flash_fwd_configs():
+    global _flash_fwd_configs_refreshed
+    if _flash_fwd_configs_refreshed:
+        return
+    fn = flash_fwd_kernel
+    while not hasattr(fn, "configs"):
+        if not hasattr(fn, "fn"):
+            return
+        fn = fn.fn
+    good = list(filter(keep, runtime.get_tuned_config("attention")))
+    if good and len(good) > len(fn.configs):
+        fn.configs = good
+        cache = getattr(fn, "cache", None)
+        if isinstance(cache, dict):
+            cache.clear()
+    _flash_fwd_configs_refreshed = True
+
+
+class _FlashFwdLazy:
+    """Defer autotune-config binding to first call.
+
+    @triton.autotune captures runtime.get_tuned_config("attention") at import
+    time, before the vendor tuned-config table is fully populated, leaving a
+    single default config without BLOCK_M/BLOCK_N (KeyError: 'BLOCK_M'). Refresh
+    on first use, when the full table is available.
+    """
+
+    def __init__(self, kernel):
+        self._kernel = kernel
+
+    def __getitem__(self, grid):
+        _refresh_flash_fwd_configs()
+        return self._kernel[grid]
+
+    def __call__(self, *args, **kwargs):
+        _refresh_flash_fwd_configs()
+        return self._kernel(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._kernel, name)
+
+
+flash_fwd_kernel = _FlashFwdLazy(flash_fwd_kernel)
+
 @triton.jit(do_not_specialize=["seqlen_q", "seqlen_k"])
 def flash_fwd_bh_parallel_kernel():
     # (TODO)

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -753,8 +753,6 @@ def flash_fwd_kernel(
         tl.store(p_lse + row_idx, lse, mask=row_idx < seqlen_q)
 
 
-
-
 _flash_fwd_configs_refreshed = False
 
 
@@ -801,6 +799,7 @@ class _FlashFwdLazy:
 
 
 flash_fwd_kernel = _FlashFwdLazy(flash_fwd_kernel)
+
 
 @triton.jit(do_not_specialize=["seqlen_q", "seqlen_k"])
 def flash_fwd_bh_parallel_kernel():


### PR DESCRIPTION
…BLOCK_M'

The @triton.autotune decorator evaluates runtime.get_tuned_config("attention") at import time, before vendor-specific tuning tables are fully loaded. On Hygon DCU, this results in incomplete configs (36 instead of 84), and after filtering returns an empty list, leaving only a default config without BLOCK_M/BLOCK_N constexprs.

This commit wraps flash_fwd_kernel with a lazy proxy that refreshes configs on first call, when the full tuning table is available. Verified on Hygon BW1000 with vLLM 0.24.0 + vllm-plugin-FL 0.3.0-rc0.

Fixes KeyError: 'BLOCK_M' in flash attention SDPA on Hygon DCU.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
