### PR TITLE
fix(sunrise): let amax write into a caller-provided out tensor

### DIFF
--- a/src/flag_gems/runtime/backend/_sunrise/ops/amax.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/amax.py
@@ -82,7 +82,7 @@ def amax_kernel(
     tl.store(out, all, row_mask)
 
 
-def amax(inp, dim=None, keepdim=False):
+def amax(inp, dim=None, keepdim=False, *, out=None):
     logger.debug("GEMS AMAX")
     if dim is None or len(dim) == 0:
         M = inp.numel()
@@ -91,13 +91,14 @@ def amax(inp, dim=None, keepdim=False):
         block_mid = triton.next_power_of_2(mid_size)
         dtype = inp.dtype
         mid = torch.empty((mid_size,), dtype=dtype, device=inp.device)
-        if not keepdim:
-            out = torch.empty([], dtype=dtype, device=inp.device)
-        else:
-            shape = list(inp.shape)
-            for i in range(0, inp.dim()):
-                shape[i] = 1
-            out = torch.empty(shape, dtype=dtype, device=inp.device)
+        if out is None:
+            if not keepdim:
+                out = torch.empty([], dtype=dtype, device=inp.device)
+            else:
+                shape = list(inp.shape)
+                for i in range(0, inp.dim()):
+                    shape[i] = 1
+                out = torch.empty(shape, dtype=dtype, device=inp.device)
         with torch_device_fn.device(inp.device):
             amax_kernel_1[(mid_size, 1)](
                 inp,
@@ -124,12 +125,14 @@ def amax(inp, dim=None, keepdim=False):
             shape[i] = 1
         M = inp.numel() // N
 
-        out = torch.empty(shape, dtype=dtype, device=inp.device)
+        out_provided = out is not None
+        if out is None:
+            out = torch.empty(shape, dtype=dtype, device=inp.device)
 
         grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
         with torch_device_fn.device(inp.device):
             amax_kernel[grid](inp, out, M, N)
-        if not keepdim:
+        if not keepdim and not out_provided:
             out = out.squeeze(dim=dim)
         return out
 


### PR DESCRIPTION
## Description

`amax_out` is registered as the `amax.out` aten overload for the sunrise backend:

```python
# src/flag_gems/runtime/backend/_sunrise/__init__.py:178
        ("amax.out", amax_out),
```

and it forwards `out=` down to `amax`:

```python
# src/flag_gems/runtime/backend/_sunrise/ops/amax.py:137
def amax_out(inp, dim=None, keepdim=False, *, out=None):
    ...
    return amax(inp, dim=dim, keepdim=keepdim, out=out)
```

but `amax` does not take it:

```python
# same file, :85
def amax(inp, dim=None, keepdim=False):
```

so every `torch.amax(..., out=...)` dispatched to this backend raises:

```
TypeError: amax() got an unexpected keyword argument 'out'
```

The two sibling reductions in the same directory are the spec here — both accept `out` and both are called by their `_out` wrapper in exactly the same way:

| op | signature | `_out` wrapper works |
|---|---|---|
| `_sunrise/ops/amin.py:85` | `def amin(inp, dim=None, keepdim=False, *, out=None)` | yes |
| `_sunrise/ops/aminmax.py:123` | `def aminmax(inp, dim=None, keepdim=False, *, out=None)` | yes |
| `_sunrise/ops/amax.py:85` | `def amax(inp, dim=None, keepdim=False)` | **no** |

## Fix

Port `amin`'s `out` handling verbatim into `amax`:

- accept a keyword-only `out=None`;
- in the full-reduction branch, only allocate when `out is None`;
- in the dim branch, remember `out_provided` and skip the trailing `squeeze` for a caller-supplied buffer (squeezing it would return a different tensor than the one the caller passed, breaking the `.out` contract).

After the patch, the only remaining differences between `amax.py` and `amin.py` are the min/max kernel math, the log string, and two pre-existing divergences I have deliberately **not** touched here (`amin` guards `len(dim)` with `not isinstance(dim, int)`, and its dim assertion uses `assert all(...)` where `amax` asserts a generator).

## Verification

The Triton kernels need hardware, but the `out` plumbing does not. Loaded `amax`/`amax_out` out of both the upstream and the patched file with `ast`, substituted the three kernel launches with real `torch` reductions of the same shape contract, and ran the exact `amax.out` call:

```
== BEFORE (upstream master) (inp, dim=None, keepdim=False)
   amax_out(dim=[1], out=y) -> TypeError: amax() got an unexpected keyword argument 'out'
   amax(dim=[1], keepdim=True) -> [7.0, 9.0]
   amax(dim=None)              -> [9.0]
== AFTER  (patched) (inp, dim=None, keepdim=False, *, out=None)
   amax_out(dim=[1], out=y) -> [7.0, 9.0] | wrote into y: [7.0, 9.0] | same object: True
   amax(dim=[1], keepdim=True) -> [7.0, 9.0]
   amax(dim=None)              -> [9.0]
   torch reference             -> [7.0, 9.0]  9.0
```

So the failure is gone, the result is written into the caller's tensor and that tensor is returned, and both no-`out` paths are byte-for-byte unchanged and agree with `torch`.

`black 26.5.1` reports the file unchanged; no imports touched; longest line is well under the flake8 `--max-line-length=120`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
