### PR TITLE
[MTHREADS] optimize sort radix pipeline

### DIFF
--- a/cpp/lib/sort.cpp
+++ b/cpp/lib/sort.cpp
@@ -184,6 +184,12 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
   int64_t n = arr.size(-1);
   int32_t m = arr.numel() / n;
   TORCH_CHECK(n < (1 << 30), "we have not implemented 2**30 per launch");
+#if defined(FLAGGEMS_USE_MUSA)
+  // Match Python Triton launches: runtime shape/loop scalars are i32.  An
+  // i64 ABI here needlessly widens address arithmetic throughout sweep.
+  const int32_t n_i32 = static_cast<int32_t>(n);
+  const int32_t m_i32 = m;
+#endif
 
   auto dtype = arr.scalar_type();
   int64_t num_bits = get_num_bits(dtype);
@@ -195,6 +201,23 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
   const int64_t num_bins = 1 << k_bits;
   const int64_t n_passes = utils::cdiv(num_bits, k_bits);
   const int64_t TILE_R_HIST = 16;
+#if defined(FLAGGEMS_USE_MUSA)
+  const bool use_compact_indices = m >= 512 && n <= 2048;
+  constexpr int64_t TILE_N_HIER = 2048;
+  constexpr int64_t TILE_N_SWEEP = 2048;
+  const int64_t grid_n_hier = utils::cdiv(n, TILE_N_HIER);
+  const int64_t grid_n_sweep = utils::cdiv(n, TILE_N_SWEEP);
+  // OneSweep's lookback chain can deadlock once a row spans more than 32
+  // 1024-element sweep tiles.  Our 2048-element sweep reaches the same
+  // dependency depth at grid_n_sweep > 16.  Resident later CTAs may otherwise
+  // wait for a predecessor CTA which has not been scheduled.  Route that
+  // entire dependency region through ordered hierarchical launches,
+  // independently of the performance crossover below.
+  const bool must_use_safe_hierarchical = num_bins == 16 && grid_n_sweep > 16;
+  const bool performance_use_hierarchical = !use_compact_indices && num_bins == 16 && grid_n_hier >= 2 &&
+                                            (m >= 1024 || (grid_n_hier >= 4 && m >= 64));
+  const bool use_hierarchical = must_use_safe_hierarchical || performance_use_hierarchical;
+#endif
 
   int64_t grid_n_hist = utils::cdiv(n, CTA_TILE_N_HIST);
 #if defined(FLAGGEMS_USE_GCU)
@@ -211,43 +234,163 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
   backend::StreamType stream = backend::getCurrentStream();
   backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
-  at::Tensor global_hist =
-      at::zeros({m, n_passes, num_bins}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));
-
-  hist_kernel(raw_stream,
-              grid_x_hist,
-              1,
-              1,
-              4,
-              1,
-              arr,
-              global_hist,
+  at::Tensor ex_cumsum_bins;
+#if defined(FLAGGEMS_USE_MUSA)
+  if (use_hierarchical) {
+    // Filled one pass at a time from tile_hist below; this avoids an
+    // additional all-passes read of the payload before hierarchical scatter.
+    ex_cumsum_bins =
+        at::empty({m, n_passes, num_bins}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));
+  } else {
+#endif
+    at::Tensor global_hist =
+        at::zeros({m, n_passes, num_bins}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));
+    hist_kernel(raw_stream,
+                grid_x_hist,
+                1,
+                1,
+                4,
+                1,
+                arr,
+                global_hist,
+#if defined(FLAGGEMS_USE_MUSA)
+                static_cast<int32_t>(n_passes),
+                m_i32,
+                n_i32,
+#else
               n_passes,
               m,
               n,
-#if defined(FLAGGEMS_USE_GCU)
-              grid_n_hist,
 #endif
-              TILES_N_PER_CTA_HIST,
-              TILE_N_HIST,
-              TILE_R_HIST,
-              k_bits,
-              descending);
+#if defined(FLAGGEMS_USE_GCU)
+                grid_n_hist,
+#endif
+                TILES_N_PER_CTA_HIST,
+                TILE_N_HIST,
+                TILE_R_HIST,
+                k_bits,
+                descending);
+    ex_cumsum_bins = (at::cumsum(global_hist, -1) - global_hist).to(torch::kInt32);
+#if defined(FLAGGEMS_USE_MUSA)
+  }
+#endif
 
