### PR TITLE
[AMD] Add CDNA4 split softmax

### DIFF
--- a/src/flag_gems/runtime/backend/_amd/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/__init__.py
@@ -37,6 +37,7 @@ LDS, so the RDNA4 candidates would be a poor fit for them.
 ARCH_MAP = {
     "gfx1200": "rdna4",
     "gfx1201": "rdna4",
+    "gfx950": "cdna4",
 }
 
 CUSTOMIZED_UNUSED_OPS = (

--- a/src/flag_gems/runtime/backend/_amd/cdna4/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna4/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/flag_gems/runtime/backend/_amd/cdna4/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna4/ops/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Only names bound here are picked up: the arch loader collects every function in
+# this namespace with inspect.getmembers and overwrites the same-named generic op,
+# so helpers must not be re-exported from here.
+from .softmax import softmax, softmax_out
+
+__all__ = [
+    "softmax",
+    "softmax_out",
+]

--- a/src/flag_gems/runtime/backend/_amd/cdna4/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_amd/cdna4/ops/softmax.py
@@ -1,0 +1,231 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CDNA4 softmax: split the reduction across workgroups when rows are scarce.
+
+The generic softmax_kernel_inner launches grid (M, 1, 1), one workgroup per row,
+so parallelism is bounded by the row count rather than by the size of the
+reduction. A 1-D input collapses to M=1, which leaves all but one of the 256 CUs
+idle no matter how large N is.
+
+Here each row is split across NUM_BLOCKS workgroups. Pass 1 reduces one chunk
+per workgroup into a partial (max, sum-of-exp) pair; pass 2 combines the partials
+with the online-softmax identity and writes the normalized output. The grid
+becomes (NUM_BLOCKS, M), so parallelism no longer depends on how many rows there
+are. Traffic stays at two reads plus one write, the same as the generic loop
+path, and the combine costs a few KB out of cache instead of a third launch.
+
+The constants below are measured on this part. Both the wavefront width and the
+CU count feed into which tile pays off and into where the generic grid is already
+wide enough on its own, so none of them are portable across architectures.
+
+Only the starved regime is taken over; softmax_out falls through to the generic
+implementation everywhere else, which already fills the card once there are
+enough rows to go around.
+"""
+
+import logging
+from functools import lru_cache
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.softmax import softmax_out as generic_softmax_out
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+# TILE_N is the only one of the three the sweep found sensitive: two fp32
+# accumulators live across the reduction loop, so a tile costs 8 * TILE_N bytes
+# of register state per workgroup and larger tiles spill. 2048 keeps margin from
+# that edge. Warp count and blocks per CU were flat, so both take the low end,
+# which keeps workgroups small enough for several to stay resident per CU.
+_TILE_N = 2048
+_NUM_WARPS = 4
+_BLOCKS_PER_CU = 2
+
+# Eligibility: a shortest reduction, and a smallest useful number of chunks per
+# row. Both are measured end to end with the ops registered, because two launches
+# plus the partials allocation put a fixed floor on this path that GPU-only
+# timing does not charge the split for, making lengths below the break-even look
+# like wins.
+#
+# The chunk minimum is sharp: four or more chunks per row always won, two always
+# lost. Since num_blocks is prev_pow2(_BLOCKS_PER_CU * CU / M), requiring four
+# already bounds the row count, so no separate row budget is needed.
+_MIN_SPLIT_N = 96 * 1024
+_MIN_BLOCKS_PER_ROW = 4
+
+
+@lru_cache(maxsize=8)
+def _cu_count(device_index):
+    return torch_device_fn.get_device_properties(device_index).multi_processor_count
+
+
+def _prev_power_of_2(n):
+    return 1 << (n.bit_length() - 1) if n >= 1 else 1
+
+
+def _split_plan(m, n, device_index):
+    """Workgroups per row, or None to leave this shape to the generic kernel."""
+    if n < _MIN_SPLIT_N:
+        return None
+    cu = _cu_count(device_index)
+    target_blocks = _BLOCKS_PER_CU * cu
+    num_blocks = _prev_power_of_2(max(1, target_blocks // m))
+    # Cap so every workgroup still gets at least one whole tile.
+    num_blocks = min(num_blocks, _prev_power_of_2(n // _TILE_N))
+    return num_blocks if num_blocks >= _MIN_BLOCKS_PER_ROW else None
+
+
+@libentry()
+@triton.jit
+def softmax_split_reduce_kernel(
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+    row = inp_ptr + pid_m * N
+
+    m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
+    z = tl.zeros([TILE_N], dtype=tl.float32)
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        m_new = tl.maximum(m, inp)
+        # An all -inf window must keep z at 0 rather than accumulate exp(nan).
+        all_neg_inf = m_new == float("-inf")
+        z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+        m = m_new
+
+    m_reduced = tl.max(m, 0)
+    # Lanes still at -inf would give exp(-inf - -inf) = exp(nan) when the whole
+    # chunk is -inf, so select the scale instead of computing it.
+    scale = tl.where(m == float("-inf"), 0.0, tl.exp(m - m_reduced))
+    z_reduced = tl.sum(z * scale, 0)
+
+    tl.store(partial_max_ptr + pid_m * NUM_BLOCKS + pid_b, m_reduced)
+    tl.store(partial_sum_ptr + pid_m * NUM_BLOCKS + pid_b, z_reduced)
+
+
+@libentry()
+@triton.jit
+def softmax_split_normalize_kernel(
+    out_ptr,
+    inp_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    N,
+    NUM_BLOCKS,
+    TILE_N: tl.constexpr,
+    TILE_B: tl.constexpr,
+):
+    pid_b = ext.program_id(0)
+    pid_m = ext.program_id(1)
+
+    # Every workgroup redoes the combine over the NUM_BLOCKS partials. That is a
+    # few KB already in cache, and it avoids both a third launch and passing the
+    # row scalars through memory.
+    b_offsets = tl.arange(0, TILE_B)
+    b_mask = b_offsets < NUM_BLOCKS
+    partial_offset = pid_m * NUM_BLOCKS + b_offsets
+    partial_max = tl.load(
+        partial_max_ptr + partial_offset, mask=b_mask, other=-float("inf")
+    )
+    partial_sum = tl.load(partial_sum_ptr + partial_offset, mask=b_mask, other=0.0)
+
+    row_max = tl.max(partial_max, 0)
+    scale = tl.where(partial_max == float("-inf"), 0.0, tl.exp(partial_max - row_max))
+    row_sum = tl.sum(partial_sum * scale, 0)
+
+    row_in = inp_ptr + pid_m * N
+    row_out = out_ptr + pid_m * N
+
+    stride = NUM_BLOCKS * TILE_N
+    for off in range(pid_b * TILE_N, N, stride):
+        n_offsets = off + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        inp = tl.load(row_in + n_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+        out = tl.exp(inp - row_max) / row_sum
+        tl.store(row_out + n_offsets, out.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def softmax_out(self, dim, half_to_float=False, *, out):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dim = dim % self.ndim
+    N = self.shape[dim]
+    M = 1
+    for i in range(dim):
+        M *= self.shape[i]
+    K = self.numel() // M // N if self.numel() else 0
+
+    plan = _split_plan(M, N, self.device.index) if K == 1 and self.numel() else None
+    if plan is None:
+        return generic_softmax_out(self, dim, half_to_float, out=out)
+
+    logger.debug("GEMS_CDNA4 SOFTMAX_OUT SPLIT M=%d N=%d blocks=%d", M, N, plan)
+
+    self = self.contiguous()
+    dtype = torch.float32 if half_to_float else self.dtype
+    if tuple(out.shape) != tuple(self.shape):
+        out.resize_(self.shape)
+    if out.dtype != dtype:
+        raise RuntimeError(f"_softmax.out: expected out dtype {dtype}, got {out.dtype}")
+
+    # One allocation for both partials; the two rows stay contiguous.
+    partials = torch.empty((2, M * plan), dtype=torch.float32, device=self.device)
+    grid = (plan, M, 1)
+
+    with torch_device_fn.device(self.device):
+        softmax_split_reduce_kernel[grid](
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            num_warps=_NUM_WARPS,
+        )
+        softmax_split_normalize_kernel[grid](
+            out,
+            self,
+            partials[0],
+            partials[1],
+            N,
+            plan,
+            TILE_N=_TILE_N,
+            TILE_B=triton.next_power_of_2(plan),
+            num_warps=_NUM_WARPS,
+        )
+    return out
+
+
+def softmax(self, dim, half_to_float=False):
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    dtype = torch.float32 if half_to_float else self.dtype
+    out = torch.empty_like(self, dtype=dtype)
+    return softmax_out(self, dim, half_to_float, out=out)

--- a/tests/test_cdna4_softmax.py
+++ b/tests/test_cdna4_softmax.py
@@ -1,0 +1,281 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the CDNA4-specific split softmax.
+
+The generic softmax test file only uses shapes with either many rows or a short
+reduction, so none of them reach the split path; these cover the regime the arch
+override exists for. The arch loader imports the override under the top-level
+name "cdna4.ops.softmax", so that is where the gate function has to be read from
+to be sure the module under test is the one actually installed.
+"""
+
+import math
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+ARCH_SOFTMAX = sys.modules.get("cdna4.ops.softmax")
+INSTALLED = ARCH_SOFTMAX is not None and ARCH_SOFTMAX.softmax is flag_gems.softmax
+
+pytestmark = pytest.mark.skipif(
+    not INSTALLED,
+    reason="CDNA4 split softmax is not the installed softmax on this device",
+)
+
+# (shape, dim) pairs the gate is expected to take over. A 1-D input is the case
+# that motivated the override: M collapses to 1, so the generic kernel runs the
+# whole reduction on a single workgroup. Lengths clear _MIN_SPLIT_N and row counts
+# stay low enough to reach _MIN_BLOCKS_PER_ROW chunks, so these engage whatever the
+# CU count of the part.
+SPLIT_SHAPES = (
+    [([1048576], 0)]
+    if cfg.QUICK_MODE
+    else [
+        ([262144], 0),
+        ([1048576], 0),
+        ([4, 262144], 1),
+        ([2, 2, 131072], 2),
+        ([1, 98305], 1),
+    ]
+)
+
+# Shapes the gate must leave alone: reduction too short to pay for the second
+# launch, too many rows to reach the chunk minimum, or a non-inner reduction.
+GENERIC_SHAPES = (
+    [([1, 256], 1)]
+    if cfg.QUICK_MODE
+    else [
+        ([1, 256], 1),
+        ([8192], 0),
+        ([1, 98303], 1),
+        ([4096, 4096], 1),
+        ([64, 512, 512], 1),
+    ]
+)
+
+FLOAT_DTYPES = [torch.float32] if cfg.QUICK_MODE else utils.FLOAT_DTYPES
+
+
+def mnk(shape, dim):
+    n = shape[dim]
+    m = math.prod(shape[:dim])
+    return m, n, math.prod(shape) // m // n
+
+
+def split_plan(shape, dim):
+    m, n, k = mnk(shape, dim)
+    if k != 1:
+        return None
+    return ARCH_SOFTMAX._split_plan(m, n, 0)
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
+def test_cdna4_softmax_gate_engages(shape, dim):
+    m, n, _ = mnk(shape, dim)
+    plan = split_plan(shape, dim)
+    assert plan is not None, f"expected the split path for M={m} N={n}"
+
+    cu = ARCH_SOFTMAX._cu_count(0)
+    assert plan >= ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    assert plan & (plan - 1) == 0, "workgroups per row must be a power of two"
+    # Every workgroup needs a whole tile, and the grid must not overshoot the
+    # block count the sweep found best.
+    assert plan * ARCH_SOFTMAX._TILE_N <= n
+    assert m * plan <= ARCH_SOFTMAX._BLOCKS_PER_CU * cu
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", GENERIC_SHAPES)
+def test_cdna4_softmax_gate_defers(shape, dim):
+    assert (
+        split_plan(shape, dim) is None
+    ), f"{shape} dim={dim} should fall through to the generic implementation"
+
+
+@pytest.mark.softmax
+def test_cdna4_softmax_gate_limits():
+    """Pin both limits from both sides.
+
+    Written against the constants and the CU count rather than literals, so the
+    assertions keep describing the intended rule on a part with a different CU
+    count.
+    """
+    cu = ARCH_SOFTMAX._cu_count(0)
+
+    # Nothing below the minimum length, however starved the grid is.
+    assert ARCH_SOFTMAX._split_plan(1, ARCH_SOFTMAX._MIN_SPLIT_N - 1, 0) is None
+    assert ARCH_SOFTMAX._split_plan(1, ARCH_SOFTMAX._MIN_SPLIT_N, 0) is not None
+
+    # The chunk minimum is what bounds the row count: num_blocks halves as M
+    # doubles, so there is a largest M that still reaches _MIN_BLOCKS_PER_ROW.
+    # Long enough that the length cap is not the one biting.
+    n = 64 * ARCH_SOFTMAX._MIN_SPLIT_N
+    row_cap = (
+        ARCH_SOFTMAX._BLOCKS_PER_CU * cu // ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    )
+    assert ARCH_SOFTMAX._split_plan(row_cap, n, 0) == ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    assert ARCH_SOFTMAX._split_plan(row_cap + 1, n, 0) is None
+
+    # Every admitted plan is a power of two at or above the chunk minimum.
+    for m in (1, 2, 8, 32, row_cap):
+        plan = ARCH_SOFTMAX._split_plan(m, n, 0)
+        assert plan >= ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+        assert plan & (plan - 1) == 0
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES + GENERIC_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna4_softmax(shape, dim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+    utils.gems_assert_close(
+        res_out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim]
+    )
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("shape, dim", SPLIT_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna4_softmax_out(shape, dim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+    # Deliberately the wrong size, so the resize path is covered too.
+    out = torch.empty((1,), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        torch.ops.aten._softmax.out(inp, dim, False, out=out)
+
+    utils.gems_assert_close(out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim])
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna4_softmax_half_to_float(dtype):
+    if dtype is torch.float32:
+        pytest.skip("half_to_float only applies to reduced-precision input")
+    shape, dim = SPLIT_SHAPES[0]
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten._softmax(inp, dim, True)
+
+    assert res_out.dtype is torch.float32
+    utils.gems_assert_close(
+        res_out, ref_out, torch.float32, equal_nan=True, reduce_dim=shape[dim]
+    )
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna4_softmax_neg_inf(dtype):
+    """Masked attention rows are the reason the combine needs an -inf guard.
+
+    A chunk that is entirely -inf must contribute a zero sum instead of exp(nan),
+    and a row that is entirely -inf has to come out the same as the single
+    workgroup version would produce.
+    """
+    shape, dim = SPLIT_SHAPES[0]
+    n = shape[dim]
+    tile = ARCH_SOFTMAX._TILE_N
+
+    rows = {
+        # Whole leading chunks masked out, so some workgroups see only -inf.
+        "leading_chunks": lambda t: t[..., : min(8 * tile, n // 2)].fill_(
+            float("-inf")
+        ),
+        # Only one finite element in the row, far from the first chunk.
+        "single_finite": lambda t: (
+            t.fill_(float("-inf")),
+            t[..., n // 2].fill_(1.0),
+        ),
+        # Every element masked: the reference is nan and the arch path must
+        # agree rather than producing a number.
+        "all_masked": lambda t: t.fill_(float("-inf")),
+    }
+
+    for name, mutate in rows.items():
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mutate(inp)
+        ref_inp = utils.to_reference(inp, True)
+
+        ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+        with flag_gems.use_gems():
+            res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+        assert split_plan(shape, dim) is not None, name
+        utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=n)
+
+
+@pytest.mark.softmax
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_cdna4_softmax_at_row_cap(dtype):
+    """Cover grid.y at the row cap: every row combines its own set of partials.
+
+    The shapes in SPLIT_SHAPES only reach M=4, so without this the widest grid the
+    split path ever runs with is a handful of rows.
+    """
+    cu = ARCH_SOFTMAX._cu_count(0)
+    # The largest row count that still reaches the chunk minimum.
+    m = ARCH_SOFTMAX._BLOCKS_PER_CU * cu // ARCH_SOFTMAX._MIN_BLOCKS_PER_ROW
+    n = 4 * ARCH_SOFTMAX._MIN_SPLIT_N
+    if ARCH_SOFTMAX._split_plan(m, n, 0) is None:
+        pytest.skip(f"the gate does not take M={m} N={n} on a {cu} CU device")
+
+    inp = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    # One fully masked row, so the all -inf guard is hit with live siblings.
+    inp[0].fill_(float("-inf"))
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=-1)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=-1)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=n)
+
+
+@pytest.mark.softmax
+def test_cdna4_softmax_non_contiguous():
+    shape, dim = SPLIT_SHAPES[0]
+    n = shape[dim]
+    base = torch.randn(
+        shape[:dim] + [2 * n], dtype=torch.float32, device=flag_gems.device
+    )
+    inp = base[..., ::2]
+    assert not inp.is_contiguous()
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.softmax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.softmax(inp, dim=dim)
+
+    utils.gems_assert_close(
+        res_out, ref_out, torch.float32, equal_nan=True, reduce_dim=n
+    )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization

### Description

Brings the split softmax to CDNA4 (gfx950). The kernel is the same two-pass reduction as #5327 and is carried over unchanged; only the gate differs.

The row budget stays implicit in a minimum chunk count: `num_blocks` is `prev_pow2(_BLOCKS_PER_CU * CU / M)`, so requiring four chunks already caps rows at M <= 128 on a 256 CU part. Below that count the split loses across the board -- at N=262144 every row count reaching four or more chunks won and every one that got two lost, in all three dtypes.

`_MIN_SPLIT_N` is 96K, set from end-to-end wall clock rather than GPU time. That distinction decides the value: two launches plus the partials allocation put a ~23 us floor on this path, and a GPU-only comparison, which does not charge the split for that floor, reads N=32768 as a 1.3x win where the registered call is 0.39x. Measured end to end at M=1, the generic kernel is still ahead at 64K (1.00x fp16, 0.95x fp32) and behind from 96K on. `_TILE_N` is 2048, `_NUM_WARPS` 4 and `_BLOCKS_PER_CU` 2, each the low end of a flat range in the sweep.

Shapes outside the gate fall through to the generic kernel untouched.

#### Results

Speedup over the generic kernel, with speedup over torch in brackets. bf16, gfx950 (MI355X, 256 CU), idle card, median of 5 independent runs.

| rows | N=98304 | N=131072 | N=262144 | N=524288 | N=1048576 |
|---|---|---|---|---|---|
| M=1 | 1.41x (0.86x) | 1.86x (1.11x) | 3.64x (2.10x) | 7.22x (4.11x) | 14.24x (8.05x) |
| M=4 | 1.43x (0.87x) | 1.86x (1.12x) | 3.67x (2.13x) | 7.26x (4.14x) | 14.22x (8.05x) |
| M=16 | 1.47x (0.89x) | 1.94x (1.15x) | 3.68x (2.16x) | 7.37x (4.21x) | 11.20x (7.25x) |
| M=64 | 1.53x (0.96x) | 1.97x (1.19x) | 3.01x (2.00x) | 3.12x (2.60x) | 3.23x (2.70x) |
| M=128 | 1.52x (1.23x) | 1.59x (1.09x) | 1.60x (1.37x) | 1.64x (1.40x) | 1.54x (1.57x) |

Across all 168 gated shapes (fp16/bf16/fp32) the median is 1.81x over generic and 1.37x over torch, worst case 1.23x, best 15.06x. Gains over torch start later: at 96K-128K the narrow dtypes sit at or just below torch and only pull ahead from 256K, while fp32 leads throughout its gated range (median 1.78x). The 447 measured shapes outside the gate are unchanged.

Numbers come from a 615-shape sweep run as five independent processes, three repeats per cell, cell order shuffled. Cross-run spread is 1.7% median and 5.7% at p95, and each run independently finds zero regressions inside the gate.

Correctness: `tests/test_cdna4_softmax.py` runs 65 passed, 1 skipped, covering both sides of the gate, each element width, `half_to_float`, non-inner dims, non-contiguous input and -inf rows, with every assertion written against the module's own constants rather than literals. Upstream `test_softmax.py` and `test_log_softmax.py`: 204 passed.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress
