### PR TITLE
fix(mthreads): avoid large-row radix sort deadlock

### DIFF
--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -255,6 +255,123 @@ def sweep(
             tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
 
 
+@triton.jit
+def compute_tile_hist(
+    arr_ptr,
+    tile_prefix_ptr,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+        local_sum = tl.sum(matches.to(tl.uint32), axis=0)
+        status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        tl.store(tile_prefix_ptr + status_offset, local_sum)
+
+
+@triton.jit
+def exclusive_scan_tile_hist(
+    tile_prefix_ptr,
+    m,
+    OUT_N,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_r = tl.program_id(1)
+    r: tl.constexpr = 2**k_bits
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        exclusive_prefix = tl.zeros((), dtype=tl.uint32)
+        for pid_n in range(0, OUT_N):
+            status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+            local_sum = tl.load(tile_prefix_ptr + status_offset).to(tl.uint32)
+            tl.store(tile_prefix_ptr + status_offset, exclusive_prefix)
+            exclusive_prefix += local_sum
+
+
+@triton.jit
+def scatter_with_tile_prefix(
+    arr_ptr,
+    associate_arr_ptr,
+    out_ptr,
+    associate_out_ptr,
+    excumsum_bins_ptr,
+    tile_prefix_ptr,
+    n_passes,
+    pass_id,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+    if associate_arr_ptr is not None:
+        associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+        local_ex_cumsum = (
+            tl.cumsum(matches.to(tl.uint32), axis=0) - matches
+        )
+        status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        exclusive_prefix = tl.load(tile_prefix_ptr + status_offset).to(tl.uint32)
+        ex_cumsum_bins = tl.load(
+            excumsum_bins_ptr + pid_m * (n_passes * r) + pass_id * r + bin_index
+        )
+        pos = ex_cumsum_bins + exclusive_prefix + local_ex_cumsum
+
+        tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
+        if associate_arr_ptr is not None:
+            tl.store(
+                associate_out_ptr + pid_m * N + pos,
+                associate_arr,
+                mask=matches,
+            )
+
+
 def radix_sort(arr, k_bits=8, descending=False):
     n = arr.shape[-1]
     m = arr.numel() // n
@@ -308,31 +425,74 @@ def radix_sort(arr, k_bits=8, descending=False):
         grid_n = triton.cdiv(n, TILE_N)
         grid_for_sweep = (m * grid_n, grid_r)
 
+        # Avoid the cross-CTA scheduling dependency in decoupled lookback for
+        # large rows.  Later resident CTAs must not spin while an earlier CTA
+        # is still waiting to be scheduled.
+        use_phased_sweep = grid_n > 32
         status = torch.empty(
-            (m, num_bins, grid_n), device=arr.device, dtype=torch.uint32
+            (m, num_bins, grid_n), device=arr.device, dtype=torch.int32
         )
 
         for i in range(0, n_passes):
             bit_offset = i * k_bits
-            status.zero_()
-            sweep[grid_for_sweep](
-                arr_in,
-                indices_in,
-                arr_out,
-                indices_out,
-                ex_cumsum_bins,
-                status,
-                n_passes,
-                i,
-                bit_offset,
-                m,
-                n,
-                grid_n,
-                TILE_N,
-                TILE_R,
-                k_bits,
-                descending,
-            )
+            if use_phased_sweep:
+                compute_tile_hist[grid_for_sweep](
+                    arr_in,
+                    status,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
+                exclusive_scan_tile_hist[(m, grid_r)](
+                    status,
+                    m,
+                    grid_n,
+                    TILE_R,
+                    k_bits,
+                )
+                scatter_with_tile_prefix[grid_for_sweep](
+                    arr_in,
+                    indices_in,
+                    arr_out,
+                    indices_out,
+                    ex_cumsum_bins,
+                    status,
+                    n_passes,
+                    i,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
+            else:
+                status.zero_()
+                sweep[grid_for_sweep](
+                    arr_in,
+                    indices_in,
+                    arr_out,
+                    indices_out,
+                    ex_cumsum_bins,
+                    status,
+                    n_passes,
+                    i,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
             # print(f"< sorted last {bit_offset + k_bits:>2d} bits: {arr_out}")
             arr_in, arr_out = arr_out, arr_in
             indices_in, indices_out = indices_out, indices_in

--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -96,7 +96,13 @@ from .tile import tile
 from .trunc import trunc, trunc_
 from .unique import _unique2
 from .upsample_linear1d_backward import upsample_linear1d_backward
-from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor as _TensorDescriptor
+except ModuleNotFoundError:
+    _has_tensor_descriptor = False
+else:
+    _has_tensor_descriptor = True
+    from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
 from .zeros import zero_, zeros
 from .zeros_like import zeros_like
 
@@ -214,26 +220,40 @@ __all__ = [
     "zeros_like",
 ]
 
+if not _has_tensor_descriptor:
+    __all__.remove("w8a8_block_fp8_matmul")
+
 
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm, addmm_dtype, addmm_dtype_out, addmm_out  # noqa: F401
-    from .baddbmm import baddbmm, baddbmm_out  # noqa: F401
-    from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
-    from .mm import mm  # noqa: F401
     from .tanh import tanh  # noqa: F401
+
+    if _has_tensor_descriptor:
+        from .addmm import (  # noqa: F401
+            addmm,
+            addmm_dtype,
+            addmm_dtype_out,
+            addmm_out,
+        )
+        from .baddbmm import baddbmm, baddbmm_out  # noqa: F401
+        from .bmm import bmm  # noqa: F401
+        from .mm import mm  # noqa: F401
+        __all__.extend(
+            [
+                "addmm",
+                "addmm_dtype",
+                "addmm_dtype_out",
+                "addmm_out",
+                "baddbmm",
+                "baddbmm_out",
+                "bmm",
+                "mm",
+            ]
+        )
 
     __all__.extend(
         [
-            "addmm",
-            "addmm_dtype",
-            "addmm_dtype_out",
-            "addmm_out",
-            "baddbmm",
-            "baddbmm_out",
-            "bmm",
             "gelu",
-            "mm",
             "tanh",
         ]
     )

--- a/src/flag_gems/runtime/backend/_mthreads/ops/sort.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/sort.py
@@ -257,6 +257,123 @@ def sweep(
             tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
 
 
+@triton.jit
+def compute_tile_hist(
+    arr_ptr,
+    tile_prefix_ptr,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+        local_sum = tl.sum(matches.to(tl.uint32), axis=0)
+        status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        tl.store(tile_prefix_ptr + status_offset, local_sum)
+
+
+@triton.jit
+def exclusive_scan_tile_hist(
+    tile_prefix_ptr,
+    m,
+    OUT_N,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_r = tl.program_id(1)
+    r: tl.constexpr = 2**k_bits
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        exclusive_prefix = tl.zeros((), dtype=tl.uint32)
+        for pid_n in range(0, OUT_N):
+            status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+            local_sum = tl.load(tile_prefix_ptr + status_offset).to(tl.uint32)
+            tl.store(tile_prefix_ptr + status_offset, exclusive_prefix)
+            exclusive_prefix += local_sum
+
+
+@triton.jit
+def scatter_with_tile_prefix(
+    arr_ptr,
+    associate_arr_ptr,
+    out_ptr,
+    associate_out_ptr,
+    excumsum_bins_ptr,
+    tile_prefix_ptr,
+    n_passes,
+    pass_id,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_m = pid % m
+    pid_n = pid // m
+    pid_r = tl.program_id(1)
+
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask
+    if associate_arr_ptr is not None:
+        associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
+
+    for bin_index in range(cta_r_start, cta_r_end):
+        matches = tl.where(mask, key == bin_index, False)
+        local_ex_cumsum = (
+            tl.cumsum(matches.to(tl.uint32), axis=0) - matches
+        )
+        status_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        exclusive_prefix = tl.load(tile_prefix_ptr + status_offset).to(tl.uint32)
+        ex_cumsum_bins = tl.load(
+            excumsum_bins_ptr + pid_m * (n_passes * r) + pass_id * r + bin_index
+        )
+        pos = ex_cumsum_bins + exclusive_prefix + local_ex_cumsum
+
+        tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
+        if associate_arr_ptr is not None:
+            tl.store(
+                associate_out_ptr + pid_m * N + pos,
+                associate_arr,
+                mask=matches,
+            )
+
+
 def radix_sort(arr, k_bits=8, descending=False):
     n = arr.shape[-1]
     m = arr.numel() // n
@@ -310,31 +427,75 @@ def radix_sort(arr, k_bits=8, descending=False):
         grid_n = triton.cdiv(n, TILE_N)
         grid_for_sweep = (m * grid_n, grid_r)
 
+        # The decoupled-lookback implementation can deadlock when resident
+        # later CTAs spin waiting for earlier CTAs which are not yet scheduled.
+        # For large rows, split it into three ordered launches: tile histogram,
+        # exclusive scan, and scatter.  No launch has a cross-CTA dependency.
+        use_phased_sweep = grid_n > 32
         status = torch.empty(
             (m, num_bins, grid_n), device=arr.device, dtype=torch.int32
         )
 
         for i in range(0, n_passes):
             bit_offset = i * k_bits
-            status.zero_()
-            sweep[grid_for_sweep](
-                arr_in,
-                indices_in,
-                arr_out,
-                indices_out,
-                ex_cumsum_bins,
-                status,
-                n_passes,
-                i,
-                bit_offset,
-                m,
-                n,
-                grid_n,
-                TILE_N,
-                TILE_R,
-                k_bits,
-                descending,
-            )
+            if use_phased_sweep:
+                compute_tile_hist[grid_for_sweep](
+                    arr_in,
+                    status,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
+                exclusive_scan_tile_hist[(m, grid_r)](
+                    status,
+                    m,
+                    grid_n,
+                    TILE_R,
+                    k_bits,
+                )
+                scatter_with_tile_prefix[grid_for_sweep](
+                    arr_in,
+                    indices_in,
+                    arr_out,
+                    indices_out,
+                    ex_cumsum_bins,
+                    status,
+                    n_passes,
+                    i,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
+            else:
+                status.zero_()
+                sweep[grid_for_sweep](
+                    arr_in,
+                    indices_in,
+                    arr_out,
+                    indices_out,
+                    ex_cumsum_bins,
+                    status,
+                    n_passes,
+                    i,
+                    bit_offset,
+                    m,
+                    n,
+                    grid_n,
+                    TILE_N,
+                    TILE_R,
+                    k_bits,
+                    descending,
+                )
             # print(f"< sorted last {bit_offset + k_bits:>2d} bits: {arr_out}")
             arr_in, arr_out = arr_out, arr_in
             indices_in, indices_out = indices_out, indices_in

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+
 import pytest
 import torch
 
@@ -89,3 +91,37 @@ def test_sort_stable(batch_size, hiddensize, descending, dtype, dim):
 
     utils.gems_assert_close(res_value, ref_value, dtype)
     utils.gems_assert_equal(res_index, ref_index)
+
+
+@pytest.mark.sort
+@pytest.mark.parametrize("batch_size", [1, 32])
+def test_sort_mthreads_sampling_vocab(batch_size):
+    """Regression for the MiniCPM5 large-vocabulary sampling sort."""
+    if flag_gems.vendor_name != "mthreads":
+        pytest.skip("MThreads scheduling regression")
+
+    torch.manual_seed(20260903)
+    y = torch.randn(
+        (batch_size, 130560), dtype=torch.float32, device=flag_gems.device
+    )
+    ref_y = utils.to_reference(y)
+    ref_value, ref_index = torch.sort(
+        ref_y, dim=-1, stable=True, descending=True
+    )
+
+    with flag_gems.use_gems():
+        res_value, res_index = torch.sort(
+            y, dim=-1, stable=True, descending=True
+        )
+
+        # SGLang_FL's default.flagos backend may call the generic module
+        # directly instead of the vendor-specialized top-level registration.
+        generic_sort = importlib.import_module("flag_gems.ops.sort")
+        generic_value, generic_index = generic_sort.sort_stable(
+            y, stable=True, dim=-1, descending=True
+        )
+
+    utils.gems_assert_close(res_value, ref_value, torch.float32)
+    utils.gems_assert_equal(res_index, ref_index)
+    utils.gems_assert_close(generic_value, ref_value, torch.float32)
+    utils.gems_assert_equal(generic_index, ref_index)


### PR DESCRIPTION
## Summary

- avoid the MThreads large-row radix-sort deadlock by replacing cross-CTA decoupled lookback with ordered histogram, exclusive-scan, and scatter launches when `grid_n > 32`
- cover both the generic and MThreads-specialized sort implementations used by SGLang-FL dispatch
- guard MThreads tensor-descriptor GEMM imports when the active Triton runtime does not provide `triton.tools.tensor_descriptor`
- add the real MiniCPM5 sampling vocabulary regression shape

## Reproduction

MiniCPM5-2.6B sampling sorts FP32 logits with shape `[batch, 130560]`, stable descending. On MTT S5000, the old large-row sweep can deadlock because resident later CTAs spin while an earlier dependency CTA has not been scheduled.

## Validation

- rebased onto `master@db33988eca77bcc45bb70719ca6b1db94229b4c6`
- MTT S5000 hardware
- regression cases: batch sizes 1 and 32, vocabulary 130560, FP32, stable descending
- result: 2 passed, 640 unrelated cases deselected
- validated against both top-level FlagGems dispatch and direct `flag_gems.ops.sort.sort_stable`
- the fix was used by the MiniCPM5-2.6B SGLang-FL accuracy path; Agent GSM8K self-test scored 63/64 and the external formal evaluation was confirmed passed

This PR is intentionally separate from the sglang-plugin-FL MiniCPM5 adaptation PR.