-  at::Tensor ex_cumsum_bins = at::cumsum(global_hist, -1) - global_hist;
-  ex_cumsum_bins = ex_cumsum_bins.to(torch::kInt32);
+#if defined(FLAGGEMS_USE_MUSA)
+  // Long rows are dominated by the decoupled-lookback portion of sweep.  For
+  // these shapes, replace the per-bin CAS/spin chain with a compact
+  // per-tile histogram, a metadata-only prefix, and one scatter program per
+  // tile.  Keep the existing OneSweep path for short rows where the extra
+  // histogram/scan launches are more expensive than lookback.
+  if (use_hierarchical) {
+    at::Tensor arr_in = arr;
+    at::Tensor arr_out = at::empty_like(arr);
+    at::Tensor arr_scratch = at::empty_like(arr);
+    at::Tensor indices_in = at::empty_like(arr, arr.options().dtype(torch::kInt64));
+    at::Tensor indices_out = at::empty_like(arr, arr.options().dtype(torch::kInt64));
+    at::Tensor tile_hist =
+        at::empty({m, grid_n_hier, num_bins}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));
 
+    const TritonJITFunction& tile_hist_kernel =
+        TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / SORT_KERNEL_PATH),
+                                        "compute_tile_hist_kernel");
+    const TritonJITFunction& hierarchical_sweep_kernel =
+        TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / SORT_KERNEL_PATH),
+                                        "sweep_hierarchical_scatter");
+    const int32_t grid_n_hier_i32 = static_cast<int32_t>(grid_n_hier);
+    for (int64_t i = 0; i < n_passes; ++i) {
+      tile_hist_kernel(raw_stream,
+                       static_cast<unsigned int>(m),
+                       static_cast<unsigned int>(grid_n_hier),
+                       1,
+                       4,
+                       1,
+                       arr_in,
+                       tile_hist,
+                       static_cast<int32_t>(i),
+                       static_cast<int32_t>(i * k_bits),
+                       m_i32,
+                       n_i32,
+                       grid_n_hier_i32,
+                       TILE_N_HIER,
+                       k_bits,
+                       descending);
+      at::Tensor pass_hist = tile_hist.sum({1}, false).to(torch::kInt32);
+      at::Tensor pass_prefix = (at::cumsum(pass_hist, -1) - pass_hist).to(torch::kInt32);
+      ex_cumsum_bins.select(1, i).copy_(pass_prefix);
+      // The metadata is tiny compared with the payload.  Keep the scan in
+      // int32 (N is bounded below 2**30) so no 64-bit prefix reaches scatter.
+      at::Tensor tile_prefix = (at::cumsum(tile_hist, 1).to(torch::kInt32) - tile_hist).contiguous();
+      hierarchical_sweep_kernel(raw_stream,
+                                static_cast<unsigned int>(m),
+                                static_cast<unsigned int>(grid_n_hier),
+                                1,
+                                4,
+                                1,
+                                arr_in,
+                                indices_in,
+                                arr_out,
+                                indices_out,
+                                ex_cumsum_bins,
+                                tile_prefix,
+                                static_cast<int32_t>(n_passes),
+                                static_cast<int32_t>(i),
+                                static_cast<int32_t>(i * k_bits),
+                                m_i32,
+                                n_i32,
+                                grid_n_hier_i32,
+                                TILE_N_HIER,
+                                k_bits,
+                                descending,
+                                i == 0);
+      if (i == 0) {
+        arr_in = arr_out;
+        arr_out = arr_scratch;
+      } else if (i < n_passes - 1) {
+        std::swap(arr_in, arr_out);
+      } else {
+        // The last pass writes the opposite ping-pong buffer; expose it
+        // directly so no post-sort copy is needed.
+        arr_in = arr_out;
+      }
+      std::swap(indices_in, indices_out);
+    }
+    return std::make_tuple(arr_in, indices_in);
+  }
+
+  // Keep pass zero read-only with respect to the user input.  The sweep
+  // synthesizes its stable row offsets on pass zero, so this avoids both
+  // clone(arr) and arange().broadcast_to(...).contiguous().
+  at::Tensor arr_in = arr;
+  at::Tensor arr_out = at::empty_like(arr);
+  at::Tensor arr_scratch = at::empty_like(arr);
+
+  const auto index_dtype = use_compact_indices ? torch::kInt32 : torch::kInt64;
+  at::Tensor indices_out = at::empty_like(arr, arr.options().dtype(index_dtype));
+  at::Tensor indices_scratch = at::empty_like(arr, arr.options().dtype(index_dtype));
+  // Pass zero has a constexpr synthesize_indices flag and does not read this
+  // pointer.  It must nevertheless be valid: the C++ JIT's nullopt pointer
+  // ABI does not match Triton's removed-None pointer specialization.
+  at::Tensor indices_in = indices_out;
+  at::Tensor final_indices =
+      use_compact_indices ? at::empty_like(arr, arr.options().dtype(torch::kInt64)) : at::Tensor();
+#else
   at::Tensor arr_in = arr.clone();
   at::Tensor indices_in = at::arange(0, n, at::TensorOptions().dtype(torch::kInt64).device(arr.device()))
                               .broadcast_to(arr.sizes())
                               .contiguous();
   at::Tensor arr_out = at::empty_like(arr_in);
   at::Tensor indices_out = at::empty_like(indices_in);
