### PR TITLE
fix(benchmark): isolate MM operator measurements

### DIFF
--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -95,6 +95,7 @@ class BenchConfig:
         self.shape_file = os.path.join(os.path.dirname(__file__), "core_shapes.yaml")
         self.query = False
         self.parallel = 0
+        self.mm_layout = None
 
 
 def pytest_addoption(parser):
@@ -207,6 +208,18 @@ def pytest_addoption(parser):
         ),
     )
 
+    parser.addoption(
+        "--mm-layout",
+        action="store",
+        default=None,
+        choices=["nn", "nt", "both"],
+        help=(
+            "Select the B layout for the MM benchmark: nn uses row-major B, "
+            "nt uses column-major B, and both runs both layouts. By default, "
+            "core runs nn while comprehensive runs both."
+        ),
+    )
+
     try:
         parser.addoption(
             "--collect-marks",
@@ -258,6 +271,7 @@ def pytest_configure(config):
     Config.record_json = config.getoption("--record") == "json"
 
     Config.parallel = int(config.getoption("--parallel") or 0)
+    Config.mm_layout = config.getoption("--mm-layout")
     if Config.record_json:
         Config.output = config.getoption("--output")
         REPORT_FILE = Config.output

--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -114,6 +114,25 @@ class BlasBenchmark(Benchmark):
         self.input_fn = input_fn
 
     def get_input_iter(self, cur_dtype) -> Generator:
+        if self.op_name == "mm" and Config.mm_layout is not None:
+            layouts = {
+                "nn": (False,),
+                "nt": (True,),
+                "both": (False, True),
+            }[Config.mm_layout]
+            for b_column_major in layouts:
+                for b, m, n, k in self.shapes:
+                    yield from self.input_fn(
+                        b,
+                        m,
+                        n,
+                        k,
+                        cur_dtype,
+                        self.device,
+                        b_column_major,
+                    )
+            return
+
         for b, m, n, k in self.shapes:
             yield from self.input_fn(b, m, n, k, cur_dtype, self.device, False)
 
@@ -550,11 +569,26 @@ def _parallel_device_count():
 
 
 def _parallel_visible_devices_env():
+    if flag_gems.vendor_name == "metax":
+        return "MACA_VISIBLE_DEVICES"
     env_name_map = {
         "cuda": "CUDA_VISIBLE_DEVICES",
         "musa": "MUSA_VISIBLE_DEVICES",
     }
     return env_name_map.get(flag_gems.device)
+
+
+def _parallel_device_ids():
+    visible_devices_env = _parallel_visible_devices_env()
+    if visible_devices_env:
+        configured_devices = os.environ.get(visible_devices_env, "")
+        if configured_devices:
+            return [
+                device.strip()
+                for device in configured_devices.split(",")
+                if device.strip()
+            ]
+    return [str(device) for device in range(_parallel_device_count())]
 
 
 def _parallel_device_label():
@@ -645,6 +679,11 @@ class ParallelBenchmarkMixin:
             else:
                 if self.op_name == "zero_":
                     with flag_gems.use_gems():
+                        metric.latency = self.get_latency(
+                            self.torch_op, *args, **kwargs
+                        )
+                elif self.op_name in ("mm", "mm_out"):
+                    with flag_gems.use_gems(include=[self.op_name]):
                         metric.latency = self.get_latency(
                             self.torch_op, *args, **kwargs
                         )
@@ -862,6 +901,8 @@ class ParallelBenchmarkMixin:
         if Config.user_desired_metrics:
             for metric in Config.user_desired_metrics:
                 cmd.extend(["--metrics", metric])
+        if Config.mm_layout is not None:
+            cmd.extend(["--mm-layout", Config.mm_layout])
 
         env = os.environ.copy()
         visible_devices_env = _parallel_visible_devices_env()
@@ -870,6 +911,11 @@ class ParallelBenchmarkMixin:
                 f"--parallel is not supported on device type '{flag_gems.device}'."
             )
         env[visible_devices_env] = str(gpu_id)
+        if flag_gems.vendor_name == "metax":
+            # mcPytorch prefers MACA_VISIBLE_DEVICES while vLLM-MetaX and some
+            # helper processes use CUDA_VISIBLE_DEVICES. Keep both consistent.
+            env["MACA_VISIBLE_DEVICES"] = str(gpu_id)
+            env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
         env[PARALLEL_WORKER_ENV] = "1"
         env[PARALLEL_RESULT_FILE_ENV] = tmp_result_path
 
@@ -899,7 +945,8 @@ class ParallelBenchmarkMixin:
             return self._run_inputs(self.get_input_iter(dtype))
         if not _parallel_device_is_available():
             pytest.skip(f"--parallel N requires {_parallel_device_label()}.")
-        available_gpus = _parallel_device_count()
+        device_ids = _parallel_device_ids()
+        available_gpus = min(_parallel_device_count(), len(device_ids))
         if available_gpus < required_gpus:
             pytest.skip(
                 "--parallel requires at least "
@@ -920,7 +967,7 @@ class ParallelBenchmarkMixin:
         merged_metrics = []
         future_to_chunk = {}
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(shape_chunks)) as ex:
-            for gpu_id, shape_chunk in enumerate(shape_chunks):
+            for gpu_id, shape_chunk in zip(device_ids, shape_chunks):
                 future = ex.submit(
                     self._run_parallel_worker_subprocess,
                     node_id=node_id,
@@ -1003,6 +1050,8 @@ class ParallelBenchmarkMixin:
 
 class ParallelBlasBenchmark(ParallelBenchmarkMixin, BlasBenchmark):
     def get_parallel_metric_group_size(self, shape):
+        if self.op_name == "mm" and Config.mm_layout is not None:
+            return 2 if Config.mm_layout == "both" else 1
         if Config.bench_level == BenchLevel.COMPREHENSIVE:
             return 2
         return 1


### PR DESCRIPTION
### PR Category

Benchmark

### Type of Change

Bug Fix

### Description

Improve MM benchmark isolation and layout control:

- Add `--mm-layout {nn,nt,both}` to explicitly select row-major or column-major B inputs.
- Forward the selected layout to parallel benchmark subprocesses.
- Restrict FlagGems activation to `mm`/`mm_out` while measuring MM, preventing unrelated operators such as `empty` and `zero_` from affecting latency.
- Respect MetaX visible-device assignments when distributing parallel benchmark workers.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
