### PR TITLE
[ARM] Add Triton W4A8-G128 linear API for CPU

### DIFF
--- a/src/flag_gems/quantized_linear.py
+++ b/src/flag_gems/quantized_linear.py
@@ -1,0 +1,22 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public quantized-linear APIs with backend-specific implementations."""
+
+from flag_gems.runtime.backend._arm.quantized_linear import (
+    pack_rhs_qsi4c128p,
+    w4a8_g128_linear,
+)
+
+__all__ = ["pack_rhs_qsi4c128p", "w4a8_g128_linear"]

--- a/src/flag_gems/runtime/backend/_arm/quantized_linear/__init__.py
+++ b/src/flag_gems/runtime/backend/_arm/quantized_linear/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ARM implementations for the public quantized-linear API."""
+
+from .api import pack_rhs_qsi4c128p, w4a8_g128_linear
+
+__all__ = ["pack_rhs_qsi4c128p", "w4a8_g128_linear"]

--- a/src/flag_gems/runtime/backend/_arm/quantized_linear/api.py
+++ b/src/flag_gems/runtime/backend/_arm/quantized_linear/api.py
@@ -1,0 +1,175 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public ARM W4A8-G128 packing and Triton execution helpers."""
+
+from __future__ import annotations
+
+import platform
+
+import torch
+
+from .q4_kernels import (
+    _pack_lhs_qai8dxp_asym_panel4_kernel,
+    _q4_fused_decode_asym_g128_kai_sdot_kernel,
+    _q4_prefill_asym_g128_i8mm_kernel,
+)
+
+_GROUP_SIZE = 128
+
+
+def pack_rhs_qsi4c128p(
+    quantized: torch.Tensor,
+    scales: torch.Tensor,
+) -> torch.Tensor:
+    """Pack signed INT4 G128 weights into the FlagGems N4/K128 ABI."""
+    if quantized.dtype != torch.int8 or quantized.ndim != 2:
+        raise ValueError("quantized weight must be an INT8 [N,K] tensor")
+    if quantized.device.type != "cpu" or scales.device != quantized.device:
+        raise ValueError("W4A8-G128 packing supports CPU tensors only")
+
+    n, k = quantized.shape
+    groups = k // _GROUP_SIZE
+    if n <= 0 or k <= 0 or n % 4 or k % _GROUP_SIZE:
+        raise ValueError("W4A8-G128 requires N%4=0 and K%128=0")
+    if scales.shape != (n, groups) or not scales.is_floating_point():
+        raise ValueError("invalid W4A8-G128 scale shape or dtype")
+    if not torch.isfinite(scales).all():
+        raise ValueError("W4A8-G128 scales must be finite")
+    if int(quantized.min()) < -8 or int(quantized.max()) > 7:
+        raise ValueError("W4 values must be in [-8,7]")
+
+    tile_stride = groups * 264 + 16
+    packed = torch.empty(
+        (n // 4, tile_stride), dtype=torch.uint8, device=quantized.device
+    )
+    packed_groups = packed[:, : groups * 264].reshape(n // 4, groups, 264)
+    scales_bf16 = scales.to(torch.bfloat16)
+    packed_groups[:, :, :8].view(torch.bfloat16).copy_(
+        scales_bf16.reshape(n // 4, 4, groups).permute(0, 2, 1).contiguous()
+    )
+
+    groups32 = k // 32
+    grouped32 = quantized.reshape(n, groups32, 32)
+    low = grouped32[:, :, :16].reshape(n, groups32, 2, 8).to(torch.int16) & 15
+    high = grouped32[:, :, 16:].reshape(n, groups32, 2, 8).to(torch.int16) & 15
+    packed32 = (
+        (low | (high << 4))
+        .to(torch.uint8)
+        .reshape(n // 4, 4, groups32, 2, 8)
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+        .reshape(n // 4, groups32, 64)
+    )
+    packed_groups[:, :, 8:264].copy_(
+        packed32.reshape(n // 4, groups, 4, 64).reshape(n // 4, groups, 256)
+    )
+
+    scaled_sums = (
+        quantized.reshape(n, groups, _GROUP_SIZE).to(torch.int16).sum(dim=-1) * 16
+    )
+    weighted_sums = (scaled_sums.to(torch.float32) * scales_bf16.to(torch.float32)).sum(
+        dim=1
+    )
+    packed[:, groups * 264 :].view(torch.float32).copy_(
+        weighted_sums.reshape(n // 4, 4)
+    )
+    return packed.reshape(-1).contiguous()
+
+
+def _validate_linear_inputs(
+    input: torch.Tensor,
+    packed_weight: torch.Tensor,
+    n: int,
+    k: int,
+) -> None:
+    if platform.machine().lower() not in {"arm64", "aarch64"}:
+        raise RuntimeError("W4A8-G128 requires an AArch64 host")
+    if input.device.type != "cpu" or packed_weight.device.type != "cpu":
+        raise ValueError("W4A8-G128 supports CPU tensors only")
+    if input.dtype != torch.bfloat16 or not input.is_contiguous():
+        raise ValueError("W4A8-G128 requires contiguous BF16 input")
+    if packed_weight.dtype != torch.uint8 or not packed_weight.is_contiguous():
+        raise ValueError("W4A8-G128 requires a contiguous UINT8 packed weight")
+    if input.ndim == 0 or input.numel() == 0 or input.shape[-1] != k:
+        raise ValueError("invalid W4A8-G128 input shape")
+    if n <= 0 or k <= 0 or n % 4 or k % _GROUP_SIZE:
+        raise ValueError("W4A8-G128 requires N%4=0 and K%128=0")
+    expected = (n // 4) * ((k // _GROUP_SIZE) * 264 + 16)
+    if packed_weight.numel() != expected:
+        raise ValueError("invalid W4A8-G128 packed byte count")
+
+
+def w4a8_g128_linear(
+    input: torch.Tensor,
+    packed_weight: torch.Tensor,
+    n: int,
+    k: int,
+) -> torch.Tensor:
+    """Execute a packed W4A8-G128 linear layer with ARM Triton kernels."""
+    _validate_linear_inputs(input, packed_weight, n, k)
+    original_shape = tuple(input.shape)
+    rows = input.numel() // k
+    input_2d = input.view(rows, k)
+
+    if rows < 4:
+        partitions = min(max(1, torch.get_num_threads()), n // 4)
+        scratch_bytes = rows * partitions * (8 + k)
+        output_bytes = rows * n * torch.bfloat16.itemsize
+        storage = torch.empty(
+            (scratch_bytes + output_bytes) // torch.bfloat16.itemsize,
+            dtype=torch.bfloat16,
+            device=input.device,
+        )
+        output = storage.as_strided((rows, n), (n, 1), scratch_bytes // 2)
+        _q4_fused_decode_asym_g128_kai_sdot_kernel[(rows, partitions)](
+            input_2d,
+            storage,
+            packed_weight,
+            scratch_bytes,
+            k,
+            K=k,
+            N=n,
+        )
+    else:
+        padded_rows = 4 * ((rows + 3) // 4)
+        lhs_panel_stride = 32 + 4 * k
+        lhs = torch.empty(
+            (padded_rows // 4) * lhs_panel_stride,
+            dtype=torch.uint8,
+            device=input.device,
+        )
+        output_padded = torch.empty(
+            (padded_rows, n), dtype=torch.bfloat16, device=input.device
+        )
+        _pack_lhs_qai8dxp_asym_panel4_kernel[(padded_rows // 4,)](
+            input_2d,
+            lhs,
+            rows,
+            k,
+            K=k,
+        )
+        _q4_prefill_asym_g128_i8mm_kernel[(padded_rows // 4, n // 4)](
+            lhs,
+            packed_weight,
+            output_padded,
+            N=n,
+            K=k,
+        )
+        output = output_padded[:rows]
+
+    return output.view(*original_shape[:-1], n)
+
+
+__all__ = ["pack_rhs_qsi4c128p", "w4a8_g128_linear"]

--- a/src/flag_gems/runtime/backend/_arm/quantized_linear/q4_kernels.py
+++ b/src/flag_gems/runtime/backend/_arm/quantized_linear/q4_kernels.py
@@ -1,0 +1,413 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Baseline ARM Triton kernels for packed W4A8-G128 linear layers."""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def _round_to_nearest_even(value):
+    """Standard RNE; LLVM selects the target's native rounding instruction."""
+    return libdevice.rint(value)
+
+
+@triton.jit
+def _round_away_from_zero(value):
+    """Match KAI/AArch64 ties-away rounding as a compiler-visible math op."""
+    return libdevice.round(value.to(tl.float32)).to(tl.int32)
+
+
+@triton.jit
+def _quantize_kai_asymmetric_i8(values, quant_multiplier, zero_point):
+    rounded = _round_away_from_zero(values.to(tl.float32) * quant_multiplier)
+    shifted = rounded + zero_point.to(tl.int32)
+    return tl.minimum(tl.maximum(shifted, -128), 127).to(tl.int8)
+
+
+@triton.jit
+def _q4_kai_asymmetric_qparams_from_minmax(row_min, row_max):
+    """KleidiAI ``qai8dxp_f32`` row quantization parameters."""
+    row_min = tl.minimum(row_min, 0.0)
+    row_max = tl.maximum(row_max, 0.0)
+    value_range = row_max - row_min
+    quant_multiplier = tl.where(value_range == 0.0, 1.0, 255.0 / value_range)
+    dequant_scale = tl.where(quant_multiplier == 0.0, 0.0, 1.0 / quant_multiplier)
+    descaled_min = row_min * quant_multiplier
+    descaled_max = row_max * quant_multiplier
+    choose_min = -128.0 + descaled_min + 127.0 + descaled_max > 0.0
+    zero_point = tl.where(choose_min, -128.0 - descaled_min, 127.0 - descaled_max)
+    zero_point = tl.minimum(tl.maximum(zero_point, -128.0), 127.0)
+    zero_point = _round_to_nearest_even(zero_point).to(tl.int8)
+    return dequant_scale, quant_multiplier, zero_point
+
+
+@triton.jit
+def _q4_token_asymmetric_qparams_kai_f32(x_base, K: tl.constexpr):
+    lanes = tl.arange(0, 16)
+    row_min = tl.full((1,), 3.4028234663852886e38, tl.float32)
+    row_max = tl.full((1,), -3.4028234663852886e38, tl.float32)
+    for start in tl.range(0, K, 16, loop_unroll_factor=1):
+        values = tl.load(x_base + start + lanes).to(tl.float32)
+        row_min = tl.minimum(row_min, tl.min(values, axis=0))
+        row_max = tl.maximum(row_max, tl.max(values, axis=0))
+    return _q4_kai_asymmetric_qparams_from_minmax(row_min, row_max)
+
+
+@triton.jit
+def _q4_store_token_asymmetric_k32_kai(data_base, x_base, quant_multiplier, zero_point):
+    lanes = tl.arange(0, 8)
+    quant0 = _quantize_kai_asymmetric_i8(
+        tl.load(x_base + lanes), quant_multiplier, zero_point
+    )
+    quant1 = _quantize_kai_asymmetric_i8(
+        tl.load(x_base + 8 + lanes), quant_multiplier, zero_point
+    )
+    quant2 = _quantize_kai_asymmetric_i8(
+        tl.load(x_base + 16 + lanes), quant_multiplier, zero_point
+    )
+    quant3 = _quantize_kai_asymmetric_i8(
+        tl.load(x_base + 24 + lanes), quant_multiplier, zero_point
+    )
+    quant01 = tl.join(quant0, quant1).permute(1, 0).reshape((16,))
+    quant23 = tl.join(quant2, quant3).permute(1, 0).reshape((16,))
+    quantized = tl.join(quant01, quant23).permute(1, 0).reshape((32,))
+    tl.store(data_base + tl.arange(0, 32), quantized)
+
+
+@triton.jit
+def _q4_decode_asym_g128_k32_lhs(lhs_data_ptr):
+    """Load/rearrange one K32 activation once for one or more N4 tiles."""
+    x_lanes = tl.arange(0, 8)
+    x0 = tl.load(lhs_data_ptr + x_lanes).to(tl.int8).reshape((2, 4))
+    x1 = tl.load(lhs_data_ptr + 8 + x_lanes).to(tl.int8).reshape((2, 4))
+    x2 = tl.load(lhs_data_ptr + 16 + x_lanes).to(tl.int8).reshape((2, 4))
+    x3 = tl.load(lhs_data_ptr + 24 + x_lanes).to(tl.int8).reshape((2, 4))
+    x0 = tl.join(x0.reshape((8,)), x0.reshape((8,))).permute(1, 0).reshape((4, 4))
+    x1 = tl.join(x1.reshape((8,)), x1.reshape((8,))).permute(1, 0).reshape((4, 4))
+    x2 = tl.join(x2.reshape((8,)), x2.reshape((8,))).permute(1, 0).reshape((4, 4))
+    x3 = tl.join(x3.reshape((8,)), x3.reshape((8,))).permute(1, 0).reshape((4, 4))
+    return x0, x1, x2, x3
+
+
+@triton.jit
+def _q4_decode_asym_g128_k32_rhs_dot(rhs_data_ptr, x0, x1, x2, x3):
+    """One compiler-visible packed-Q4 SDOT body with a reusable LHS."""
+    q_lanes = tl.arange(0, 16)
+    q0 = tl.load(rhs_data_ptr + q_lanes)
+    q1 = tl.load(rhs_data_ptr + 16 + q_lanes)
+    q2 = tl.load(rhs_data_ptr + 32 + q_lanes)
+    q3 = tl.load(rhs_data_ptr + 48 + q_lanes)
+    q0_low = (q0 << 4).to(tl.int8).reshape((4, 4))
+    q1_low = (q1 << 4).to(tl.int8).reshape((4, 4))
+    q2_low = (q2 << 4).to(tl.int8).reshape((4, 4))
+    q3_low = (q3 << 4).to(tl.int8).reshape((4, 4))
+    q0_high = (q0 & 0xF0).to(tl.int8).reshape((4, 4))
+    q1_high = (q1 & 0xF0).to(tl.int8).reshape((4, 4))
+    q2_high = (q2 & 0xF0).to(tl.int8).reshape((4, 4))
+    q3_high = (q3 & 0xF0).to(tl.int8).reshape((4, 4))
+
+    partial01 = tl.sum(q0_low.to(tl.int32) * x0.to(tl.int32), axis=1)
+    partial23 = tl.sum(q1_low.to(tl.int32) * x0.to(tl.int32), axis=1)
+    partial01 += tl.sum(q2_low.to(tl.int32) * x1.to(tl.int32), axis=1)
+    partial23 += tl.sum(q3_low.to(tl.int32) * x1.to(tl.int32), axis=1)
+    partial01 += tl.sum(q0_high.to(tl.int32) * x2.to(tl.int32), axis=1)
+    partial23 += tl.sum(q1_high.to(tl.int32) * x2.to(tl.int32), axis=1)
+    partial01 += tl.sum(q2_high.to(tl.int32) * x3.to(tl.int32), axis=1)
+    partial23 += tl.sum(q3_high.to(tl.int32) * x3.to(tl.int32), axis=1)
+    partial = tl.join(partial01, partial23).permute(1, 0).reshape((4, 2))
+    return tl.sum(partial, axis=1)
+
+
+@triton.jit
+def _q4_decode_asym_g128_k32_dot(lhs_data_ptr, rhs_data_ptr):
+    x0, x1, x2, x3 = _q4_decode_asym_g128_k32_lhs(lhs_data_ptr)
+    return _q4_decode_asym_g128_k32_rhs_dot(rhs_data_ptr, x0, x1, x2, x3)
+
+
+@triton.jit
+def _q4_decode_asym_g128_sdot_kernel(
+    lhs_packed_ptr,
+    rhs_packed_ptr,
+    out_ptr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+):
+    """G128 Q4 decode for partitioned, compact KleidiAI-style activations."""
+    row = tl.program_id(0)
+    partition = tl.program_id(1)
+    partitions = tl.num_programs(1)
+    tile_count: tl.constexpr = N // 4
+    tiles_per_partition = (tile_count + partitions - 1) // partitions
+    local_begin = partition * tiles_per_partition
+    local_end = tl.minimum(tile_count, local_begin + tiles_per_partition)
+    groups128: tl.constexpr = K // 128
+    rhs_group_stride: tl.constexpr = 264
+    rhs_tile_stride: tl.constexpr = groups128 * rhs_group_stride + 16
+    output_lanes = tl.arange(0, 4)
+    lhs_packed_ptr = lhs_packed_ptr.to(tl.pointer_type(tl.uint8))
+
+    lhs_row_ptr = lhs_packed_ptr + (row * partitions + partition) * (8 + K)
+    lhs_scale = tl.load(lhs_row_ptr.to(tl.pointer_type(tl.float32)))
+    zero_point = tl.load(lhs_row_ptr + 4).to(tl.int8).to(tl.int32)
+
+    for tile in range(local_begin, local_end):
+        result = tl.zeros((4,), dtype=tl.float32)
+        rhs_tile_ptr = rhs_packed_ptr + tile * rhs_tile_stride
+        rhs_group_ptr = rhs_tile_ptr
+        lhs_group_ptr = lhs_row_ptr + 8
+        for group in tl.range(0, groups128, loop_unroll_factor=1):
+            rhs_scale = tl.load(
+                rhs_group_ptr.to(tl.pointer_type(tl.bfloat16)) + output_lanes
+            ).to(tl.float32)
+            dot_scaled16 = tl.zeros((4,), dtype=tl.int32)
+            for subgroup in tl.range(0, 4, loop_unroll_factor=1):
+                lhs_data_ptr = lhs_group_ptr + subgroup * 32
+                dot_scaled16 += _q4_decode_asym_g128_k32_dot(
+                    lhs_data_ptr,
+                    rhs_group_ptr + 8 + subgroup * 64,
+                )
+            result += dot_scaled16.to(tl.float32) * rhs_scale
+            lhs_group_ptr += 128
+            rhs_group_ptr += rhs_group_stride
+
+        weighted_sum_scaled16 = tl.load(
+            (rhs_tile_ptr + groups128 * rhs_group_stride).to(
+                tl.pointer_type(tl.float32)
+            )
+            + output_lanes
+        )
+        result -= zero_point.to(tl.float32) * weighted_sum_scaled16
+        result *= lhs_scale * (1.0 / 16.0)
+
+        output_offsets = row * N + tile * 4 + output_lanes
+        tl.store(out_ptr + output_offsets, result.to(tl.bfloat16))
+
+
+@triton.jit
+def _q4_fused_decode_asym_g128_kai_sdot_kernel(
+    x_ptr,
+    workspace_ptr,
+    rhs_packed_ptr,
+    output_byte_offset,
+    stride_xm,
+    K: tl.constexpr,
+    N: tl.constexpr,
+):
+    """KleidiAI-compatible FP32 activation pack plus Triton G128 GEMV."""
+    row = tl.program_id(0)
+    partition = tl.program_id(1)
+    partitions = tl.num_programs(1)
+    workspace_bytes = workspace_ptr.to(tl.pointer_type(tl.uint8))
+    groups32: tl.constexpr = K // 32
+    lhs_row_stride: tl.constexpr = 8 + K
+    source_row = x_ptr + row * stride_xm
+    scale, quant_multiplier, zero_point = _q4_token_asymmetric_qparams_kai_f32(
+        source_row, K=K
+    )
+    scratch_base = (row * partitions + partition) * lhs_row_stride
+    scratch_row = workspace_bytes + scratch_base
+    tl.store(
+        scratch_row.to(tl.pointer_type(tl.float32)) + tl.arange(0, 1),
+        scale,
+    )
+    tl.store(scratch_row + 4 + tl.arange(0, 1), zero_point)
+    for group in tl.range(0, groups32, loop_unroll_factor=1):
+        _q4_store_token_asymmetric_k32_kai(
+            scratch_row + 8 + group * 32,
+            source_row + group * 32,
+            quant_multiplier,
+            zero_point,
+        )
+    out_ptr = (workspace_bytes + output_byte_offset).to(tl.pointer_type(tl.bfloat16))
+    _q4_decode_asym_g128_sdot_kernel(
+        workspace_bytes,
+        rhs_packed_ptr,
+        out_ptr,
+        K=K,
+        N=N,
+    )
+
+
+@triton.jit
+def _pack_lhs_qai8dxp_asym_panel4_kernel(
+    x_ptr,
+    lhs_packed_ptr,
+    M,
+    stride_xm,
+    K: tl.constexpr,
+):
+    """Panel4 pack with KleidiAI's FP32 asymmetric activation semantics."""
+    panel = tl.program_id(0)
+    rows = panel * 4 + tl.arange(0, 4)
+    source_rows = tl.minimum(rows, M - 1)
+    lanes16 = tl.arange(0, 16)
+    row_min = tl.full((4,), 3.4028234663852886e38, tl.float32)
+    row_max = tl.full((4,), -3.4028234663852886e38, tl.float32)
+    for start in tl.range(0, K, 16, loop_unroll_factor=1):
+        values = tl.load(
+            x_ptr + source_rows[:, None] * stride_xm + start + lanes16[None, :]
+        ).to(tl.float32)
+        row_min = tl.minimum(row_min, tl.min(values, axis=1))
+        row_max = tl.maximum(row_max, tl.max(values, axis=1))
+    scales, multipliers, zero_points = _q4_kai_asymmetric_qparams_from_minmax(
+        row_min, row_max
+    )
+    panel_stride: tl.constexpr = 32 + 4 * K
+    panel_base = lhs_packed_ptr + panel * panel_stride
+    tl.store(
+        panel_base.to(tl.pointer_type(tl.float32)) + tl.arange(0, 4),
+        scales,
+    )
+    tl.store(panel_base + 16 + tl.arange(0, 4), zero_points)
+
+    lanes8 = tl.arange(0, 8)
+    store_lanes = tl.arange(0, 32)
+    groups32: tl.constexpr = K // 32
+    data_base = panel_base + 32
+    for group in tl.range(0, groups32, loop_unroll_factor=1):
+        for offset in tl.static_range(0, 32, 8):
+            values = tl.load(
+                x_ptr
+                + source_rows[:, None] * stride_xm
+                + group * 32
+                + offset
+                + lanes8[None, :]
+            )
+            quantized = _quantize_kai_asymmetric_i8(
+                values,
+                multipliers[:, None],
+                zero_points[:, None],
+            )
+            tl.store(
+                data_base + group * 128 + offset * 4 + store_lanes,
+                quantized.reshape((32,)),
+            )
+
+
+@triton.jit
+def _q4_load_g128_k32_i8mm_weight(rhs_data_ptr):
+    """Unpack one K32 slice while preserving the I8MM lowering algebra."""
+    block_n: tl.constexpr = 4
+    packed_flat = tl.load(rhs_data_ptr + tl.arange(0, 64))
+    packed = (
+        packed_flat.reshape((2, block_n, 8)).permute(0, 2, 1).reshape((16, block_n))
+    )
+    weight_low = (packed << 4).to(tl.int8)
+    weight_high = (packed & 0xF0).to(tl.int8)
+    return tl.join(weight_low, weight_high).permute(0, 2, 1).reshape((32, block_n))
+
+
+@triton.jit
+def _q4_load_g128_k32_i8mm_lhs(lhs_blob):
+    """Load one panel4 K32 slice in the layout recognized by the dot pass."""
+    lhs_seq = (
+        tl.load(lhs_blob + tl.arange(0, 128))
+        .to(tl.int8)
+        .reshape((4, 4, 8))
+        .permute(1, 0, 2)
+        .reshape((4, 32))
+    )
+    return lhs_seq.reshape((4, 2, 16)).permute(0, 2, 1).reshape((4, 32))
+
+
+@triton.jit
+def _q4_prefill_asym_g128_i8mm_tile(
+    lhs_packed_ptr,
+    rhs_packed_ptr,
+    out_ptr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    GROUPS128_RUNTIME,
+    PID_M_OVERRIDE: tl.constexpr,
+    PID_N_OVERRIDE: tl.constexpr,
+):
+    """G128 Q4 M4 prefill: four K32 SMMLA bodies per scale/correction."""
+    pid_m = PID_M_OVERRIDE
+    pid_n = PID_N_OVERRIDE
+    block_n: tl.constexpr = 4
+    groups128: tl.constexpr = K // 128
+    cols = pid_n * block_n + tl.arange(0, block_n)
+    lanes_m4 = tl.arange(0, 4)
+    result0 = tl.zeros((4, block_n), tl.float32)
+    lhs_panel_stride: tl.constexpr = 32 + 4 * K
+    lhs_data_offset: tl.constexpr = 32
+    lhs_zp_offset: tl.constexpr = 16
+    lhs_row_base = lhs_packed_ptr + pid_m * lhs_panel_stride
+
+    rhs_tile_stride: tl.constexpr = groups128 * 264 + 16
+    rhs_tile_ptr = rhs_packed_ptr + pid_n * rhs_tile_stride
+
+    # Keep the G128 reduction as tl.range rather than static_range.  The CPU
+    # backend can then preserve a compact loop at production K sizes instead
+    # of cloning the full M16 microkernel and spilling its accumulators.
+    for group128 in tl.range(0, GROUPS128_RUNTIME, loop_unroll_factor=1):
+        rhs_blob = rhs_tile_ptr + group128 * 264
+        rhs_scale = tl.load(
+            rhs_blob.to(tl.pointer_type(tl.bfloat16)) + tl.arange(0, 4)
+        ).to(tl.float32)
+        dot0 = tl.zeros((4, block_n), dtype=tl.int32)
+        for subgroup in tl.range(0, 4, loop_unroll_factor=1):
+            group32 = group128 * 4 + subgroup
+            weight = _q4_load_g128_k32_i8mm_weight(rhs_blob + 8 + subgroup * 64)
+            lhs0_blob = lhs_row_base + lhs_data_offset + group32 * 128
+            dot0 += tl.dot(
+                _q4_load_g128_k32_i8mm_lhs(lhs0_blob),
+                weight,
+                out_dtype=tl.int32,
+            )
+
+        result0 += dot0.to(tl.float32) * rhs_scale[None, :]
+
+    # Correction values do not participate in the I8MM loop, so load them after
+    # the accumulator reduction to keep the loop's live range compact.
+    scale0 = tl.load(lhs_row_base.to(tl.pointer_type(tl.float32)) + lanes_m4)
+    zp0 = tl.load(lhs_row_base + lhs_zp_offset + lanes_m4).to(tl.int8).to(tl.int32)
+
+    weighted_sum_scaled16 = tl.load(
+        (rhs_tile_ptr + groups128 * 264).to(tl.pointer_type(tl.float32))
+        + tl.arange(0, 4)
+    )
+    result0 -= zp0[:, None].to(tl.float32) * weighted_sum_scaled16[None, :]
+    result0 *= scale0[:, None] * (1.0 / 16.0)
+
+    output_row = pid_m * 4
+    tl.store(
+        out_ptr + (output_row + lanes_m4)[:, None] * N + cols[None, :],
+        result0.to(tl.bfloat16),
+    )
+
+
+@triton.jit
+def _q4_prefill_asym_g128_i8mm_kernel(
+    lhs_packed_ptr,
+    rhs_packed_ptr,
+    out_ptr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+):
+    _q4_prefill_asym_g128_i8mm_tile(
+        lhs_packed_ptr,
+        rhs_packed_ptr,
+        out_ptr,
+        N=N,
+        K=K,
+        GROUPS128_RUNTIME=K // 128,
+        PID_M_OVERRIDE=tl.program_id(0),
+        PID_N_OVERRIDE=tl.program_id(1),
+    )

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -21,6 +21,8 @@ import logging
 import math
 import multiprocessing
 import os