+#endif
 
   const int64_t TILE_R_SWEEP = 8;
-  const int64_t TILE_N_SWEEP = 2048;
   int64_t grid_r_sweep = utils::cdiv(num_bins, TILE_R_SWEEP);
+#if !defined(FLAGGEMS_USE_MUSA)
+  const int64_t TILE_N_SWEEP = 2048;
   int64_t grid_n_sweep = utils::cdiv(n, TILE_N_SWEEP);
+#endif
+#if defined(FLAGGEMS_USE_MUSA)
+  const int32_t grid_n_sweep_i32 = static_cast<int32_t>(grid_n_sweep);
+#endif
 #if defined(FLAGGEMS_USE_GCU)
   int64_t total_tasks_sweep = m * grid_n_sweep;
   unsigned int grid_x_sweep = std::min(total_tasks_sweep, (int64_t)48);
@@ -266,6 +409,10 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
   for (int64_t i = 0; i < n_passes; ++i) {
     int64_t bit_offset = i * k_bits;
     status.zero_();
+#if defined(FLAGGEMS_USE_MUSA)
+    const at::Tensor& pass_indices_out =
+        (use_compact_indices && i == n_passes - 1) ? final_indices : indices_out;
+#endif
     sweep_kernel(raw_stream,
                  grid_x_sweep,
                  grid_y_sweep,
@@ -275,28 +422,76 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
                  arr_in,
                  indices_in,
                  arr_out,
+#if defined(FLAGGEMS_USE_MUSA)
+                 pass_indices_out,
+#else
                  indices_out,
+#endif
                  ex_cumsum_bins,
                  status,
+#if defined(FLAGGEMS_USE_MUSA)
+                 static_cast<int32_t>(n_passes),
+                 static_cast<int32_t>(i),
+                 static_cast<int32_t>(bit_offset),
+                 m_i32,
+                 n_i32,
+                 grid_n_sweep_i32,
+#else
                  n_passes,
                  i,
                  bit_offset,
                  m,
                  n,
                  grid_n_sweep,
+#endif
 #if defined(FLAGGEMS_USE_GCU)
                  total_tasks_sweep,
 #endif
                  TILE_N_SWEEP,
                  TILE_R_SWEEP,
                  k_bits,
+#if defined(FLAGGEMS_USE_MUSA)
+                 descending,
+                 i == 0);
+#else
                  descending);
+#endif
 
+#if defined(FLAGGEMS_USE_MUSA)
+    if (i == 0) {
+      arr_in = arr_out;
+      arr_out = arr_scratch;
+      indices_in = indices_out;
+      std::swap(indices_out, indices_scratch);
+    } else if (i < n_passes - 1) {
+      at::Tensor recycled_arr = arr_in;
+      arr_in = arr_out;
+      arr_out = recycled_arr;
+      at::Tensor recycled_indices = indices_in;
+      indices_in = indices_out;
+      indices_out = recycled_indices;
+    } else {
+      at::Tensor last_input = arr_in;
+      arr_in = arr_out;
+      arr_out = last_input;
+    }
+#else
     std::swap(arr_in, arr_out);
     std::swap(indices_in, indices_out);
+#endif
   }
 
+#if defined(FLAGGEMS_USE_MUSA)
+  // The one-pass bool case takes the pass-zero transition above, which makes
+  // indices_in the written buffer and recycles indices_out.  Multi-pass
+  // OneSweep leaves the last written index buffer in indices_out; compact
+  // indices write their final pass directly to final_indices.
+  const at::Tensor& result_indices =
+      use_compact_indices ? final_indices : (n_passes == 1 ? indices_in : indices_out);
+  return std::make_tuple(arr_in, result_indices);
+#else
   return std::make_tuple(arr_in, indices_in);
+#endif
 #endif  // FLAGGEMS_USE_MLU
 }
 
@@ -322,6 +517,43 @@ std::tuple<at::Tensor, at::Tensor> sort_stable(const at::Tensor& inp,
   } else {
     contiguous_inp = inp.contiguous();
   }
