### PR TITLE
fix(ascend): fix multinomial NaN/OOM and cumsum device bug on Ascend backend

### DIFF
--- a/benchmark/test_multinomial.py
+++ b/benchmark/test_multinomial.py
@@ -22,7 +22,19 @@ from . import base, consts
 
 def _input_fn(shape, dtype, device):
     dist = torch.rand(shape, dtype=dtype, device=device)
-    n_samples = 10000
+    n_categories = shape[-1] if len(shape) > 1 else shape[0]
+    batch = shape[0] if len(shape) > 1 else 1
+
+    # NPU's native torch.multinomial (baseline) allocates an internal tensor
+    # roughly proportional to  batch * n_samples * n_categories * sizeof(float)
+    # with a large constant factor (~8x observed).  Keep the product under a
+    # safe budget to avoid OOM on a 60 GiB NPU.
+    MEM_BUDGET = 8 * (1024 ** 3)  # 8 GiB budget (conservative)
+    BYTES_PER_ELEM = 4 * 8        # float32 * ~8x overhead factor
+    max_samples = MEM_BUDGET // max(batch * n_categories * BYTES_PER_ELEM, 1)
+    n_samples = min(n_categories, max_samples)
+    n_samples = max(n_samples, 1)  # at least 1 sample
+
     yield dist, n_samples, True,
 
 
@@ -31,7 +43,35 @@ def _input_fn(shape, dtype, device):
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
 def test_multinomial_with_replacement():