+import sys
+import threading
 import time
 import warnings
 from abc import abstractmethod
@@ -1557,7 +1559,13 @@ class LibEntry(triton.KernelInterface):
             for p in self.jit_function.params
             if not p.is_constexpr and p.do_not_specialize
         ]
-        self.lock = multiprocessing.Lock()
+        if sys.platform == "darwin":
+            # A process-shared semaphore consumes one file descriptor per
+            # decorated kernel and can exhaust macOS's low default limit. The
+            # cache is process-local, so only threads need serialization here.
+            self.lock = threading.Lock()
+        else:
+            self.lock = multiprocessing.Lock()
         self.signature = fn.signature
 
     @staticmethod

--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -1284,6 +1284,11 @@ def _patch_missing_symbols(module, names):
     for name in names:
         if hasattr(module, name):
             continue
+        # Some CPU libdevice implementations expose rint but omit nearbyint.
+        # FlagGems only needs their shared round-to-nearest-even value semantics.
+        if name == "nearbyint" and hasattr(module, "rint"):
+            setattr(module, name, module.rint)
+            continue
         # Prefer the pure-triton fallback over borrowing from another backend's
         # libdevice.  This loop only runs for symbols the vendor's own libdevice
         # lacks, so a candidate match necessarily comes from a *foreign* module
