### PR TITLE
fix(enflame/gcu400): call copy_ with the canonical (dst, src) signature

### DIFF
--- a/src/flag_gems/runtime/backend/_enflame/gcu400/ops/contiguous.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu400/ops/contiguous.py
@@ -27,4 +27,4 @@ def contiguous(inp, memory_format=torch.contiguous_format):
     if inp.is_contiguous(memory_format=memory_format):
         return inp
     out = torch.empty_like(inp, memory_format=memory_format)
-    return copy_(inp, out0=out)
+    return copy_(out, inp)


### PR DESCRIPTION
## Description

`contiguous()` on the Enflame gcu400 backend crashes on any non-contiguous input:

```python
# src/flag_gems/runtime/backend/_enflame/gcu400/ops/contiguous.py
from .copy import copy_
...
    out = torch.empty_like(inp, memory_format=memory_format)
    return copy_(inp, out0=out)
```

but `copy_` in `_enflame/gcu400/ops/copy.py` is the ordinary in-place helper, not a `pointwise_dynamic` kernel:

```python
def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
```

so the call raises:

```
TypeError: copy_() missing a required argument: 'src'
```

`out0=` is the gcu300 spelling, where `copy` really is a `@pointwise_dynamic` kernel (`_enflame/gcu300/ops/copy.py:22`, `def copy(src)`). gcu400's `copy.py` is otherwise a straight port of `flag_gems/ops/copy.py` — the only differences are the `pointwise_dynamic` import path and three `logger.debug` strings — but `contiguous.py` was left on the old call form.

`contiguous` is exported by that backend (`_enflame/gcu400/ops/__init__.py:76`, and listed in `__all__` at :393), so this is on the live dispatch path.

## Fix

Use the same call the canonical implementation and the cambricon backend already use:

```python
# src/flag_gems/ops/contiguous.py:30
# src/flag_gems/runtime/backend/_cambricon/ops/contiguous.py:30
    return copy_(out, inp)
```

Note this also corrects the argument order: `out` is the destination, `inp` the source.

## Verification

No Enflame hardware needed — the failure is argument binding. Reconstructed gcu400's real `copy_` signature from master with `ast` and replayed both call shapes:

```
gcu400 copy_ SIGNATURE: (dst, src, non_blocking=None)
FAIL  gcu400 contiguous.py:30   copy_(inp, out0=out)  -> TypeError: missing a required argument: 'src'
OK    canonical ops/contiguous.py:30  copy_(out, inp)
```

`black 26.5.1` reports the file unchanged; no imports touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
