### PR TITLE
[CI] Add rule check to forbid use_gems() in PR-changed test files

### DIFF
--- a/.github/workflows/rule-check.yaml
+++ b/.github/workflows/rule-check.yaml
@@ -89,12 +89,10 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.11'
-      - name: Install dependencies
-        run: pip install pyyaml
-      - name: Check KernelGen tests for use_gems
+      - name: Check changed test files for use_gems
         run: |
           python tools/ci_checks/check_kernelgen_tests.py \
-            --operators '${{ needs.derive-changed-operators.outputs.changed_operators }}'
+            --changed-files '${{ needs.derive-changed-operators.outputs.changed_files }}'
 
   check-operator-markers:
     runs-on: ubuntu-latest

--- a/tools/ci_checks/check_kernelgen_tests.py
+++ b/tools/ci_checks/check_kernelgen_tests.py
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Check KernelGen test files for forbidden use_gems() calls.
+"""Check test files for forbidden use_gems() calls.
 
 Rules:
-  1. Test files for KernelGen operators must NOT call flag_gems.use_gems()
-     or use_gems() directly, as this bypasses reference implementation comparison.
+  1. Test files must NOT call flag_gems.use_gems() or use_gems() directly,
+     as this bypasses reference implementation comparison.
+  2. In incremental mode (default in CI), only PR-changed test files are checked.
 
 Exit codes:
   0 - all checks pass
@@ -32,21 +33,8 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
-
-OPERATORS_YAML = Path("conf/operators.yaml")
 TESTS_DIR = Path("tests")
 
-
-def get_kernelgen_operators() -> set[str]:
-    """Get operator IDs that have 'KernelGen' label."""
-    if not OPERATORS_YAML.exists():
-        print(f"::error::Cannot find {OPERATORS_YAML}", file=sys.stderr)
-        sys.exit(2)
-    with open(OPERATORS_YAML) as f:
-        data = yaml.safe_load(f)
-    ops = data.get("ops", [])
-    return {op["id"] for op in ops if "KernelGen" in op.get("labels", [])}
 
 
 def find_use_gems_calls(filepath: Path) -> list[tuple[int, str]]:
@@ -89,7 +77,7 @@ def find_use_gems_calls(filepath: Path) -> list[tuple[int, str]]:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Check KernelGen tests for forbidden use_gems() calls"
+        description="Check test files for forbidden use_gems() calls"
     )
     parser.add_argument(
         "--operators",
@@ -98,22 +86,28 @@ def main():
     )
     parser.add_argument(
         "--changed-files",
-        help="JSON list of changed test file paths (incremental mode)",
+        help="JSON list of changed file paths (incremental mode)",
         default="",
     )
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Check all KernelGen operator tests (full scan, not used in CI)",
+        help="Check all test files (full scan)",
     )
     args = parser.parse_args()
 
-    kernelgen_ops = get_kernelgen_operators()
-    print(f"KernelGen operators in registry: {len(kernelgen_ops)}")
-
-    # Incremental mode: only check operators from the current PR
+    # Determine which test files to check
     if args.all:
-        ops_to_check = kernelgen_ops
+        test_files = sorted(TESTS_DIR.glob("test_*.py"))
+    elif args.changed_files:
+        try:
+            changed = json.loads(args.changed_files)
+        except json.JSONDecodeError:
+            changed = [f.strip() for f in args.changed_files.split(",") if f.strip()]
+        test_files = [
+            Path(f) for f in changed
+            if re.match(r"tests/test_.+\.py$", f)
+        ]
     elif args.operators:
         try:
             requested_ops = json.loads(args.operators)
@@ -121,39 +115,24 @@ def main():
             requested_ops = [
                 op.strip() for op in args.operators.split(",") if op.strip()
             ]
-        # Only check ops that are KernelGen
-        ops_to_check = set(requested_ops) & kernelgen_ops
-    elif args.changed_files:
-        # Derive operators from changed test file paths
-        try:
-            changed = json.loads(args.changed_files)
-        except json.JSONDecodeError:
-            changed = [f.strip() for f in args.changed_files.split(",") if f.strip()]
-        ops_from_files = set()
-        for fp in changed:
-            m = re.match(r"tests/test_(.+)\.py$", fp)
-            if m:
-                ops_from_files.add(m.group(1))
-        ops_to_check = ops_from_files & kernelgen_ops
+        test_files = [
+            TESTS_DIR / f"test_{op_id}.py" for op_id in requested_ops
+        ]
     else:
-        # No operators specified and not --all: nothing to check (safe default)
-        print("No operators specified. Use --operators or --all.")
+        print("No operators or files specified. Use --operators, --changed-files, or --all.")
         sys.exit(0)
 
-    if not ops_to_check:
-        print("No KernelGen operators to check.")
+    # Filter to files that actually exist
+    test_files = [f for f in test_files if f.exists()]
+
+    if not test_files:
+        print("No test files to check.")
         sys.exit(0)
 
-    print(f"Checking {len(ops_to_check)} operator test(s)...")
+    print(f"Checking {len(test_files)} test file(s)...")
     all_violations = []
 
-    for op_id in sorted(ops_to_check):
-        # Find corresponding test file(s)
-        test_file = TESTS_DIR / f"test_{op_id}.py"
-        if not test_file.exists():
-            # Try with leading underscore stripped from test name
-            continue
-
+    for test_file in sorted(test_files):
         violations = find_use_gems_calls(test_file)
         if violations:
             for lineno, code in violations:
@@ -165,6 +144,10 @@ def main():
         for v in all_violations:
             print(f"::error::{v}")
             print(f"  • {v}")
+        print(
+            "\nTests must not call use_gems(). "
+            "The test framework handles operator dispatch automatically."
+        )
         sys.exit(1)
     else:
         print("✅ No forbidden use_gems() calls found.")


### PR DESCRIPTION
Add check_use_gems.py that scans test files changed in a PR for use_gems() calls via AST parsing. Only incremental — existing files are not affected. Fails CI if any changed test file contains use_gems() or flag_gems.use_gems().

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