@@ -1332,6 +1337,7 @@ tl_extra_shim = _patch_missing_symbols(
         "lgamma",
         "log",
         "log2",
+        "nearbyint",
         "nextafter",
         "normcdfinv",
         "pow",

--- a/tests/test_arm_w4a8_g128.py
+++ b/tests/test_arm_w4a8_g128.py
@@ -1,0 +1,123 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import platform
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.quantized_linear import pack_rhs_qsi4c128p, w4a8_g128_linear
+
+_ARM_CPU_BACKEND_ACTIVE = (
+    platform.machine().lower() in {"arm64", "aarch64"}
+    and flag_gems.vendor_name == "arm"
+    and flag_gems.device == "cpu"
+)
+
+
+def _asymmetric_a8_reference(input: torch.Tensor):
+    values = input.to(torch.float32)
+    zeros = torch.zeros(values.shape[0], dtype=torch.float32)
+    row_min = torch.minimum(values.amin(dim=1), zeros)
+    row_max = torch.maximum(values.amax(dim=1), zeros)
+    value_range = row_max - row_min
+    multiplier = torch.where(value_range == 0, 1.0, 255.0 / value_range)
+    scale = 1.0 / multiplier
+    descaled_min = row_min * multiplier
+    descaled_max = row_max * multiplier
+    choose_min = -128.0 + descaled_min + 127.0 + descaled_max > 0.0
+    zero_point = torch.where(choose_min, -128.0 - descaled_min, 127.0 - descaled_max)
+    zero_point = torch.round(zero_point.clamp(-128.0, 127.0)).to(torch.int32)
+    scaled = values * multiplier[:, None]
+    rounded = torch.sign(scaled) * torch.floor(torch.abs(scaled) + 0.5)
+    quantized = (rounded.to(torch.int32) + zero_point[:, None]).clamp(-128, 127)
+    return quantized, scale, zero_point
+
+
+def _reference(input, weight, weight_scale):
+    quantized, input_scale, zero_point = _asymmetric_a8_reference(input)
+    m, k = quantized.shape
+    n = weight.shape[0]
+    groups = k // 128
+    centered = quantized - zero_point[:, None]
+    accumulator = torch.einsum(
+        "mgk,ngk->mng",
+        centered.reshape(m, groups, 128).to(torch.float32),
+        weight.reshape(n, groups, 128).to(torch.float32),
+    )
+    scales = weight_scale.to(torch.bfloat16).to(torch.float32)
+    return ((accumulator * scales[None, :, :]).sum(dim=-1) * input_scale[:, None]).to(
+        torch.bfloat16
+    )
+
+
+@pytest.mark.skipif(
+    not _ARM_CPU_BACKEND_ACTIVE,
+    reason="requires an AArch64 Triton CPU backend",
+)
+@pytest.mark.parametrize(
+    ("m", "n", "k"),
+    [(1, 64, 128), (5, 64, 128), (8, 64, 128), (1, 96, 5120), (8, 64, 5120)],
+)
+def test_w4a8_g128_matches_reference(m, n, k):
+    torch.manual_seed(1000 + m + n + k)
+    input = (0.4 * torch.randn((m, k), dtype=torch.bfloat16)).contiguous()
+    weight = torch.randint(-8, 8, (n, k), dtype=torch.int8)
+    scales = 0.001 + 0.02 * torch.rand((n, k // 128))
+    packed = pack_rhs_qsi4c128p(weight, scales)
+
+    output = w4a8_g128_linear(input, packed, n, k)
+
+    assert output.shape == (m, n)
+    assert output.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        output, _reference(input, weight, scales), rtol=0.02, atol=0.125
+    )
+
+
+def test_w4a8_g128_packer_rejects_invalid_contracts():
+    weight = torch.zeros((4, 128), dtype=torch.int8)
+    scales = torch.ones((4, 1), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="INT8"):
+        pack_rhs_qsi4c128p(weight.to(torch.int16), scales)
+    with pytest.raises(ValueError, match="scale shape"):
+        pack_rhs_qsi4c128p(weight, torch.ones((4, 2)))
+    invalid_weight = weight.clone()
+    invalid_weight[0, 0] = -9
+    with pytest.raises(ValueError, match=r"\[-8,7\]"):
+        pack_rhs_qsi4c128p(invalid_weight, scales)
+    invalid_scale = scales.clone()
+    invalid_scale[0, 0] = torch.inf
+    with pytest.raises(ValueError, match="finite"):
+        pack_rhs_qsi4c128p(weight, invalid_scale)
+
+
+@pytest.mark.skipif(
+    not _ARM_CPU_BACKEND_ACTIVE,
+    reason="requires an AArch64 Triton CPU backend",
+)
+def test_w4a8_g128_decode_is_repeatable():
+    torch.manual_seed(43)
+    n, k = 64, 128
+    input = torch.randn((1, k), dtype=torch.bfloat16)
+    weight = torch.randint(-8, 8, (n, k), dtype=torch.int8)
+    scales = torch.rand((n, 1), dtype=torch.float32)
+    packed = pack_rhs_qsi4c128p(weight, scales)
+
+    first = w4a8_g128_linear(input, packed, n, k)
+    second = w4a8_g128_linear(input, packed, n, k)
+
+    torch.testing.assert_close(second, first, rtol=0, atol=0)

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -18,6 +18,7 @@ import multiprocessing
 import os
 import signal
 import sqlite3
+import sys
 import threading
 import time
 from contextlib import contextmanager
@@ -58,6 +59,14 @@ def assume_flagtune_platform_package_is_available(monkeypatch):
         "_platform_cost_model_available",
         lambda: True,
     )
+
+
+def test_libentry_uses_platform_appropriate_lock():
+    if sys.platform == "darwin":
+        expected_lock_type = type(threading.Lock())
+    else:
+        expected_lock_type = type(multiprocessing.Lock())
+    assert type(softmax_kernel_inner.lock) is expected_lock_type
 
 
 # not_raises is copied from https://gist.github.com/oisinmulvihill/45c14271fad7794a4a52516ecb784e69

--- a/tests/test_triton_lang_helper.py
+++ b/tests/test_triton_lang_helper.py
@@ -1,0 +1,26 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from flag_gems.utils import triton_lang_helper
+
+
+def test_patch_missing_nearbyint_uses_rint():
+    rint = object()
+    module = SimpleNamespace(rint=rint)
+
+    patched = triton_lang_helper._patch_missing_symbols(module, ("nearbyint",))
+
+    assert patched.nearbyint is rint

--- a/tools/ci_checks/check_kernelgen_tests.py
+++ b/tools/ci_checks/check_kernelgen_tests.py
@@ -36,7 +36,6 @@ from pathlib import Path
 TESTS_DIR = Path("tests")
 
 
-
 def find_use_gems_calls(filepath: Path) -> list[tuple[int, str]]:
     """Find use_gems() calls in a Python file using AST.
 
@@ -104,10 +103,7 @@ def main():
             changed = json.loads(args.changed_files)
         except json.JSONDecodeError:
             changed = [f.strip() for f in args.changed_files.split(",") if f.strip()]
-        test_files = [
-            Path(f) for f in changed
-            if re.match(r"tests/test_.+\.py$", f)
-        ]
+        test_files = [Path(f) for f in changed if re.match(r"tests/test_.+\.py$", f)]
     elif args.operators:
         try:
             requested_ops = json.loads(args.operators)
@@ -115,11 +111,11 @@ def main():
             requested_ops = [
                 op.strip() for op in args.operators.split(",") if op.strip()
             ]
-        test_files = [
-            TESTS_DIR / f"test_{op_id}.py" for op_id in requested_ops
-        ]
+        test_files = [TESTS_DIR / f"test_{op_id}.py" for op_id in requested_ops]
     else:
-        print("No operators or files specified. Use --operators, --changed-files, or --all.")
+        print(
+            "No operators or files specified. Use --operators, --changed-files, or --all."
+        )
         sys.exit(0)
 
     # Filter to files that actually exist


### PR DESCRIPTION
  ## Summary

  This PR adds a minimal ARM CPU W4A8-G128 linear implementation based on FlagTree-cpu
  It provides a vLLM-independent API for:
  - Packing symmetric INT4 group-wise weights into the ARM N4/K128 layout.
  - Dynamically quantizing activations to INT8 per token.
  - Executing W4A8-G128 linear layers on AArch64 CPUs.
  - Using separate Triton paths for decode and prefill workloads.

  The public entry points are:

  ```python
  from flag_gems.quantized_linear import (
      pack_rhs_qsi4c128p,
      w4a8_g128_linear,
  )
```

  This PR does not contain vLLM registration, model-specific checkpoint handling, W8A8 support, C++ dispatch code, or a native extension.

  ## Implementation

  ### Weight packing

  pack_rhs_qsi4c128p() accepts:

  - Signed INT4 values represented as an INT8 [N, K] tensor.
  - Per-group floating-point scales with shape [N, K / 128].
  - Symmetric W4 quantization.
  - N % 4 == 0 and K % 128 == 0.

  It produces a contiguous packed buffer consumed directly by the Triton kernels.

  ### Decode

  For fewer than four input rows, the implementation:

  - Dynamically quantizes each activation row to INT8.
  - Uses per-token asymmetric quantization compatible with the PyTorch/KleidiAI ARM dynamic-4bit path.
  - Partitions output-channel tiles across CPU workers.
  - Executes the packed W4A8 dot product through the ARM Triton lowering path.

  ### Prefill

  For four or more rows, the implementation:

  - Packs activations into M4 panels.
  - Pads the row count to a multiple of four when necessary.
  - Uses an M4 Triton dot-product kernel for the W4A8 computation.
  - Slices padded rows from the returned result.

  ## ARM CPU compatibility fixes

  Two small compatibility fixes are required before the new API can be used on macOS ARM64.

  ### CPU libdevice

  The Triton CPU libdevice provides rint but may not provide nearbyint. FlagGems evaluates existing Triton function dependencies during package import, so the missing
  symbol prevents import flag_gems.

  This PR maps nearbyint to rint when only rint is available. Both provide round-to-nearest-even value semantics for this use case.

  ### macOS kernel locks

  LibEntry previously created a process-shared multiprocessing.Lock for every decorated kernel. On macOS, each lock consumes a file descriptor, and importing FlagGems
  can exceed the default descriptor limit.

  The cache protected by this lock is process-local, so macOS now uses threading.Lock. Other platforms retain the existing multiprocessing.Lock behavior.

  ## Correctness

  The tests cover:

  - Decode and prefill execution.
  - Production-size K=5120 decode and prefill shapes.
  - BF16 input and output.
  - W4 symmetric group-size-128 weights.
  - Dynamic asymmetric activation quantization.
  - Weight packing validation.
  - Repeated decode execution.
  - CPU libdevice compatibility.
  - Platform-appropriate LibEntry locking.

  ## Validation

  ### Mac M5 Pro / macOS ARM64

  Environment:

  - Python 3.11.16
  - PyTorch 2.11.0
  - Triton CPU 3.7.2
  - Apple Clang 21.0.0

  Result:

  9 passed, 0 skipped

  The API was additionally validated through a companion vllm-plugin-FL integration by loading all Qwen3.8-27B W4A8 checkpoint shards and completing two short
  generation requests.

  ### CIX P1 / Linux AArch64

  Environment:

  - Debian 13
  - Python 3.11.2
  - PyTorch 2.11.0+cpu
  - Triton CPU 3.7.2
  - GCC 14.2.0

  Result:

  9 passed, 0 skipped

  The decode and prefill Triton kernels executed directly on CIX P1 and were compared with the reference implementation. No Python kernel fallback or mock execution
  was used.

  ## Upstream CI formatting

  The final `style(ci)` commit only formats `tools/ci_checks/check_kernelgen_tests.py`. The file was introduced unformatted in the current `master`, which makes the repository-wide pre-commit job fail before evaluating this PR. This commit does not change checker behavior and can be dropped after the same formatting reaches `master`.

  ## Scope

  Included:

  - ARM W4A8-G128 packing API.
  - Triton decode and prefill kernels.
  - Required ARM CPU import compatibility.
  - Focused correctness and regression tests.

  Not included:

  - vLLM platform or model registration.
  - Qwen checkpoint metadata integration.
  - W8A8 or MiniCPM support.
  - C++ dispatchers or native extensions.
  - DFlash2 or speculative decoding.
  - Performance-specific kernel variants.

  The vLLM and Qwen integration is maintained separately in vllm-plugin-FL.