+
+#if defined(FLAGGEMS_USE_MUSA)
+  const auto dtype = contiguous_inp.scalar_type();
+  const int64_t n = contiguous_inp.size(-1);
+  const int64_t m = contiguous_inp.numel() / n;
+  const int64_t local_limit = dtype == torch::kInt64 ? 512 : 1024;
+  if (dtype != torch::kBool && !c10::isFloatingType(dtype) && n <= local_limit) {
+    at::Tensor out = at::empty_like(contiguous_inp);
+    at::Tensor out_index = at::empty_like(contiguous_inp, contiguous_inp.options().dtype(torch::kInt64));
+    const TritonJITFunction& local_sort_kernel =
+        TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / SORT_KERNEL_PATH),
+                                        "sort_kernel");
+
+    c10::DeviceGuard guard(contiguous_inp.device());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
+    local_sort_kernel(raw_stream,
+                      m,
+                      1,
+                      1,
+                      4,
+                      1,
+                      contiguous_inp,
+                      out,
+                      out_index,
+                      n,
+                      utils::next_power_of_2(n),
+                      descending,
+                      false);
+
+    if (original_dim != ndim - 1) {
+      out = out.movedim(-1, original_dim);
+      out_index = out_index.movedim(-1, original_dim);
+    }
+    return std::make_tuple(out, out_index);
+  }
+#endif
 
   int64_t k_bits = (contiguous_inp.scalar_type() == torch::kBool) ? 1 : 4;
   auto [out, out_index] = radix_sort(contiguous_inp, k_bits, descending);

--- a/src/flag_gems/runtime/backend/_mthreads/ops/sort.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/sort.py
@@ -17,12 +17,108 @@ import logging
 import torch
 import triton
 import triton.language as tl
+import triton.language.core as core
 
-from flag_gems.ops.topk import _get_finfo_val, _get_iinfo_val, argsort
+from flag_gems.config import use_c_extension
+from flag_gems.ops.topk import _get_finfo_val, _get_iinfo_val, _log2, zeros_like
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _stable_compare_and_swap(x, ids, flip, i: core.constexpr, n_dims: core.constexpr):
+    """Bitonic compare/swap with original-index tie breaking.
+
+    `argsort`'s generic comparator swaps equal keys on descending phases,
+    which is valid for top-k but violates torch.sort(stable=True).  This local
+    variant always orders equal keys by their original index.
+    """
+    n_outer: core.constexpr = x.numel >> n_dims
+    shape: core.constexpr = [n_outer * 2**i, 2, 2 ** (n_dims - i - 1)]
+    y = core.reshape(x, shape)
+    y_idx = core.reshape(ids, shape)
+    lane = core.arange(0, 2)[None, :, None]
+
+    y_left = core.where(lane == 0, y, 0)
+    y_right = core.where(lane == 1, y, 0)
+    left = core.reshape(
+        core.broadcast_to(tl.sum(y_left, 1)[:, None, :], shape), x.shape
+    ).to(x.dtype)
+    right = core.reshape(
+        core.broadcast_to(tl.sum(y_right, 1)[:, None, :], shape), x.shape
+    ).to(x.dtype)
+
+    idx_left = core.where(lane == 0, y_idx, 0)
+    idx_right = core.where(lane == 1, y_idx, 0)
+    left_idx = core.reshape(
+        core.broadcast_to(tl.sum(idx_left, 1)[:, None, :], shape), ids.shape
+    ).to(ids.dtype)
+    right_idx = core.reshape(
+        core.broadcast_to(tl.sum(idx_right, 1)[:, None, :], shape), ids.shape
+    ).to(ids.dtype)
+
+    swap_ascending = (left > right) | ((left == right) & (left_idx > right_idx))
+    swap_descending = (left < right) | ((left == right) & (left_idx < right_idx))
+    swap = core.where(flip != 0, swap_descending, swap_ascending)
+
+    if core.constexpr(x.dtype.primitive_bitwidth) == 8:
+        value_type = core.int8
+    elif core.constexpr(x.dtype.primitive_bitwidth) == 16:
+        value_type = core.int16
+    elif core.constexpr(x.dtype.primitive_bitwidth) == 32:
+        value_type = core.int32
+    elif core.constexpr(x.dtype.primitive_bitwidth) == 64:
+        value_type = core.int64
+    else:
+        raise ValueError("Unsupported dtype")
+    value = x.to(value_type, bitcast=True)
+    value_left = left.to(value_type, bitcast=True)
+    value_right = right.to(value_type, bitcast=True)
+    result = value ^ core.where(swap, value_left ^ value_right, zeros_like(value))
+
+    if core.constexpr(ids.dtype.primitive_bitwidth) == 32:
+        index_type = core.int32
+    elif core.constexpr(ids.dtype.primitive_bitwidth) == 64:
+        index_type = core.int64
+    else:
+        raise ValueError("Unsupported index dtype")
+    index = ids.to(index_type, bitcast=True)
+    index_left = left_idx.to(index_type, bitcast=True)
+    index_right = right_idx.to(index_type, bitcast=True)
+    result_idx = index ^ core.where(swap, index_left ^ index_right, zeros_like(index))
+    return result.to(x.dtype, bitcast=True), result_idx.to(ids.dtype, bitcast=True)
+
+
+@triton.jit
+def _stable_bitonic_merge(
+    x, ids, stage: core.constexpr, order: core.constexpr, n_dims: core.constexpr
+):
+    if order == 2:
+        shape: core.constexpr = [
+            (x.numel >> n_dims) * 2 ** (n_dims - 1 - stage),
+            2,
+            2**stage,
+        ]
+        flip = core.reshape(
+            core.broadcast_to(core.arange(0, 2)[None, :, None], shape), x.shape
+        )
+    else:
+        flip = order
+    for i in core.static_range(stage):
+        x, ids = _stable_compare_and_swap(x, ids, flip, i + (n_dims - stage), n_dims)
+    return x, ids
+
+
+@triton.jit
+def stable_argsort(x, ids, dim: tl.constexpr, descending: tl.constexpr):
+    n_dims: core.constexpr = _log2(x.shape[dim])
+    for stage in core.static_range(1, n_dims + 1):
+        x, ids = _stable_bitonic_merge(
+            x, ids, stage, 2 if stage < n_dims else descending, n_dims
+        )
+    return x, ids
 
 
 def unwrap_if_constexpr(o):
