### PR TITLE
fix(testing): let assert_close accept an explicit rtol

### DIFF
--- a/src/flag_gems/testing/__init__.py
+++ b/src/flag_gems/testing/__init__.py
@@ -77,13 +77,14 @@ def _maybe_move_to_cpu(res, ref):
     return res, ref
 
 
-def assert_close(res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4):
+def assert_close(res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4, rtol=None):
     if dtype is None:
         dtype = torch.float32
     assert res.dtype == dtype
     ref = ref.to(dtype)
     res, ref = _maybe_move_to_cpu(res, ref)
-    rtol = RESOLUTION[dtype]
+    if rtol is None:
+        rtol = RESOLUTION[dtype]
     torch.testing.assert_close(
         res, ref, atol=atol * reduce_dim, rtol=rtol, equal_nan=equal_nan
     )

--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -309,10 +309,18 @@ def to_cpu(res, ref):
     return res
 
 
-def gems_assert_close(res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4):
+def gems_assert_close(
+    res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4, rtol=None
+):
     res = to_cpu(res, ref)
     flag_gems.testing.assert_close(
-        res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim, atol=atol
+        res,
+        ref,
+        dtype,
+        equal_nan=equal_nan,
+        reduce_dim=reduce_dim,
+        atol=atol,
+        rtol=rtol,
     )
 
 


### PR DESCRIPTION
## Description

`tests/test_fp8_paged_mqa_logits_ops.py` passes `rtol=1e-3` to `gems_assert_close` in both of its comparisons:

```python
# tests/test_fp8_paged_mqa_logits_ops.py:193 and :286
gems_assert_close(
    res_out_masked,
    ref_out_masked,
    res_out_masked.dtype,
    equal_nan=True,
    atol=5e-2,
    rtol=1e-3,
    reduce_dim=1,
)
```

Neither helper in the chain accepts `rtol`, and neither takes `**kwargs`:

```python
# tests/accuracy_utils.py:312
def gems_assert_close(res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4):

# src/flag_gems/testing/__init__.py:80
def assert_close(res, ref, dtype, equal_nan=False, reduce_dim=1, atol=1e-4):
    ...
    rtol = RESOLUTION[dtype]
```

so both call sites raise before comparing anything:

```
TypeError: gems_assert_close() got an unexpected keyword argument 'rtol'
```

These two tests are gated behind `torch.cuda.is_available()`, DeepGEMM and SM90/SM100, so the failure only surfaces on the hardware that actually runs them.

## Fix

Thread an optional `rtol` through both helpers instead of dropping the argument at the call sites. Dropping it would not be equivalent: `res_out_masked` is `float32` here, and `RESOLUTION[torch.float32]` is `1.3e-6` — roughly 800x tighter than the `1e-3` the test asks for — so removing the kwarg would replace a `TypeError` with a spurious tolerance failure.

`rtol=None` keeps the existing `RESOLUTION[dtype]` behaviour, so every current caller is unaffected.

## Verification

`torch.testing.assert_close` is pure CPU here, so this is checkable without a GPU. Extracted `assert_close` from the upstream and patched files with `ast`, stubbed `_maybe_move_to_cpu`, and replayed the exact call shape used by the two failing tests:

```
== BEFORE (upstream master) (res, ref, dtype, equal_nan=False, reduce_dim=1, atol=0.0001)
   call with rtol=1e-3 : TypeError: assert_close() got an unexpected keyword argument 'rtol'
   call without rtol   : OK (default RESOLUTION path preserved)
== AFTER  (patched) (res, ref, dtype, equal_nan=False, reduce_dim=1, atol=0.0001, rtol=None)
   call with rtol=1e-3 : OK
   call without rtol   : OK (default RESOLUTION path preserved)
```

And a check that the new argument is actually honoured rather than swallowed — comparing `1.0` against `1.02` (2e-2 relative error) with `atol=0.0`:

```
   rtol=0.001: assertion (correctly fails)
   rtol=0.05 : passed    (correctly passes)
```

`black 26.5.1` reports both files clean; no imports were touched, so `isort --profile black` is unaffected; longest new line is 88 chars, well under the flake8 `--max-line-length=120`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