-    bench = base.GenericBenchmark2DOnly(
+    # Custom shapes for multinomial to avoid OOM on NPU and stay within
+    # the n_categories <= 2^24 hardware limit of aclnnMultinomial.
+    # The generic Benchmark shapes from core_shapes.yaml include
+    # 1-D / 3-D shapes and entries > 2^24 that are unsuitable.
+    _MULTINOMIAL_SHAPES = [
+        (1, 1000),       # small single distribution
+        (1, 10000),      # medium single distribution
+        (100, 1000),     # small batch
+        (1000, 1000),    # balanced batch
+        (10000, 256),    # large batch, narrow categories
+        (1000, 4096),    # medium batch, wide categories
+    ]
+
+    class MultinomialBenchmark(base.GenericBenchmark):
+        DEFAULT_SHAPE_DESC = "batch_size, n_categories"
+
+        def set_shapes(self, shape_file_path=None):
+            # Bypass yaml / DEFAULT_SHAPES entirely to ensure only
+            # multinomial-safe shapes are used.
+            self.shapes = list(_MULTINOMIAL_SHAPES)
+
+        def set_more_shapes(self):
+            return []
+
+        def get_input_iter(self, dtype):
+            for shape in self.shapes:
+                yield from self.input_fn(shape, dtype, self.device)
+
+    bench = MultinomialBenchmark(
         input_fn=_input_fn,
         op_name="multinomial",
         torch_op=torch.multinomial,

--- a/benchmark/test_multinomial.py
+++ b/benchmark/test_multinomial.py
@@ -29,8 +29,8 @@ def _input_fn(shape, dtype, device):
     # roughly proportional to  batch * n_samples * n_categories * sizeof(float)
     # with a large constant factor (~8x observed).  Keep the product under a
     # safe budget to avoid OOM on a 60 GiB NPU.
-    MEM_BUDGET = 8 * (1024 ** 3)  # 8 GiB budget (conservative)
-    BYTES_PER_ELEM = 4 * 8        # float32 * ~8x overhead factor
+    MEM_BUDGET = 8 * (1024**3)  # 8 GiB budget (conservative)
+    BYTES_PER_ELEM = 4 * 8  # float32 * ~8x overhead factor
     max_samples = MEM_BUDGET // max(batch * n_categories * BYTES_PER_ELEM, 1)
     n_samples = min(n_categories, max_samples)
     n_samples = max(n_samples, 1)  # at least 1 sample
@@ -48,12 +48,12 @@ def test_multinomial_with_replacement():
     # The generic Benchmark shapes from core_shapes.yaml include
     # 1-D / 3-D shapes and entries > 2^24 that are unsuitable.
     _MULTINOMIAL_SHAPES = [
-        (1, 1000),       # small single distribution
-        (1, 10000),      # medium single distribution
-        (100, 1000),     # small batch
-        (1000, 1000),    # balanced batch
-        (10000, 256),    # large batch, narrow categories
-        (1000, 4096),    # medium batch, wide categories
+        (1, 1000),  # small single distribution
+        (1, 10000),  # medium single distribution
+        (100, 1000),  # small batch
+        (1000, 1000),  # balanced batch
+        (10000, 256),  # large batch, narrow categories
+        (1000, 4096),  # medium batch, wide categories
     ]
 
     class MultinomialBenchmark(base.GenericBenchmark):

--- a/src/flag_gems/runtime/backend/_ascend/ops/cumsum.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/cumsum.py
@@ -439,9 +439,8 @@ def normed_cumsum(inp, dim=-1):
             )
             return out
 
-        if inp.dtype != torch.float64:
-            acc_dtype = torch.float32
-        sums = torch.empty((n_rows, n_chunks), dtype=acc_dtype, device=device.name)
+        acc_dtype = torch.float32 if inp.dtype != torch.float64 else torch.float64
+        sums = torch.empty((n_rows, n_chunks), dtype=acc_dtype, device=inp.device)
         cumsums = torch.empty_like(sums)
         block_cumsum_kernel[grid](
             inp,

--- a/src/flag_gems/runtime/backend/_ascend/ops/multinomial.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/multinomial.py
@@ -76,16 +76,18 @@ def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
 
     # Sampling without replacement
     if (not with_replacement) or n_samples == 1:
-        # In case of with_replacement, sampling is approximated by selecing
-        # the top k indices over sorted probabilities with an exponential pertubation
-        # s = argmax( p / q ) where q ~ Exp(1)
-        q = torch.empty_like(prob).exponential_(1.0)
-        s = torch.div(prob, q, out=q)
+        prob_f32 = prob.float()
+        prob_f32.clamp_(min=1e-12)  # avoid zero probabilities producing NaN
+        q = torch.empty(
+            prob.shape, dtype=torch.float32, device=prob.device
+        ).exponential_(1.0)
+        q.clamp_(min=1e-20)  # prevent division overflow
+        s = prob_f32 / q
         if n_samples == 1:
             return torch.argmax(s, dim=-1, keepdim=True).to(torch.int64)
         else:
-            vals, indices = torch.topk(s, n_samples, dim=-1)
-            return indices.to(torch.int64)
+            _, indices = torch.sort(s, dim=-1, descending=True, stable=True)
+            return indices.narrow(-1, 0, n_samples).to(torch.int64)
 
     from flag_gems.runtime.backend._ascend import ops as asd_ops
 


### PR DESCRIPTION
### PR Category
Operator | OP Test | Benchmark

### Type of Change
Bug Fix

### Description

This PR fixes several bugs in the Ascend backend for `multinomial` and `cumsum` operators, and hardens the multinomial benchmark to avoid OOM on NPU devices.

**1. `multinomial` operator fix (`src/flag_gems/runtime/backend/_ascend/ops/multinomial.py`)**
- Cast probabilities to `float32` before the Gumbel-max sampling to avoid precision issues on Ascend NPU.
- Added `clamp_(min=1e-12)` on probabilities to prevent zero values from producing `NaN` after division.
- Added `clamp_(min=1e-20)` on exponential samples to prevent division overflow.
- Replaced `torch.topk` with `torch.sort` + `narrow` for sampling without replacement, which is more numerically stable and avoids incorrect results when top-k ties occur.

**2. `cumsum` operator fix (`src/flag_gems/runtime/backend/_ascend/ops/cumsum.py`)**
- Fixed `acc_dtype` variable scoping: previously `acc_dtype` was only assigned inside the `if inp.dtype != torch.float64` branch, leaving it potentially undefined. Now uses a single ternary expression.
- Fixed `device.name` → `inp.device` for `torch.empty()` allocation, resolving a device mismatch error.

**3. Benchmark hardening (`benchmark/test_multinomial.py`)**
- Added dynamic `n_samples` calculation based on a memory budget (~8 GiB) to prevent OOM when NPU's native `torch.multinomial` allocates large internal buffers.
- Created a custom `MultinomialBenchmark` class with NPU-safe shapes that respect the `aclnnMultinomial` hardware limit of `n_categories <= 2^24`, bypassing the generic shapes from `core_shapes.yaml` which include unsuitable 1-D/3-D shapes and entries exceeding this limit.

### Issue
- Resolves `NaN` output in `multinomial` without replacement on Ascend NPU
- Resolves `cumsum` crash due to incorrect device placement
- Resolves OOM during multinomial benchmark on NPU devices

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
Benchmark tested with the following custom shapes on Ascend NPU:
- `(1, 1000)`, `(1, 10000)` — single distribution
- `(100, 1000)`, `(1000, 1000)` — batch distributions
- `(10000, 256)` — large batch, narrow categories
- `(1000, 4096)` — medium batch, wide categories

All shapes complete without OOM. The `sort` + `narrow` approach for without-replacement sampling produces correct results without NaN.