@@ -134,31 +230,30 @@ def compute_global_hist_kernel(
 
     for p in range(0, num_passes):  # parallel
         bit_offset = p * num_bits_per_pass
-        for r_start in range(0, r, TILE_R):  # parallel
-            bin_indices = r_start + tl.arange(0, TILE_R)
-            acc = tl.zeros((TILE_R, TILE_N), dtype=tl.int64)
-            for n_start in range(cta_n_start, cta_n_end, TILE_N):  # sequantial
-                n_offsets = n_start + tl.arange(0, TILE_N)  # (TILE_N, )
-                mask = n_offsets < cta_n_end
-                arr = tl.load(arr_ptr + pid_m * n + n_offsets, mask=mask)
-                arr = convert_to_uint_preverse_order(arr, descending)
-                key = (arr >> bit_offset) & bfe_mask  # (TILE_N, )
-                matches = tl.where(
-                    mask, (bin_indices[:, None] == key), False
-                )  # (TILE_R, TILE_N)
-                acc += matches
-            local_sum = tl.sum(acc, axis=1)
-            tl.atomic_add(
-                out_ptr + pid_m * num_passes * r + p * r + bin_indices,
-                local_sum,
-                sem="relaxed",
-            )
+        bin_indices = tl.arange(0, r)
+        acc = tl.zeros((r,), dtype=tl.int32)
+        for n_start in range(cta_n_start, cta_n_end, TILE_N):  # sequential
+            n_offsets = n_start + tl.arange(0, TILE_N)
+            mask = n_offsets < cta_n_end
+            arr = tl.load(arr_ptr + pid_m * n + n_offsets, mask=mask)
+            arr = convert_to_uint_preverse_order(arr, descending)
+            # The C++ JIT ABI passes bit_offset as int64 while Python's launch
+            # specializes it as int32.  Keep the histogram input explicitly
+            # i32 so both launchers lower to the MUSA histogram primitive.
+            key = ((arr >> bit_offset) & bfe_mask).to(tl.int32)
+            key = tl.where(mask, key, 0)
+            acc += tl.histogram(key, r, mask=mask).to(tl.int32)
+        tl.atomic_add(
+            out_ptr + pid_m * num_passes * r + p * r + bin_indices,
+            acc,
+            sem="relaxed",
+        )
 
 
 @triton.jit
 def sweep(
     arr_ptr,
-    associate_arr_ptr,  # inputs: (key & value)
+    associate_arr_ptr,  # inputs: (key & value); always a valid workspace ptr
     out_ptr,
     associate_out_ptr,  # outputs: (key & value)
     excumsum_bins_ptr,
@@ -173,6 +268,7 @@ def sweep(
     TILE_R: tl.constexpr,
     k_bits: tl.constexpr,
     descending: tl.constexpr,
+    synthesize_indices: tl.constexpr,
 ):
     # r: num_bins = 2 ** k_bits
     # OUT_N: grid_n = cdiv(N, )
@@ -207,7 +303,12 @@ def sweep(
     arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
     arr_u = convert_to_uint_preverse_order(arr, descending)
     key = (arr_u >> bit_offset) & bfe_mask  # (TILE_N, )
-    if associate_arr_ptr is not None:
+    if synthesize_indices:
+        # The first stable radix pass starts from original row offsets.  Do
+        # not materialize arange().broadcast_to(...).contiguous(), and do not
+        # read the dummy index workspace passed by the C++ JIT ABI.
+        associate_arr = n_offsets
+    else:
         associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
 
     # since triton can only use scalar as condition, loop by bin_index
@@ -253,14 +354,179 @@ def sweep(
 
         # scatter
         tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
-        if associate_arr_ptr is not None:
-            tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
+        tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
+
+
+# Hierarchical 4-bit path: materialize the per-tile histogram, scan compact
+# metadata between kernels, then scatter from the resulting tile prefixes.
+@triton.jit
+def compute_tile_hist_kernel(
+    arr_ptr,
+    tile_hist_ptr,
+    pass_id,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    key = (convert_to_uint_preverse_order(arr, descending) >> bit_offset) & bfe_mask
+    key = tl.where(mask, key, 0).to(tl.int32)
+    counts = tl.histogram(key, r, mask=mask).to(tl.int32)
+    bins = tl.arange(0, r)
+    tl.store(tile_hist_ptr + (pid_m * OUT_N + pid_n) * r + bins, counts)
+
+
+@triton.jit
+def sweep_hierarchical_scatter(
+    arr_ptr,
+    associate_arr_ptr,
+    out_ptr,
+    associate_out_ptr,
+    excumsum_bins_ptr,
+    tile_prefix_ptr,
+    n_passes,
+    pass_id,
+    bit_offset,
+    m,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+    synthesize_indices: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    key = (convert_to_uint_preverse_order(arr, descending) >> bit_offset) & bfe_mask
+    if synthesize_indices:
+        associate_arr = n_offsets
+    else:
+        associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
+
+    # One program owns every bin for a tile.  arr/key/index remain live once;
+    # only the per-bin predicate and local scan are recomputed.
+    for bin_index in range(0, r):
+        matches = tl.where(mask, key == bin_index, False)
+        local_exclusive = tl.cumsum(matches.to(tl.uint32), axis=0) - matches
+        tile_prefix = tl.load(tile_prefix_ptr + (pid_m * OUT_N + pid_n) * r + bin_index)
+        global_bin_base = tl.load(
+            excumsum_bins_ptr + pid_m * (n_passes * r) + pass_id * r + bin_index
+        )
+        pos = global_bin_base + tile_prefix + local_exclusive
+        tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
+        tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
+
+
+def radix_sort_hierarchical(arr, k_bits=4, descending=False):
+    """Hierarchical stable radix path with no lookback/status dependency."""
+    n = arr.shape[-1]
+    m = arr.numel() // n
+    dtype = arr.dtype
+    num_bits = 1 if dtype == torch.bool else arr.itemsize * 8
+    num_bins = 2**k_bits
+    n_passes = triton.cdiv(num_bits, k_bits)
+    tile_n = 2048
+    grid_n = triton.cdiv(n, tile_n)
+    with torch_device_fn.device(arr.device):
+        # Match the production C++ path: each pass derives its global bin
+        # prefix from tile metadata, avoiding a separate full-array histogram.
+        ex_cumsum_bins = torch.empty(
+            (m, n_passes, num_bins), device=arr.device, dtype=torch.int32
+        )
+        arr_in = arr
+        arr_out = torch.empty_like(arr)
+        arr_scratch = torch.empty_like(arr)
+        idx_in = torch.empty_like(arr, dtype=torch.int64)
+        idx_out = torch.empty_like(arr, dtype=torch.int64)
+        tile_hist = torch.empty(
+            (m, grid_n, num_bins), device=arr.device, dtype=torch.int32
+        )
+        for i in range(n_passes):
+            compute_tile_hist_kernel[(m, grid_n)](
+                arr_in,
+                tile_hist,
+                i,
+                i * k_bits,
+                m,
+                n,
+                grid_n,
+                tile_n,
+                k_bits,
+                descending,
+            )
+            pass_hist = tile_hist.sum(1, dtype=torch.int32)
+            ex_cumsum_bins[:, i].copy_(
+                torch.cumsum(pass_hist, -1, dtype=torch.int32) - pass_hist
+            )
+            # int32 is sufficient: every tile prefix is bounded by N < 2**30.
+            tile_prefix = (
+                torch.cumsum(tile_hist, 1, dtype=torch.int32) - tile_hist
+            ).contiguous()
+            sweep_hierarchical_scatter[(m, grid_n)](
+                arr_in,
+                idx_in,
+                arr_out,
+                idx_out,
+                ex_cumsum_bins,
+                tile_prefix,
+                n_passes,
+                i,
+                i * k_bits,
+                m,
+                n,
+                grid_n,
+                tile_n,
+                k_bits,
+                descending,
+                i == 0,
+            )
+            if i == 0:
+                arr_in, arr_out = arr_out, arr_scratch
+            else:
+                arr_in, arr_out = arr_out, arr_in
+            idx_in, idx_out = idx_out, idx_in
+    return arr_in, idx_in
 
 
 def radix_sort(arr, k_bits=8, descending=False):
     n = arr.shape[-1]
     m = arr.numel() // n
     assert n < (1 << 30), "we have not implemented 2**30 per launch"
+    # Keep safety and performance routing separate.  Decoupled lookback can
+    # deadlock beyond the #5978 dependency depth of 32 1024-element tiles.
+    # This OneSweep uses 2048-element tiles, so grid_n_sweep > 16 is the
+    # equivalent cross-CTA dependency region.  Shorter rows use hierarchy
+    # only at the measured crossover.
+    grid_n_hier = (n + 2047) // 2048
+    grid_n_sweep = (n + 2047) // 2048
+    must_use_safe_hierarchical = (
+        k_bits == 4 and arr.dtype != torch.bool and grid_n_sweep > 16
+    )
+    performance_use_hierarchical = (
+        k_bits == 4
+        and arr.dtype != torch.bool
+        and grid_n_hier >= 2
+        and (m >= 1024 or (grid_n_hier >= 4 and m >= 64))
+    )
+    if arr.device.type == "musa" and (
+        must_use_safe_hierarchical or performance_use_hierarchical
+    ):
+        return radix_sort_hierarchical(arr, k_bits, descending)
     dtype = arr.dtype
     num_bits = 1 if dtype == torch.bool else (arr.itemsize * 8)
 
@@ -294,15 +560,24 @@ def radix_sort(arr, k_bits=8, descending=False):
         ex_cumsum_bins = torch.cumsum(global_hist, -1) - global_hist
         ex_cumsum_bins = ex_cumsum_bins.to(torch.int32)
 
-        # sort
-        arr_in = torch.clone(arr)
-        indices_in = (
-            torch.arange(0, n, dtype=torch.int64, device=arr_in.device)
-            .broadcast_to(arr.shape)
-            .contiguous()
-        )
+        # Pass zero reads the user tensor directly and writes workspace A;
+        # later passes ping-pong A/B, so the input is never used as output.
+        arr_in = arr
         arr_out = torch.empty_like(arr)
-        indices_out = torch.empty_like(indices_in)
+        arr_scratch = torch.empty_like(arr)
+        # N is bounded below 2**30.  The compact payload wins on many short
+        # rows; retain the measured int64 path for fewer, longer rows.
+        use_compact_indices = m >= 512 and n <= 2048
+        index_dtype = torch.int32 if use_compact_indices else torch.int64
+        indices_out = torch.empty_like(arr, dtype=index_dtype)
+        indices_scratch = torch.empty_like(arr, dtype=index_dtype)
+        # The first pass never reads this pointer (synthesize_indices=True),
+        # but keeping it valid gives Python and C++ JIT launchers an identical
+        # physical ABI.
+        indices_in = indices_out
+        final_indices = (
+            torch.empty_like(arr, dtype=torch.int64) if use_compact_indices else None
+        )
 
         TILE_R = 8
         grid_r = triton.cdiv(num_bins, TILE_R)
@@ -317,11 +592,16 @@ def radix_sort(arr, k_bits=8, descending=False):
         for i in range(0, n_passes):
             bit_offset = i * k_bits
             status.zero_()
+            pass_indices_out = (
+                final_indices
+                if use_compact_indices and i == n_passes - 1
+                else indices_out
+            )
             sweep[grid_for_sweep](
                 arr_in,
                 indices_in,
                 arr_out,
-                indices_out,
+                pass_indices_out,
                 ex_cumsum_bins,
                 status,
                 n_passes,
@@ -334,12 +614,27 @@ def radix_sort(arr, k_bits=8, descending=False):
                 TILE_R,
                 k_bits,
                 descending,
+                i == 0,
             )
             # print(f"< sorted last {bit_offset + k_bits:>2d} bits: {arr_out}")
-            arr_in, arr_out = arr_out, arr_in
-            indices_in, indices_out = indices_out, indices_in
+            if i == 0:
+                arr_in, arr_out = arr_out, arr_scratch
+                indices_in, indices_out = indices_out, indices_scratch
+            elif i < n_passes - 1:
+                arr_in, arr_out = arr_out, arr_in
+                indices_in, indices_out = indices_out, indices_in
+            else:
+                arr_in, arr_out = arr_out, arr_in
 
-    return arr_in, indices_in
+    # Pass zero recycles indices_out.  For bool's one-pass radix sort, the
+    # written output is therefore indices_in; multi-pass paths leave their
+    # final written index buffer in indices_out.
+    result_indices = (
+        final_indices
+        if use_compact_indices
+        else (indices_in if n_passes == 1 else indices_out)
+    )
+    return arr_in, result_indices
 
 
 @libentry()
@@ -368,22 +663,39 @@ def sort_kernel(
         in_val = tl.load(in_ptr, mask=mask, other=mask_val)
 
     index_val = tl.arange(0, BLOCK_SIZE)
+    # Bitonic's descending phases must reverse the complete comparison key.
+    # Encode the user-visible ascending tie-break in the payload so the final
+    # full reverse still returns equal values in original-index order.
+    if DESCENDING:
+        index_val = BLOCK_SIZE - 1 - index_val
 
-    sorted_in_val, sorted_index_val = argsort(
+    sorted_in_val, sorted_index_val = stable_argsort(
         in_val, index_val, 0, descending=DESCENDING
     )
     tl.store(out_ptr, sorted_in_val, mask=mask)
+    if DESCENDING:
+        sorted_index_val = BLOCK_SIZE - 1 - sorted_index_val
     tl.store(out_index_ptr, sorted_index_val, mask=mask)
 
 
 def sort(inp, dim=-1, descending=False):
     # We only implement stable radix sort here
     logger.debug("GEMS_MTHREADS SORT")
+    if use_c_extension:
+        # The native extension exposes the production MUSA implementation in
+        # the flag_gems namespace.  Route the backend override through it when
+        # installed; the pure-Python path remains the fallback for source
+        # checkouts and non-C++ builds.
+        return torch.ops.flag_gems.sort(inp, dim, descending)
     return sort_stable(inp, stable=False, dim=dim, descending=descending)
 
 
 def sort_stable(inp, *, stable, dim=-1, descending=False):
     logger.debug("GEMS_MTHREADS SORT_STABLE")
+    if use_c_extension:
+        return torch.ops.flag_gems.sort.stable(
+            inp, stable=stable, dim=dim, descending=descending
+        )
     # We only implement stable radix sort here
     _ = stable
     sort_elem_cnt = inp.shape[dim]
@@ -398,6 +710,34 @@ def sort_stable(inp, *, stable, dim=-1, descending=False):
         inp = inp.contiguous()
 
     dtype = inp.dtype
+    # The OneSweep path has a fixed multi-kernel setup cost.  Keep this first
+    # local path integer-only until floating-point NaN ordering has its own
+    # validation and comparator implementation.
+    local_limit = 512 if dtype == torch.int64 else 1024
+    if (
+        dtype != torch.bool
+        and not dtype.is_floating_point
+        and sort_elem_cnt <= local_limit
+    ):
+        block_size = triton.next_power_of_2(sort_elem_cnt)
+        m = inp.numel() // sort_elem_cnt
+        out = torch.empty_like(inp)
+        out_index = torch.empty_like(inp, dtype=torch.int64)
+        sort_kernel[(m,)](
+            inp,
+            out,
+            out_index,
+            sort_elem_cnt,
+            block_size,
+            descending,
+            False,
+            num_warps=4,
+        )
+        if dim != inp.ndim - 1:
+            out = torch.movedim(out, -1, dim)
+            out_index = torch.movedim(out_index, -1, dim)
+        return out, out_index
+
     num_bits_per_pass = 1 if dtype == torch.bool else 4
     out, out_index = radix_sort(inp, num_bits_per_pass, descending)
 


### PR DESCRIPTION
## Summary

Optimize MTHREADS `torch.sort` / `torch.sort(stable=True)` with a stable local path, a clone-free radix pipeline, and an ordered long-row route that avoids OneSweep lookback deadlock.

## Bottlenecks

- full int64 index materialization
- input clone
- expensive histogram work
- duplicated tile payload loads
- long-row lookback/CAS/spin

## Optimization

- stable local bitonic for eligible small integer rows
- synthesize original indices in radix pass zero
- remove input clone and index materialization
- use `tl.histogram`
- selectively use int32 intermediate indices
- hierarchical tile-prefix stable scatter
- no lookback/CAS/spin on long rows
- route production C++ through the optimized kernels

## Routing

```text
Small integer                 → stable bitonic
Deadlock-risk/profitable row  → 4-bit hierarchical radix
Other rows                    → 4-bit OneSweep
```

The mandatory safety route is non-bool 4-bit radix with `grid_n_sweep > 16`. With the current 2048-element OneSweep tile, this is the same cross-CTA dependency depth as PR #5978's `grid_n > 32` at 1024 elements. The independent performance gate remains for shorter rows.

## Performance

Recorded MTT S5000 `sort_stable` results (ms):

| dtype | shape | Torch | Original MTHREADS | Final MTHREADS | Speedup |
|---|---:|---:|---:|---:|---:|
| FP32 | 4096×4096 | 5.245 | 146.976 | 19.807 | 7.42× |
| FP32 | 1024×65536 | 31.320 | 666.546 | 75.488 | 8.83× |
| INT32 | 4096×4096 | 5.342 | 44.354 | 20.806 | 2.13× |
| INT32 | 1024×65536 | 34.422 | 249.929 | 79.571 | 3.14× |
| FP16 | 1024×65536 | 13.253 | 124.496 | 40.288 | 3.09× |
| BF16 | 1024×65536 | 13.252 | 115.408 | 37.377 | 3.09× |

## Validation

Recorded MTT S5000 validation covered exact values/indices, stable duplicates, NaN/±0/±inf, non-contiguous layouts, input preservation, and C++ production dispatch. The post-safety-gate C++ MUSA long-row stress rerun is required before merge.

## Scope

- `cpp/lib/sort.cpp`
- `src/flag_gems/runtime/backend/_mthreads/ops/sort.py`

Tests and benchmarks are unchanged.
