### PR TITLE
feat(pt2): add torch.compile support for FlagGems kernels used by vLLM 0.24

### DIFF
--- a/src/flag_gems/fused/fused_add_rms_norm.py
+++ b/src/flag_gems/fused/fused_add_rms_norm.py
@@ -20,7 +20,7 @@ import triton.language as tl
 
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
-from flag_gems.utils import triton_lang_extension as ext
+from flag_gems.utils.triton_lang_extension import program_id
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ def fused_add_rms_norm_kernel(
     else:
         cdtype = input_ptr.dtype.element_ty
 
-    pid = ext.program_id(0)
+    pid = program_id(0)
     input_ptr += pid * in_stride_r
     residual_ptr += pid * r_stride_r
 
@@ -85,7 +85,7 @@ def fused_add_rms_norm_loop_kernel(
     else:
         cdtype = input_ptr.dtype.element_ty
 
-    pid = ext.program_id(0)
+    pid = program_id(0)
     row_start = pid * N
 
     # Pass 1: add residual and compute variance

--- a/src/flag_gems/fused/rotary_embedding.py
+++ b/src/flag_gems/fused/rotary_embedding.py
@@ -21,7 +21,7 @@ import triton.language as tl
 
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
-from flag_gems.utils import triton_lang_extension as ext
+from flag_gems.utils.triton_lang_extension import program_id
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ def apply_rotary_pos_emb_kernel(
     ROTARY_INTERLEAVED: tl.constexpr,
     MAX_POSITION_EMBEDDINGS: tl.constexpr,
 ):
-    s_id = ext.program_id(0)
+    s_id = program_id(0)
 
     if pos_ptr is None:
         pos_id = s_id % seq_len
@@ -140,7 +140,7 @@ def apply_rotary_pos_emb_inplace_kernel(
     ROTARY_INTERLEAVED: tl.constexpr,
     MAX_POSITION_EMBEDDINGS: tl.constexpr,
 ):
-    s_id = ext.program_id(0)
+    s_id = program_id(0)
 
     if pos_ptr is None:
         pos_id = s_id % seq_len

--- a/src/flag_gems/modules/activation.py
+++ b/src/flag_gems/modules/activation.py
@@ -33,8 +33,11 @@ def gems_silu_and_mul(
     x: torch.Tensor,
     y: torch.Tensor,
 ) -> torch.Tensor:
-    logger.debug("GEMS CUSTOM SILU_AND_MUL FORWARD")
-    # TODO: Implement C++ wrapper for silu_and_mul
+
+    # NOTE: Dynamo cannot trace logging.Logger methods
+    # (torch._dynamo.exc.Unsupported 'logging.Logger method not supported
+    # for non-export cases'), so this entry point must not log.
+    # Debug-only removal; numerics/control flow unchanged.
     return flag_gems.silu_and_mul(x, y)
 
 

--- a/src/flag_gems/modules/normalization.py
+++ b/src/flag_gems/modules/normalization.py
@@ -47,23 +47,24 @@ __all__ = [
 def gems_rms_forward(
     x: torch.Tensor, residual: Optional[torch.Tensor], weight: torch.Tensor, eps: float
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+
+    # NOTE: Dynamo cannot trace logging.Logger methods
+    # (torch._dynamo.exc.Unsupported 'logging.Logger method not supported
+    # for non-export cases'), so this entry point must not log.
+    # Debug-only removal; numerics/control flow unchanged.
     add_residual = residual is not None
     if add_residual:
         if use_c_extension:
-            logger.debug("GEMS CUSTOM FUSED_ADD_RMS_NORM(C EXTENSION)")
             torch.ops.flag_gems.fused_add_rms_norm(x, residual, weight, eps)
             return x, residual
         else:
-            logger.debug("GEMS CUSTOM FUSED_ADD_RMS_NORM")
             return flag_gems.fused_add_rms_norm(
                 x, residual, list(weight.size()), weight, eps
             )
     else:
         if use_c_extension:
-            logger.debug("GEMS CUSTOM RMS_NORM(C EXTENSION)")
             return torch.ops.flag_gems.rms_norm(x, weight, eps)
         else:
-            logger.debug("GEMS CUSTOM RMS_NORM")
             return flag_gems.rms_norm(x, list(weight.size()), weight, eps)
 
 

--- a/src/flag_gems/modules/rotary_embedding.py
+++ b/src/flag_gems/modules/rotary_embedding.py
@@ -42,8 +42,11 @@ def gems_rope_forward(
     rotary_interleaved: bool = False,
     inplace: bool = False,
 ) -> Union[torch.Tensor, torch.Tensor]:
+    # NOTE: Dynamo cannot trace logging.Logger methods
+    # (torch._dynamo.exc.Unsupported "logging.Logger method not supported
+    # for non-export cases"), so this entry point must not log.
+    # Debug-only removal; numerics/control flow unchanged.
     if use_c_extension:
-        logger.debug("GEMS CUSTOM ROPE FORWARD(C EXTENSION)")
         if inplace:
             torch.ops.flag_gems.rotary_embedding_inplace(
                 query, key, cos, sin, position_ids, rotary_interleaved
@@ -54,7 +57,6 @@ def gems_rope_forward(
                 query, key, cos, sin, position_ids, rotary_interleaved
             )
     else:
-        logger.debug("GEMS CUSTOM ROPE FORWARD")
         # Fallback to pure python implementation
         return flag_gems.apply_rotary_pos_emb(
             query, key, cos, sin, position_ids, rotary_interleaved, inplace

--- a/src/flag_gems/ops/rms_norm.py
+++ b/src/flag_gems/ops/rms_norm.py
@@ -22,7 +22,7 @@ import triton.language as tl
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
-from flag_gems.utils import triton_lang_extension as ext
+from flag_gems.utils.triton_lang_extension import program_id
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ def rms_norm_loop_kernel(
     else:
         cdtype = in_ptr.dtype.element_ty
 
-    pid = ext.program_id(0)
+    pid = program_id(0)
 
     # Pass 1: compute sum(x^2) in chunks
     acc = tl.zeros((TILE_N,), dtype=tl.float32)
@@ -167,7 +167,7 @@ def rms_norm_grad_dx_loop_kernel(
     eps,  # epsilon to avoid division by zero
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = ext.program_id(0)
+    pid = program_id(0)
     DX += pid * dx_stride_r
     X += pid * x_stride_r
     DY += pid * x_stride_r
@@ -219,7 +219,7 @@ def rms_norm_grad_dx_kernel(
     eps,  # epsilon to avoid division by zero
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = ext.program_id(0)
+    pid = program_id(0)
     DX += pid * dx_stride_r
     X += pid * x_stride_r
     DY += pid * x_stride_r

--- a/src/flag_gems/pt2/__init__.py
+++ b/src/flag_gems/pt2/__init__.py
@@ -1,0 +1,115 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Pure-Python PyTorch compiler integration for existing FlagGems kernels."""
+
+from flag_gems.pt2.fused_moe import (
+    MOE_SUM_SPEC,
+    TOPK_SOFTMAX_SPEC,
+    moe_sum,
+    supports_pt2_fused_moe,
+    topk_softmax,
+)
+from flag_gems.pt2.manifest import (
+    CompileKind,
+    CompileOpSpec,
+    get_compile_manifest,
+    get_compile_spec,
+)
+from flag_gems.pt2.mhc import (
+    HC_HEAD_FUSED_SPEC,
+    MHC_POST_SPEC,
+    MHC_PRE_SPEC,
+    hc_head_fused_kernel,
+    mhc_post,
+    mhc_pre,
+)
+from flag_gems.pt2.moe_routing import (
+    GROUPED_TOPK_SPEC,
+    TOPK_HASH_SOFTPLUS_SQRT_SPEC,
+    TOPK_SOFTPLUS_SQRT_SPEC,
+    grouped_topk,
+    supports_pt2_moe_routing,
+    topk_softplus_sqrt,
+    uses_common_moe_routing_kernels,
+)
+from flag_gems.pt2.pointwise_dynamic import (
+    ACTIVATION_POINTWISE_FAMILIES,
+    GELU_AND_MUL_POINTWISE_SPEC,
+    SILU_AND_MUL_POINTWISE_SPEC,
+    SILU_AND_MUL_WITH_CLAMP_POINTWISE_SPEC,
+    PointwiseFamilySpec,
+    PointwisePlan,
+    gelu_and_mul_pointwise,
+    materialize_gelu_and_mul_plan,
+    materialize_pointwise_family_plans,
+    materialize_pointwise_plan,
+    materialize_silu_and_mul_plan,
+    materialize_silu_and_mul_with_clamp_plan,
+    materialized_pointwise_plans,
+    silu_and_mul_pointwise,
+    silu_and_mul_with_clamp_pointwise,
+)
+from flag_gems.pt2.rms_norm import (
+    FUSED_ADD_RMS_NORM_SPEC,
+    RMS_NORM_SPEC,
+    rms_norm,
+    supports_pt2_rms_norm,
+)
+from flag_gems.pt2.rotary_embedding import (
+    ROTARY_EMBEDDING_INPLACE_SPEC,
+    rotary_embedding_inplace,
+    supports_pt2_triton,
+)
+
+__all__ = [
+    "ACTIVATION_POINTWISE_FAMILIES",
+    "CompileKind",
+    "CompileOpSpec",
+    "GELU_AND_MUL_POINTWISE_SPEC",
+    "GROUPED_TOPK_SPEC",
+    "FUSED_ADD_RMS_NORM_SPEC",
+    "HC_HEAD_FUSED_SPEC",
+    "MHC_POST_SPEC",
+    "MHC_PRE_SPEC",
+    "MOE_SUM_SPEC",
+    "ROTARY_EMBEDDING_INPLACE_SPEC",
+    "RMS_NORM_SPEC",
+    "SILU_AND_MUL_POINTWISE_SPEC",
+    "SILU_AND_MUL_WITH_CLAMP_POINTWISE_SPEC",
+    "TOPK_SOFTMAX_SPEC",
+    "TOPK_HASH_SOFTPLUS_SQRT_SPEC",
+    "TOPK_SOFTPLUS_SQRT_SPEC",
+    "PointwiseFamilySpec",
+    "PointwisePlan",
+    "gelu_and_mul_pointwise",
+    "get_compile_manifest",
+    "get_compile_spec",
+    "grouped_topk",
+    "hc_head_fused_kernel",
+    "mhc_post",
+    "mhc_pre",
+    "materialize_gelu_and_mul_plan",
+    "materialize_pointwise_family_plans",
+    "materialize_pointwise_plan",
+    "materialize_silu_and_mul_plan",
+    "materialize_silu_and_mul_with_clamp_plan",
+    "materialized_pointwise_plans",
+    "moe_sum",
+    "rotary_embedding_inplace",
+    "rms_norm",
+    "silu_and_mul_pointwise",
+    "silu_and_mul_with_clamp_pointwise",
+    "supports_pt2_fused_moe",
+    "supports_pt2_moe_routing",
+    "supports_pt2_triton",
+    "supports_pt2_rms_norm",
+    "topk_softmax",
+    "topk_softplus_sqrt",
+    "uses_common_moe_routing_kernels",
+]

--- a/src/flag_gems/pt2/fused_moe.py
+++ b/src/flag_gems/pt2/fused_moe.py
@@ -1,0 +1,305 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transparent PT2 contracts for common FlagGems MoE primitives.
+
+This module covers two existing NVIDIA/common kernels with different execution
+contracts:
+
+* ``topk_softmax`` is one direct JITFunction that mutates three caller-owned
+  buffers.  Expert count, top-k, index dtype, and ``renormalize`` determine
+  guarded constexpr launch metadata; token count remains a runtime grid value.
+* ``moe_sum`` is an Autotuner with four original ``BLOCK_SIZE`` configs and
+  ``key=["hidden_size", "topk"]``.  The whole Autotuner and its callable META
+  grid are passed to ``wrap_triton``; no config is pinned or copied.
+
+Eager execution retains the original public FlagGems launchers.  Compiled
+execution replaces only logging/Python launch control with ``triton_op`` and
+``wrap_triton`` around the exact same kernel objects.  No compile-only math
+kernel or opaque custom-op fallback is defined here.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.fused.moe_sum import moe_sum as _eager_moe_sum
+from flag_gems.fused.moe_sum import moe_sum_kernel as MOE_SUM_AUTOTUNER
+from flag_gems.fused.topk_softmax import topk_gating_softmax_kernel as TOPK_SOFTMAX_JIT
+from flag_gems.fused.topk_softmax import topk_softmax as _eager_topk_softmax
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+_TOPK_INDEX_DTYPES = (torch.int32, torch.uint32, torch.int64)
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def supports_pt2_fused_moe() -> bool:
+    """Return whether transparent Triton operator APIs are available."""
+
+    return _HAS_TRITON_OP
+
+
+def _check_same_device(reference: torch.Tensor, other: torch.Tensor) -> None:
+    torch._check(other.device == reference.device)
+
+
+def _check_topk_contract(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+) -> tuple[int, int, int]:
+    """Validate the actual dense ABI used by the original top-k kernel."""
+
+    torch._check(gating_output.ndim == 2)
+    torch._check(topk_weights.ndim == 2)
+    torch._check(topk_indices.ndim == 2)
+    torch._check(token_expert_indices.ndim == 2)
+
+    num_tokens = gating_output.shape[0]
+    num_experts = gating_output.shape[1]
+    topk = topk_weights.shape[1]
+    torch._check(num_experts > 0)
+    torch._check(num_experts <= 1024)
+    torch._check(topk > 0)
+    torch._check(topk <= 32)
+    torch._check(topk <= num_experts)
+    torch._check(topk_weights.shape[0] == num_tokens)
+    torch._check(topk_indices.shape[0] == num_tokens)
+    torch._check(topk_indices.shape[1] == topk)
+    torch._check(token_expert_indices.shape[0] == num_tokens)
+    torch._check(token_expert_indices.shape[1] == topk)
+
+    torch._check(gating_output.dtype in _FLOAT_DTYPES)
+    torch._check(topk_weights.dtype == torch.float32)
+    torch._check(topk_indices.dtype in _TOPK_INDEX_DTYPES)
+    torch._check(token_expert_indices.dtype == torch.int32)
+    _check_same_device(gating_output, topk_weights)
+    _check_same_device(gating_output, topk_indices)
+    _check_same_device(gating_output, token_expert_indices)
+
+    # The original kernel does not accept strides and computes all addresses
+    # as row * dense_width + column.  Reject layouts it cannot represent.
+    torch._check(gating_output.is_contiguous())
+    torch._check(topk_weights.is_contiguous())
+    torch._check(topk_indices.is_contiguous())
+    torch._check(token_expert_indices.is_contiguous())
+    return num_tokens, num_experts, topk
+
+
+def _index_triton_dtype(dtype: torch.dtype):
+    if dtype == torch.int32:
+        return tl.int32
+    if dtype == torch.uint32:
+        return tl.uint32
+    if dtype == torch.int64:
+        return tl.int64
+    raise TypeError("topk_indices must be int32/int64/uint32")
+
+
+def _check_moe_sum_contract(
+    input: torch.Tensor, output: torch.Tensor
+) -> tuple[int, int, int]:
+    """Validate the strided-row, contiguous-hidden ABI of ``moe_sum``."""
+
+    torch._check(input.ndim == 3)
+    torch._check(output.ndim == 2)
+    num_tokens, topk, hidden_size = input.shape
+    torch._check(topk > 0)
+    torch._check(hidden_size > 0)
+    torch._check(output.shape[0] == num_tokens)
+    torch._check(output.shape[1] == hidden_size)
+    torch._check(input.dtype in _FLOAT_DTYPES)
+    torch._check(output.dtype == input.dtype)
+    _check_same_device(input, output)
+
+    # input_stride_hidden/output_stride_hidden are present in the Python ABI,
+    # but this kernel addresses hidden elements with raw offsets.  Only a
+    # unit-stride hidden dimension is semantically supported.
+    torch._check(input.stride(2) == 1)
+    torch._check(output.stride(1) == 1)
+    return num_tokens, topk, hidden_size
+
+
+if _HAS_TRITON_OP:
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::topk_softmax",
+        mutates_args={
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        },
+    )
+    def _topk_softmax_op(
+        topk_weights: torch.Tensor,
+        topk_indices: torch.Tensor,
+        token_expert_indices: torch.Tensor,
+        gating_output: torch.Tensor,
+        renormalize: bool,
+    ) -> None:
+        num_tokens, num_experts, topk = _check_topk_contract(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+        )
+        if num_tokens == 0:
+            return
+
+        index_ty = _index_triton_dtype(topk_indices.dtype)
+        block_size_experts = ((triton.next_power_of_2(num_experts) + 31) // 32) * 32
+        block_size_experts = min(block_size_experts, 1024)
+        block_size_rows = max(1024 // block_size_experts, 1)
+        if num_experts > 128:
+            block_size_rows = 1
+            num_warps = 1
+        else:
+            num_warps = 4
+        grid = (triton.cdiv(num_tokens, block_size_rows),)
+
+        torch.library.wrap_triton(TOPK_SOFTMAX_JIT)[grid](
+            input_ptr=gating_output,
+            finished_ptr=None,
+            output_ptr=topk_weights,
+            indices_ptr=topk_indices,
+            source_rows_ptr=token_expert_indices,
+            num_rows=num_tokens,
+            k=topk,
+            num_experts=num_experts,
+            start_expert=0,
+            end_expert=num_experts,
+            renormalize=renormalize,
+            INDEX_TY=index_ty,
+            BLOCK_SIZE_ROWS=block_size_rows,
+            BLOCK_SIZE_EXPERTS=block_size_experts,
+            num_warps=num_warps,
+        )
+
+    @torch.library.triton_op("flag_gems_pt2::moe_sum", mutates_args={"output"})
+    def _moe_sum_op(input: torch.Tensor, output: torch.Tensor) -> None:
+        num_tokens, topk, hidden_size = _check_moe_sum_contract(input, output)
+        if num_tokens == 0:
+            return
+
+        grid = lambda meta: (
+            num_tokens,
+            triton.cdiv(hidden_size, meta["BLOCK_SIZE"]),
+        )
+        torch.library.wrap_triton(MOE_SUM_AUTOTUNER)[grid](
+            input,
+            output,
+            num_tokens,
+            topk,
+            hidden_size,
+            input.stride(0),
+            input.stride(1),
+            input.stride(2),
+            output.stride(0),
+            output.stride(1),
+        )
+
+else:
+    _topk_softmax_op = None
+    _moe_sum_op = None
+
+
+_TRANSPARENT_REQUIRES = (
+    "torch.library.triton_op",
+    "torch.library.wrap_triton",
+    "NVIDIA/common FlagGems kernel identity",
+)
+
+TOPK_SOFTMAX_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::topk_softmax",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=("flag_gems.fused.topk_softmax.topk_gating_softmax_kernel"),
+        mutates_args=(
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        ),
+        dynamic_dims=("num_tokens",),
+        requires=_TRANSPARENT_REQUIRES,
+    )
+)
+
+MOE_SUM_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::moe_sum",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel="flag_gems.fused.moe_sum.moe_sum_kernel (Autotuner)",
+        mutates_args=("output",),
+        dynamic_dims=("num_tokens",),
+        requires=_TRANSPARENT_REQUIRES,
+    )
+)
+
+
+def _missing_triton_op() -> RuntimeError:
+    return RuntimeError(
+        "This Torch build lacks triton_op/wrap_triton; the transparent "
+        "FlagGems MoE primitive PT2 contracts are unavailable"
+    )
+
+
+def topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+) -> None:
+    """Run the original top-k softmax kernel in eager or compiled mode."""
+
+    if torch.compiler.is_compiling():
+        if _topk_softmax_op is None:
+            raise _missing_triton_op()
+        _topk_softmax_op(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+        )
+        return
+    _eager_topk_softmax(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+    )
+
+
+def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
+    """Run the original autotuned MoE reduction in eager or compiled mode."""
+
+    if torch.compiler.is_compiling():
+        if _moe_sum_op is None:
+            raise _missing_triton_op()
+        _moe_sum_op(input, output)
+        return
+    _eager_moe_sum(input, output)
+
+
+__all__ = [
+    "MOE_SUM_AUTOTUNER",
+    "MOE_SUM_SPEC",
+    "TOPK_SOFTMAX_JIT",
+    "TOPK_SOFTMAX_SPEC",
+    "moe_sum",
+    "supports_pt2_fused_moe",
+    "topk_softmax",
+]

--- a/src/flag_gems/pt2/manifest.py
+++ b/src/flag_gems/pt2/manifest.py
@@ -1,0 +1,73 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Declarative compiler contracts for existing FlagGems implementations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Iterable
+
+
+class CompileKind(str, Enum):
+    ATEN_NATIVE = "aten_native"
+    TRITON_TRACEABLE = "triton_traceable"
+    OPAQUE_CUSTOM = "opaque_custom"
+    RESOLVE_ONLY = "resolve_only"
+    EAGER_ONLY = "eager_only"
+
+
+@dataclass(frozen=True)
+class CompileOpSpec:
+    """Compiler-facing facts; never an alternative kernel implementation."""
+
+    op_name: str
+    kind: CompileKind
+    source_kernel: str
+    mutates_args: tuple[str, ...] = ()
+    dynamic_dims: tuple[str, ...] = ()
+    requires: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict:
+        result = asdict(self)
+        result["kind"] = self.kind.value
+        return result
+
+
+_MANIFEST: dict[str, CompileOpSpec] = {}
+
+
+def register_compile_spec(spec: CompileOpSpec) -> CompileOpSpec:
+    previous = _MANIFEST.get(spec.op_name)
+    if previous is not None and previous != spec:
+        raise RuntimeError(f"Conflicting compiler spec for {spec.op_name!r}")
+    _MANIFEST[spec.op_name] = spec
+    return spec
+
+
+def get_compile_spec(op_name: str) -> CompileOpSpec:
+    return _MANIFEST[op_name]
+
+
+def get_compile_manifest() -> tuple[CompileOpSpec, ...]:
+    return tuple(_MANIFEST[name] for name in sorted(_MANIFEST))
+
+
+def iter_compile_manifest() -> Iterable[CompileOpSpec]:
+    return iter(get_compile_manifest())
+
+
+__all__ = [
+    "CompileKind",
+    "CompileOpSpec",
+    "get_compile_manifest",
+    "get_compile_spec",
+    "iter_compile_manifest",
+    "register_compile_spec",
+]

--- a/src/flag_gems/pt2/mhc.py
+++ b/src/flag_gems/pt2/mhc.py
@@ -1,0 +1,518 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PT2 contracts for the existing FlagGems MHC Triton kernels.
+
+Each contract launches the *original* ``@triton.autotune``-wrapped kernel
+object through ``torch.library.triton_op`` + ``torch.library.wrap_triton``.
+Dynamo explicitly supports exactly one autotuner layer on a wrapped kernel
+(``torch._higher_order_ops.triton_kernel_wrap``) and Inductor re-autotunes
+among the same declared ``configs`` at compile time
+(``define_user_defined_triton_kernel(kernel, configs, ...))``.  In eager
+execution ``triton_op``'s backend runs the op body with ``wrap_triton``
+disabled, i.e. the call falls through to the original ``Autotuner.run`` —
+bit-identical to the uncompiled FlagGems launcher, including its
+benchmarking cache.  No kernel is copied or rewritten, and no launch
+parameter is decided by Python inside the traced body: running host-side
+cache bookkeeping under symbolic shapes during the fake/meta trace was the
+root cause of the old ``TypeError('unhashable type: non-nested SymInt')``
+failures in a pinned-config design (autotuner-cache keys embed shapes).
+
+Grids: ``mhc_pre`` / ``hc_head_fused`` launch with the original
+``(num_tokens,)`` tuple grid, which does not depend on the selected config.
+``mhc_post`` needs ``cdiv(H, BLOCK_H)`` while ``BLOCK_H`` is only chosen at
+compile time under Inductor autotuning, so it uses the documented META
+closure grid pattern (``lambda META: (N, cdiv(H, META["BLOCK_H"]))``), which
+``wrap_triton`` supports for both eager (wrap disabled → plain
+``Autotuner.run(grid=callable)``) and compile.
+"""
+
+# ``import a.b.c as name`` resolves to the attribute ``c`` of package ``a.b``
+# when a.b.__init__ eagerly re-exports a same-named symbol (flag_gems.fused.mhc
+# does exactly that), so bind the submodules through importlib instead.
+import importlib as _importlib
+
+import torch
+
+import flag_gems.fused.mhc as _mhc_pkg  # noqa: F401  (ensures submodules loaded)
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+
+_hc_head_mod = _importlib.import_module("flag_gems.fused.mhc.hc_head_fused_kernel")
+_mhc_post_mod = _importlib.import_module("flag_gems.fused.mhc.mhc_post")
+_mhc_pre_mod = _importlib.import_module("flag_gems.fused.mhc.mhc_pre")
+
+# The original autotune-wrapped kernel objects: ``*.fn`` chains end at the
+# same JITFunction objects the eager launchers invoke.
+MHC_PRE_FUSED_AUTOTUNER = _mhc_pre_mod.mhc_pre_fused_kernel_hc_mult_4
+MHC_PRE_GENERIC_AUTOTUNER = _mhc_pre_mod.mhc_pre_generic_kernel
+MHC_POST_HCMULT4_AUTOTUNER = _mhc_post_mod.mhc_post_kernel_hc_mult_4
+MHC_POST_GENERIC_AUTOTUNER = _mhc_post_mod.mhc_post_kernel_generic
+HC_HEAD_FUSED_AUTOTUNER = _hc_head_mod._hc_head_fused_kernel
+
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+
+
+def supports_pt2_triton() -> bool:
+    """Return whether this Torch build exposes the required PT2 Triton APIs."""
+
+    return _HAS_TRITON_OP
+
+
+def _num_tokens_bucket(num_tokens: int) -> int:
+    """Mirror of the bucket table in ``flag_gems.fused.mhc.mhc_pre.mhc_pre``.
+
+    It is passed to the kernel as the ``num_tokens_bucket`` autotune-key
+    argument, so the traced path must produce the identical value for every
+    token count; keeping it in sync is part of the contract.
+    """
+
+    if num_tokens <= 512:
+        return 1
+    if num_tokens <= 1024:
+        return 2
+    if num_tokens <= 2048:
+        return 3
+    if num_tokens <= 4096:
+        return 4
+    return 5
+
+
+if _HAS_TRITON_OP:
+
+    # The fn->bf16 cast of the GEMM must not re-execute on every compiled
+    # call.  ``torch.compile`` cannot hoist a tensor->tensor cast out of a
+    # graph (it depends on the runtime value of ``fn``), and the original
+    # WeakKeyDictionary/_version cache cannot be traced.  The split below
+    # moves the cast+GEMM behind a plain custom op whose body runs *outside*
+    # the graph; Inductor treats it as an opaque extern call, so the
+    # data_ptr+_version cache is consulted once per call and the cast fires
+    # exactly once per (weight tensor, version).
+    _FN_BF16_CACHE: dict = {}
+    _FN_BF16_CAST_CALLS = {"n": 0}  # cast-count observability for benchmarks
+
+    def _get_fn_bf16_cached(fn: torch.Tensor) -> torch.Tensor:
+        key = fn.data_ptr()
+        entry = _FN_BF16_CACHE.get(key)
+        if entry is not None and entry[0] == fn._version:
+            return entry[1]
+        _FN_BF16_CAST_CALLS["n"] += 1
+        out = fn.to(dtype=torch.bfloat16)
+        # strong ref: guards against data_ptr reuse after the weight is freed
+        _FN_BF16_CACHE[key] = (fn._version, out, fn)
+        return out
+
+    @torch.library.custom_op("flag_gems_pt2::mhc_pre_gemm", mutates_args=())
+    def _mhc_pre_gemm_op(
+        residual_flat: torch.Tensor,  # (num_tokens, hc_mult, hidden_size), bf16
+        fn: torch.Tensor,  # (hc_mult3, hc_hidden_size), fp32
+    ) -> torch.Tensor:
+        """fn->bf16 cached cast + cuBLAS GEMM, opaque to the compiled graph."""
+        num_tokens = residual_flat.shape[0]
+        hc_hidden_size = fn.shape[1]
+        x_flat = residual_flat.reshape(num_tokens, hc_hidden_size)
+        fn_bf16 = _get_fn_bf16_cached(fn)
+        return torch.mm(x_flat, fn_bf16.t()).float()
+
+    @_mhc_pre_gemm_op.register_fake
+    def _(residual_flat, fn):
+        return residual_flat.new_empty(
+            residual_flat.shape[0], fn.shape[0], dtype=torch.float32
+        )
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::mhc_pre",
+        mutates_args={"post_mix", "comb_mix", "layer_input"},
+    )
+    def _mhc_pre_op(
+        residual: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        post_mix: torch.Tensor,
+        comb_mix: torch.Tensor,
+        layer_input: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+    ) -> None:
+        """Opaque cached GEMM + original fused MHC-pre Triton kernel."""
+
+        num_tokens = residual.shape[0]
+        hc_mult = residual.shape[1]
+        hidden_size = residual.shape[2]
+        hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+        hc_hidden_size = hc_mult * hidden_size
+        num_tokens_bucket = _num_tokens_bucket(num_tokens)
+
+        # Step 1: cached bf16 cast + GEMM behind a custom op (outside graph).
+        gemm_out = torch.ops.flag_gems_pt2.mhc_pre_gemm(residual, fn)
+
+        # Step 2: the original autotune-wrapped kernel, same call signature
+        # as the eager launcher.  Eager (wrap_triton disabled by triton_op):
+        # falls through to Autotuner.run.  Compile: Dynamo traces the single
+        # autotuner layer and Inductor re-autotunes among the same configs.
+        if hc_mult == 4:
+            torch.library.wrap_triton(_mhc_pre_mod.mhc_pre_fused_kernel_hc_mult_4)[
+                (num_tokens,)
+            ](
+                gemm_out,
+                hc_scale,
+                hc_base,
+                residual,
+                post_mix,
+                comb_mix,
+                layer_input,
+                num_tokens,
+                num_tokens_bucket,
+                residual.stride(0),
+                residual.stride(1),
+                residual.stride(2),
+                layer_input.stride(0),
+                layer_input.stride(1),
+                hidden_size,
+                hc_hidden_size,
+                rms_eps=rms_eps,
+                hc_pre_eps=hc_pre_eps,
+                hc_sinkhorn_eps=hc_sinkhorn_eps,
+                hc_post_mult_value=hc_post_mult_value,
+                sinkhorn_repeat=sinkhorn_repeat,
+                HC_MULT3=hc_mult3,
+            )
+        else:
+            torch.library.wrap_triton(_mhc_pre_mod.mhc_pre_generic_kernel)[
+                (num_tokens,)
+            ](
+                gemm_out,
+                hc_scale,
+                hc_base,
+                residual,
+                post_mix,
+                comb_mix,
+                layer_input,
+                num_tokens,
+                num_tokens_bucket,
+                residual.stride(0),
+                residual.stride(1),
+                residual.stride(2),
+                layer_input.stride(0),
+                layer_input.stride(1),
+                hidden_size,
+                hc_hidden_size,
+                rms_eps=rms_eps,
+                hc_pre_eps=hc_pre_eps,
+                hc_sinkhorn_eps=hc_sinkhorn_eps,
+                hc_post_mult_value=hc_post_mult_value,
+                sinkhorn_repeat=sinkhorn_repeat,
+                HC=hc_mult,
+            )
+
+    @torch.library.triton_op("flag_gems_pt2::mhc_post", mutates_args={"out"})
+    def _mhc_post_op(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post: torch.Tensor,
+        comb: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        """Original MHC-post Triton kernel with the documented META grid."""
+
+        N, hc, H = residual.shape
+        a = comb.contiguous()
+        b = residual.contiguous()
+        c = post.squeeze(-1).contiguous()
+        d = x.contiguous()
+
+        if hc == 4:
+            # BLOCK_H is chosen by the (Inductor- or eager-) autotuner, so the
+            # grid must be computed from the config: documented META-closure
+            # grid, equivalent to the eager launcher's ``grid_specialized``.
+            torch.library.wrap_triton(_mhc_post_mod.mhc_post_kernel_hc_mult_4)[
+                lambda META: (N, (H + META["BLOCK_H"] - 1) // META["BLOCK_H"])
+            ](
+                a,
+                b,
+                c,
+                d,
+                out,
+                H=H,
+            )
+        else:
+            torch.library.wrap_triton(_mhc_post_mod.mhc_post_kernel_generic)[
+                lambda META: (N, hc, (H + META["BLOCK_H"] - 1) // META["BLOCK_H"])
+            ](
+                a,
+                b,
+                c,
+                d,
+                out,
+                H=H,
+                HC=hc,
+            )
+
+    @torch.library.triton_op("flag_gems_pt2::hc_head_fused", mutates_args={"out"})
+    def _hc_head_fused_op(
+        hs_flat: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        out: torch.Tensor,
+        hidden_size: int,
+        rms_eps: float,
+        hc_eps: float,
+        hc_mult: int,
+    ) -> None:
+        """Original HC-head fused Triton kernel; mutates ``out`` in place."""
+
+        num_tokens = hs_flat.shape[0]
+        residual_c = hs_flat.contiguous()
+        fn_c = fn.contiguous()
+        # ``out_c is out`` is the traceable form of the eager launcher's
+        # ``out.data_ptr() == out_c.data_ptr()`` check (FakeTensors have no
+        # data_ptr).  Same condition, same behavior; ``out`` arrives
+        # contiguous from the public wrapper (``empty_like``) in practice.
+        out_c = out if out.is_contiguous() else torch.empty_like(out)
+
+        torch.library.wrap_triton(_hc_head_mod._hc_head_fused_kernel)[(num_tokens,)](
+            residual_c,
+            fn_c,
+            hc_scale,
+            hc_base,
+            out_c,
+            num_tokens,
+            hidden_size,
+            rms_eps,
+            hc_eps,
+            residual_c.stride(0),
+            fn_c.stride(0),
+            out_c.stride(0),
+            HC=hc_mult,
+        )
+
+        if out_c is not out:
+            out.copy_(out_c)
+
+else:
+    _mhc_pre_op = None
+    _mhc_post_op = None
+    _hc_head_fused_op = None
+    _FN_BF16_CACHE = {}
+    _FN_BF16_CAST_CALLS = {"n": 0}
+
+
+def fn_bf16_cast_count() -> int:
+    """Number of fn->bf16 casts actually executed (hot-path observability)."""
+    return _FN_BF16_CAST_CALLS["n"]
+
+
+MHC_PRE_GEMM_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::mhc_pre_gemm",
+        kind=CompileKind.OPAQUE_CUSTOM,
+        source_kernel=(
+            "opaque: data_ptr+_version-keyed fn->bf16 cache + torch.mm "
+            "(body runs outside the compiled graph; not Inductor-traceable "
+            "by design)"
+        ),
+        mutates_args=(),
+        dynamic_dims=("num_tokens",),
+        requires=("torch.library.custom_op",),
+    )
+)
+
+
+MHC_PRE_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::mhc_pre",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.mhc.mhc_pre.mhc_pre_fused_kernel_hc_mult_4 "
+            "(original @triton.autotune object wrapped by wrap_triton; "
+            "generic fallback: mhc_pre_generic_kernel)"
+        ),
+        mutates_args=("post_mix", "comb_mix", "layer_input"),
+        dynamic_dims=("num_tokens",),
+        requires=(
+            "torch.library.triton_op",
+            "torch.library.wrap_triton",
+            "torch.library.custom_op",
+            "flag_gems_pt2::mhc_pre_gemm (OPAQUE_CUSTOM)",
+        ),
+    )
+)
+
+MHC_POST_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::mhc_post",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.mhc.mhc_post.mhc_post_kernel_hc_mult_4 "
+            "(original @triton.autotune object wrapped by wrap_triton; "
+            "generic fallback: mhc_post_kernel_generic)"
+        ),
+        mutates_args=("out",),
+        dynamic_dims=("num_tokens",),
+        requires=("torch.library.triton_op", "torch.library.wrap_triton"),
+    )
+)
+
+HC_HEAD_FUSED_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::hc_head_fused",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.mhc.hc_head_fused_kernel._hc_head_fused_kernel "
+            "(original @triton.autotune object wrapped by wrap_triton)"
+        ),
+        mutates_args=("out",),
+        dynamic_dims=("num_tokens",),
+        requires=("torch.library.triton_op", "torch.library.wrap_triton"),
+    )
+)
+
+
+def mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compiler-visible mhc_pre calling the original FlagGems kernel.
+
+    Supported PT2 builds call the registered ``triton_op`` in both eager and
+    compiled execution, so the same JITFunction body runs in both modes.  The
+    ``n_splits`` argument is accepted for interface parity with the dispatch
+    contract; the original FlagGems implementation reserves it and only
+    supports ``n_splits == 1``.
+    """
+
+    if n_splits != 1:
+        raise NotImplementedError(
+            "FlagGems mhc_pre reserves n_splits for a future split implementation; "
+            "only n_splits == 1 is supported"
+        )
+    if _mhc_pre_op is None:
+        raise RuntimeError(
+            "This Torch build does not provide torch.library.triton_op and "
+            "torch.library.wrap_triton; FlagGems mhc_pre cannot enter a PT2 graph"
+        )
+
+    outer_shape = residual.shape[:-2]
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+
+    residual_flat = residual.reshape(-1, hc_mult, hidden_size).contiguous()
+    num_tokens = residual_flat.shape[0]
+
+    post_mix = torch.empty(
+        num_tokens, hc_mult, dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        num_tokens, hc_mult * hc_mult, dtype=torch.float32, device=residual.device
+    )
+    layer_input = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=residual.device
+    )
+
+    _mhc_pre_op(
+        residual_flat,
+        fn,
+        hc_scale,
+        hc_base,
+        post_mix,
+        comb_mix,
+        layer_input,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+    )
+
+    return (
+        post_mix.view(*outer_shape, hc_mult, 1),
+        comb_mix.view(*outer_shape, hc_mult, hc_mult),
+        layer_input.view(*outer_shape, hidden_size),
+    )
+
+
+def mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+) -> torch.Tensor:
+    """Compiler-visible mhc_post calling the original FlagGems kernel."""
+
+    if _mhc_post_op is None:
+        raise RuntimeError(
+            "This Torch build does not provide torch.library.triton_op and "
+            "torch.library.wrap_triton; FlagGems mhc_post cannot enter a PT2 graph"
+        )
+
+    out = torch.empty_like(residual)
+    _mhc_post_op(x, residual, post, comb, out)
+    return out
+
+
+def hc_head_fused_kernel(
+    hs_flat: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    out: torch.Tensor,
+    hidden_size: int,
+    rms_eps: float,
+    hc_eps: float,
+    hc_mult: int,
+) -> None:
+    """Compiler-visible hc_head_fused_kernel; mutates ``out`` in place."""
+
+    if _hc_head_fused_op is None:
+        raise RuntimeError(
+            "This Torch build does not provide torch.library.triton_op and "
+            "torch.library.wrap_triton; FlagGems hc_head_fused_kernel cannot "
+            "enter a PT2 graph"
+        )
+
+    _hc_head_fused_op(
+        hs_flat, fn, hc_scale, hc_base, out, hidden_size, rms_eps, hc_eps, hc_mult
+    )
+
+
+__all__ = [
+    "HC_HEAD_FUSED_AUTOTUNER",
+    "HC_HEAD_FUSED_SPEC",
+    "MHC_POST_GENERIC_AUTOTUNER",
+    "MHC_POST_HCMULT4_AUTOTUNER",
+    "MHC_POST_SPEC",
+    "MHC_PRE_FUSED_AUTOTUNER",
+    "MHC_PRE_GENERIC_AUTOTUNER",
+    "MHC_PRE_GEMM_SPEC",
+    "MHC_PRE_SPEC",
+    "fn_bf16_cast_count",
+    "hc_head_fused_kernel",
+    "mhc_post",
+    "mhc_pre",
+    "supports_pt2_triton",
+]

--- a/src/flag_gems/pt2/moe_routing.py
+++ b/src/flag_gems/pt2/moe_routing.py
@@ -1,0 +1,590 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transparent PT2 adapters for the FlagGems MoE routing kernels.
+
+The adapters in this module only replace Python launch control.  Eager mode
+continues to call the public FlagGems launchers, while compiled mode launches
+the exact same common/NVIDIA Triton ``JITFunction`` objects through
+``torch.library.triton_op`` and ``torch.library.wrap_triton``.
+
+``grouped_topk`` remains the original two-stage algorithm (group scoring,
+then expert selection).  ``topk_softplus_sqrt`` remains two explicitly
+different structural families: direct top-k and hash-table routing.  Token
+count is the runtime grid dimension; expert/group/top-k configuration,
+branch identity, dtype, and layout are compile specializations.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.fused.grouped_topk import (
+    group_idx_and_topk_triton as GROUPED_TOPK_SELECT_JIT,
+)
+from flag_gems.fused.grouped_topk import grouped_topk as _eager_grouped_topk
+from flag_gems.fused.grouped_topk import topk_with_k2_triton as GROUPED_TOPK_GROUP_JIT
+from flag_gems.fused.topk_softplus_sqrt import (
+    _fused_topk_kernel as TOPK_SOFTPLUS_SQRT_JIT,
+)
+from flag_gems.fused.topk_softplus_sqrt import (
+    _hash_kernel as TOPK_HASH_SOFTPLUS_SQRT_JIT,
+)
+from flag_gems.fused.topk_softplus_sqrt import (
+    topk_softplus_sqrt as _eager_topk_softplus_sqrt,
+)
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_TOPK_INDEX_DTYPES = (torch.int32, torch.uint32, torch.int64)
+_HASH_DTYPES = (torch.int32, torch.int64)
+
+
+def supports_pt2_moe_routing() -> bool:
+    """Return whether this Torch build exposes transparent Triton APIs."""
+
+    return _HAS_TRITON_OP
+
+
+def uses_common_moe_routing_kernels(
+    grouped_topk_impl: object,
+    topk_softplus_sqrt_impl: object,
+) -> bool:
+    """Check that a public/vendor export still names the captured kernels.
+
+    A vendor or optional C++ installation may replace a public FlagGems
+    launcher.  In that case the plugin must retain that launcher instead of
+    silently compiling the common/NVIDIA adapter around a different kernel.
+    """
+
+    return (
+        grouped_topk_impl is _eager_grouped_topk
+        and topk_softplus_sqrt_impl is _eager_topk_softplus_sqrt
+    )
+
+
+def _check_same_device(reference: torch.Tensor, other: torch.Tensor) -> None:
+    torch._check(other.device == reference.device)
+
+
+def _input_triton_dtype(dtype: torch.dtype):
+    if dtype == torch.float32:
+        return tl.float32
+    if dtype == torch.float16:
+        return tl.float16
+    if dtype == torch.bfloat16:
+        return tl.bfloat16
+    raise TypeError("routing input must be float16/bfloat16/float32")
+
+
+def _normalize_grouped_bias(scores: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+    # Preserve the original public launcher's cast/flatten semantics.  These
+    # are ordinary ATen operations and remain visible to Dynamo/Inductor.
+    if bias.dtype != scores.dtype:
+        bias = bias.to(scores.dtype)
+    if bias.ndim != 1:
+        bias = bias.flatten()
+    return bias
+
+
+def _check_grouped_topk_contract(
+    scores: torch.Tensor,
+    bias: torch.Tensor,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    scoring_func: int,
+) -> tuple[int, int]:
+    torch._check(scores.ndim == 2)
+    num_tokens, num_experts = scores.shape
+    torch._check(num_experts > 0)
+    torch._check(n_group > 0)
+    torch._check(n_group <= 32)
+    # The first original kernel computes the top two experts in each group.
+    # A one-expert group cannot satisfy that ABI (the plugin's model path
+    # already rejects this family); fail closed for direct PT2 callers too.
+    torch._check(num_experts > n_group)
+    torch._check(num_experts % n_group == 0)
+    torch._check(topk_group > 0)
+    torch._check(topk_group <= n_group)
+    torch._check(topk > 0)
+    torch._check(topk <= 32)
+    torch._check(topk <= topk_group * (num_experts // n_group))
+    torch._check(scoring_func >= 0)
+    torch._check(scoring_func <= 1)
+    torch._check(scores.dtype in _FLOAT_DTYPES)
+    torch._check(scores.stride(1) == 1)
+
+    torch._check(bias.ndim == 1)
+    torch._check(bias.shape[0] == num_experts)
+    torch._check(bias.dtype == scores.dtype)
+    torch._check(bias.stride(0) == 1)
+    _check_same_device(scores, bias)
+    return num_tokens, num_experts
+
+
+def _check_topk_softplus_contract(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    has_bias: bool,
+) -> tuple[int, int, int]:
+    torch._check(gating_output.ndim == 2)
+    torch._check(topk_weights.ndim == 2)
+    torch._check(topk_indices.ndim == 2)
+    torch._check(token_expert_indices.ndim == 2)
+    num_tokens, num_experts = gating_output.shape
+    topk = topk_weights.shape[1]
+    torch._check(num_experts > 0)
+    torch._check(topk > 0)
+    torch._check(topk <= num_experts)
+    torch._check(topk_weights.shape[0] == num_tokens)
+    torch._check(topk_indices.shape[0] == num_tokens)
+    torch._check(topk_indices.shape[1] == topk)
+    torch._check(token_expert_indices.shape[0] == num_tokens)
+    torch._check(token_expert_indices.shape[1] == topk)
+
+    torch._check(gating_output.dtype in _FLOAT_DTYPES)
+    torch._check(topk_weights.dtype == torch.float32)
+    torch._check(topk_indices.dtype in _TOPK_INDEX_DTYPES)
+    torch._check(token_expert_indices.dtype == torch.int32)
+    _check_same_device(gating_output, topk_weights)
+    _check_same_device(gating_output, topk_indices)
+    _check_same_device(gating_output, token_expert_indices)
+
+    # Both original kernels compute dense row-major addresses and accept no
+    # stride arguments.  Reject layouts their ABI cannot represent.
+    torch._check(gating_output.is_contiguous())
+    torch._check(topk_weights.is_contiguous())
+    torch._check(topk_indices.is_contiguous())
+    torch._check(token_expert_indices.is_contiguous())
+
+    if has_bias:
+        torch._check(correction_bias.ndim == 1)
+        torch._check(correction_bias.shape[0] == num_experts)
+        torch._check(correction_bias.dtype in _FLOAT_DTYPES)
+        torch._check(correction_bias.is_contiguous())
+        _check_same_device(gating_output, correction_bias)
+    return num_tokens, num_experts, topk
+
+
+def _check_hash_contract(
+    gating_output: torch.Tensor,
+    input_ids: torch.Tensor,
+    tid2eid: torch.Tensor,
+    num_tokens: int,
+    topk: int,
+) -> None:
+    torch._check(input_ids.ndim == 1)
+    torch._check(input_ids.shape[0] == num_tokens)
+    torch._check(input_ids.dtype in _HASH_DTYPES)
+    torch._check(input_ids.is_contiguous())
+    torch._check(tid2eid.ndim == 2)
+    torch._check(tid2eid.shape[1] == topk)
+    torch._check(tid2eid.dtype in _HASH_DTYPES)
+    torch._check(tid2eid.is_contiguous())
+    _check_same_device(gating_output, input_ids)
+    _check_same_device(gating_output, tid2eid)
+
+
+if _HAS_TRITON_OP:
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::grouped_topk",
+        mutates_args={},
+    )
+    def _grouped_topk_op(
+        scores: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        bias: torch.Tensor,
+        scoring_func: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        bias = _normalize_grouped_bias(scores, bias)
+        num_tokens, num_experts = _check_grouped_topk_contract(
+            scores,
+            bias,
+            n_group,
+            topk_group,
+            topk,
+            scoring_func,
+        )
+
+        if scoring_func == 1:
+            scores_processed = torch.sigmoid(scores.float()).to(scores.dtype)
+        else:
+            scores_processed = scores
+
+        group_scores = torch.empty(
+            (num_tokens, n_group),
+            device=scores.device,
+            dtype=scores.dtype,
+        )
+        topk_values = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.float32,
+        )
+        topk_indices = torch.empty(
+            (num_tokens, topk),
+            device=scores.device,
+            dtype=torch.int32,
+        )
+        if num_tokens == 0:
+            return topk_values, topk_indices
+
+        num_experts_per_group = num_experts // n_group
+        input_dtype = _input_triton_dtype(scores.dtype)
+        block_group_scores = triton.next_power_of_2(num_experts_per_group)
+        torch.library.wrap_triton(GROUPED_TOPK_GROUP_JIT)[(num_tokens * n_group,)](
+            scores_processed,
+            bias,
+            group_scores,
+            num_experts_per_group,
+            n_group,
+            scores_processed.stride(0),
+            group_scores.stride(0),
+            BLOCK_SIZE=block_group_scores,
+            INPUT_DTYPE=input_dtype,
+        )
+
+        block_group = triton.next_power_of_2(n_group)
+        block_expert = triton.next_power_of_2(num_experts)
+        torch.library.wrap_triton(GROUPED_TOPK_SELECT_JIT)[(num_tokens,)](
+            scores_processed,
+            group_scores,
+            topk_values,
+            topk_indices,
+            bias,
+            num_tokens,
+            n_group,
+            topk_group,
+            topk,
+            num_experts,
+            num_experts_per_group,
+            routed_scaling_factor,
+            scores_processed.stride(0),
+            group_scores.stride(0),
+            topk_values.stride(0),
+            N_GROUP=n_group,
+            TOPK_GROUP=topk_group,
+            TOPK=topk,
+            BLOCK_GROUP=block_group,
+            BLOCK_EXPERT=block_expert,
+            INPUT_DTYPE=input_dtype,
+            renormalize=int(renormalize),
+        )
+        return topk_values, topk_indices
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::topk_softplus_sqrt",
+        mutates_args={
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        },
+    )
+    def _topk_softplus_sqrt_op(
+        topk_weights: torch.Tensor,
+        topk_indices: torch.Tensor,
+        token_expert_indices: torch.Tensor,
+        gating_output: torch.Tensor,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        correction_bias: torch.Tensor,
+        has_bias: bool,
+    ) -> None:
+        num_tokens, num_experts, topk = _check_topk_softplus_contract(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            correction_bias,
+            has_bias,
+        )
+        if num_tokens == 0:
+            return
+
+        torch.library.wrap_triton(TOPK_SOFTPLUS_SQRT_JIT)[(num_tokens,)](
+            gating_output,
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            correction_bias,
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            topk=topk,
+            renormalize=renormalize,
+            routed_scaling_factor=routed_scaling_factor,
+            HAS_BIAS=has_bias,
+            BLOCK_E=triton.next_power_of_2(num_experts),
+            num_warps=1,
+            num_stages=1,
+        )
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::topk_hash_softplus_sqrt",
+        mutates_args={
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        },
+    )
+    def _topk_hash_softplus_sqrt_op(
+        topk_weights: torch.Tensor,
+        topk_indices: torch.Tensor,
+        token_expert_indices: torch.Tensor,
+        gating_output: torch.Tensor,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        correction_bias: torch.Tensor,
+        has_bias: bool,
+        input_ids: torch.Tensor,
+        tid2eid: torch.Tensor,
+    ) -> None:
+        num_tokens, num_experts, topk = _check_topk_softplus_contract(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            correction_bias,
+            has_bias,
+        )
+        _check_hash_contract(
+            gating_output,
+            input_ids,
+            tid2eid,
+            num_tokens,
+            topk,
+        )
+        if num_tokens == 0:
+            return
+
+        torch.library.wrap_triton(TOPK_HASH_SOFTPLUS_SQRT_JIT)[(num_tokens,)](
+            gating_output,
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            correction_bias,
+            input_ids,
+            tid2eid,
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            topk=topk,
+            renormalize=renormalize,
+            routed_scaling_factor=routed_scaling_factor,
+            HAS_BIAS=has_bias,
+            BLOCK_E=triton.next_power_of_2(num_experts),
+            BLOCK_K=triton.next_power_of_2(topk),
+            num_warps=1,
+            num_stages=1,
+        )
+
+else:
+    _grouped_topk_op = None
+    _topk_softplus_sqrt_op = None
+    _topk_hash_softplus_sqrt_op = None
+
+
+_TRANSPARENT_REQUIRES = (
+    "torch.library.triton_op",
+    "torch.library.wrap_triton",
+    "NVIDIA/common FlagGems kernel identity",
+)
+
+GROUPED_TOPK_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::grouped_topk",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.grouped_topk.topk_with_k2_triton + "
+            "flag_gems.fused.grouped_topk.group_idx_and_topk_triton"
+        ),
+        mutates_args=(),
+        dynamic_dims=("num_tokens",),
+        requires=_TRANSPARENT_REQUIRES,
+    )
+)
+
+TOPK_SOFTPLUS_SQRT_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::topk_softplus_sqrt",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel="flag_gems.fused.topk_softplus_sqrt._fused_topk_kernel",
+        mutates_args=(
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        ),
+        dynamic_dims=("num_tokens",),
+        requires=_TRANSPARENT_REQUIRES,
+    )
+)
+
+TOPK_HASH_SOFTPLUS_SQRT_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::topk_hash_softplus_sqrt",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel="flag_gems.fused.topk_softplus_sqrt._hash_kernel",
+        mutates_args=(
+            "topk_weights",
+            "topk_indices",
+            "token_expert_indices",
+        ),
+        dynamic_dims=("num_tokens",),
+        requires=_TRANSPARENT_REQUIRES,
+    )
+)
+
+
+def _missing_triton_op() -> RuntimeError:
+    return RuntimeError(
+        "This Torch build lacks triton_op/wrap_triton; the transparent "
+        "FlagGems MoE routing PT2 contracts are unavailable"
+    )
+
+
+def grouped_topk(
+    scores: torch.Tensor,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    bias: torch.Tensor,
+    scoring_func: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the original two-stage grouped-top-k implementation."""
+
+    if torch.compiler.is_compiling():
+        if _grouped_topk_op is None:
+            raise _missing_triton_op()
+        return _grouped_topk_op(
+            scores,
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )
+
+    # Define the empty-token contract before constructing Triton's zero grid.
+    # Non-empty eager calls retain the unmodified public FlagGems launcher.
+    if scores.ndim == 2 and scores.shape[0] == 0:
+        normalized_bias = _normalize_grouped_bias(scores, bias)
+        _check_grouped_topk_contract(
+            scores,
+            normalized_bias,
+            n_group,
+            topk_group,
+            topk,
+            scoring_func,
+        )
+        return (
+            torch.empty((0, topk), dtype=torch.float32, device=scores.device),
+            torch.empty((0, topk), dtype=torch.int32, device=scores.device),
+        )
+    return _eager_grouped_topk(
+        scores,
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func,
+    )
+
+
+def topk_softplus_sqrt(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    correction_bias: torch.Tensor | None = None,
+    input_ids: torch.Tensor | None = None,
+    tid2eid: torch.Tensor | None = None,
+) -> None:
+    """Run the original direct or hash softplus-sqrt routing kernel."""
+
+    if (input_ids is None) != (tid2eid is None):
+        raise ValueError("input_ids and tid2eid must be both present or both absent")
+
+    if torch.compiler.is_compiling():
+        placeholder_bias = gating_output if correction_bias is None else correction_bias
+        has_bias = correction_bias is not None
+        if input_ids is None:
+            if _topk_softplus_sqrt_op is None:
+                raise _missing_triton_op()
+            _topk_softplus_sqrt_op(
+                topk_weights,
+                topk_indices,
+                token_expert_indices,
+                gating_output,
+                renormalize,
+                routed_scaling_factor,
+                placeholder_bias,
+                has_bias,
+            )
+            return
+        if _topk_hash_softplus_sqrt_op is None:
+            raise _missing_triton_op()
+        _topk_hash_softplus_sqrt_op(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            routed_scaling_factor,
+            placeholder_bias,
+            has_bias,
+            input_ids,
+            tid2eid,
+        )
+        return
+
+    _eager_topk_softplus_sqrt(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        routed_scaling_factor,
+        correction_bias,
+        input_ids,
+        tid2eid,
+    )
+
+
+__all__ = [
+    "GROUPED_TOPK_GROUP_JIT",
+    "GROUPED_TOPK_SELECT_JIT",
+    "GROUPED_TOPK_SPEC",
+    "TOPK_HASH_SOFTPLUS_SQRT_JIT",
+    "TOPK_HASH_SOFTPLUS_SQRT_SPEC",
+    "TOPK_SOFTPLUS_SQRT_JIT",
+    "TOPK_SOFTPLUS_SQRT_SPEC",
+    "grouped_topk",
+    "supports_pt2_moe_routing",
+    "topk_softplus_sqrt",
+    "uses_common_moe_routing_kernels",
+]

--- a/src/flag_gems/pt2/pointwise_dynamic.py
+++ b/src/flag_gems/pt2/pointwise_dynamic.py
@@ -1,0 +1,619 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transparent PT2 adapters for generated ``pointwise_dynamic`` kernels.
+
+The Python control plane and tensor execution plane are deliberately split:
+
+* a :class:`PointwiseFamilySpec` binds one existing FlagGems scalar/kernel
+  generator to structural input metadata;
+* :func:`materialize_pointwise_plan` runs rank code generation and imports the
+  generated module before Dynamo starts;
+* eager execution keeps the generated wrapper/``LibEntry`` path;
+* compiled execution launches the exact same generated ``JITFunction`` through
+  ``torch.library.triton_op`` and ``torch.library.wrap_triton``.
+
+Plans contain no Tensor, data pointer, output allocation, token count, grid, or
+shape value. Rank, dtype, layout family, and guarded GELU approximation select
+an immutable plan; concrete shapes and launch parameters remain symbolic or
+runtime-specialized after the Dynamo boundary.
+
+This adapter intentionally supports the common inference subset used by the
+vLLM activation backend: one output, tensor-only inputs, equal-dtype elementwise
+operands, and optional scalar-tensor broadcasts. Unsupported pointwise schemas
+are rejected while materializing instead of silently dropping eager promotion,
+mutation, autotune, or wrapper semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+import torch
+import triton
+
+from flag_gems.fused.gelu_and_mul import gelu_none_and_mul_kernel as _gelu_none_source
+from flag_gems.fused.gelu_and_mul import gelu_tanh_and_mul_kernel as _gelu_tanh_source
+from flag_gems.fused.silu_and_mul import silu_and_mul_kernel as _silu_source
+from flag_gems.fused.silu_and_mul_with_clamp import (
+    silu_and_mul_with_clamp_kernel as _silu_clamp_source,
+)
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+from flag_gems.utils.codegen_config_utils import get_heuristics_for_num_warps_fn
+from flag_gems.utils.pointwise_dynamic import (
+    PointwiseDynamicFunction,
+    PointwiseKernelMaterialization,
+)
+
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+_SUPPORTED_RANKS = (1, 2, 3)
+_SUPPORTED_LAYOUTS = ("contiguous_c", "split_last_dim_c")
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+@dataclass(frozen=True)
+class PointwiseFamilySpec:
+    """Graph-independent description of one existing generated kernel family."""
+
+    name: str
+    source_pointwise: PointwiseDynamicFunction
+    num_inputs: int
+    scalar_input_indices: tuple[int, ...] = ()
+
+    @property
+    def primary_input_indices(self) -> tuple[int, ...]:
+        return tuple(
+            i for i in range(self.num_inputs) if i not in self.scalar_input_indices
+        )
+
+
+@dataclass(frozen=True)
+class PointwisePlan:
+    """Tensor-free specialization plan for one generated kernel family."""
+
+    token: int
+    op_name: str
+    ndim: int
+    kernel_ndim: int
+    dtype: torch.dtype
+    layout_class: str
+    num_inputs: int
+    scalar_input_indices: tuple[int, ...]
+    materialization: PointwiseKernelMaterialization
+    num_warps_policy: Callable[[int], int]
+    tensor_stride_order: tuple[int, ...]
+    scalar_stride_order: tuple[int, ...]
+
+    @property
+    def jit_function(self):
+        return self.materialization.jit_function
+
+    @property
+    def primary_input_indices(self) -> tuple[int, ...]:
+        return tuple(
+            i for i in range(self.num_inputs) if i not in self.scalar_input_indices
+        )
+
+
+_FAMILIES: dict[str, PointwiseFamilySpec] = {}
+_PLANS_BY_KEY: dict[tuple[str, int, torch.dtype, str], PointwisePlan] = {}
+_PLANS_BY_TOKEN: dict[int, PointwisePlan] = {}
+_NEXT_PLAN_TOKEN = 0
+
+
+def register_pointwise_family(spec: PointwiseFamilySpec) -> PointwiseFamilySpec:
+    """Register structural facts without generating or launching a kernel."""
+
+    if torch.compiler.is_compiling():
+        raise RuntimeError("pointwise family registration is forbidden inside Dynamo")
+    if not isinstance(spec.source_pointwise, PointwiseDynamicFunction):
+        raise TypeError(f"{spec.name!r} is not a PointwiseDynamicFunction")
+    if spec.num_inputs < 1:
+        raise ValueError("pointwise family must have at least one tensor input")
+
+    scalar_indices = tuple(sorted(set(spec.scalar_input_indices)))
+    if scalar_indices != spec.scalar_input_indices:
+        raise ValueError("scalar_input_indices must be sorted and unique")
+    if any(i < 0 or i >= spec.num_inputs for i in scalar_indices):
+        raise ValueError(f"invalid scalar input index for {spec.name!r}")
+    if len(scalar_indices) == spec.num_inputs:
+        raise ValueError("pointwise family requires a non-scalar primary tensor")
+
+    schema = spec.source_pointwise.fx
+    if (
+        schema.num_input_tensors() != spec.num_inputs
+        or schema.num_non_tensor_args() != 0
+        or schema.num_output_tensors() != 1
+    ):
+        raise RuntimeError(
+            f"Unsupported PT2 pointwise schema for {spec.name!r}: {schema}. "
+            "This adapter requires tensor-only inputs and exactly one output."
+        )
+
+    previous = _FAMILIES.get(spec.name)
+    if previous is not None and previous != spec:
+        raise RuntimeError(f"Conflicting pointwise family {spec.name!r}")
+    _FAMILIES[spec.name] = spec
+    return spec
+
+
+SILU_AND_MUL_FAMILY = register_pointwise_family(
+    PointwiseFamilySpec("silu_and_mul", _silu_source, num_inputs=2)
+)
+GELU_NONE_AND_MUL_FAMILY = register_pointwise_family(
+    PointwiseFamilySpec("gelu_and_mul.none", _gelu_none_source, num_inputs=2)
+)
+GELU_TANH_AND_MUL_FAMILY = register_pointwise_family(
+    PointwiseFamilySpec("gelu_and_mul.tanh", _gelu_tanh_source, num_inputs=2)
+)
+SILU_AND_MUL_WITH_CLAMP_FAMILY = register_pointwise_family(
+    PointwiseFamilySpec(
+        "silu_and_mul_with_clamp",
+        _silu_clamp_source,
+        num_inputs=3,
+        scalar_input_indices=(2,),
+    )
+)
+
+ACTIVATION_POINTWISE_FAMILIES = (
+    SILU_AND_MUL_FAMILY.name,
+    GELU_NONE_AND_MUL_FAMILY.name,
+    GELU_TANH_AND_MUL_FAMILY.name,
+    SILU_AND_MUL_WITH_CLAMP_FAMILY.name,
+)
+
+
+def _family(name: str) -> PointwiseFamilySpec:
+    try:
+        return _FAMILIES[name]
+    except KeyError as exc:
+        raise KeyError(f"unknown pointwise family: {name!r}") from exc
+
+
+def materialize_pointwise_plan(
+    op_name: str,
+    *,
+    ndim: int = 2,
+    dtype: torch.dtype = torch.bfloat16,
+    layout_class: str = "split_last_dim_c",
+) -> PointwisePlan:
+    """Materialize structural codegen state outside a Dynamo graph."""
+
+    global _NEXT_PLAN_TOKEN
+
+    if torch.compiler.is_compiling():
+        raise RuntimeError("pointwise plan materialization is forbidden inside Dynamo")
+    if ndim not in _SUPPORTED_RANKS:
+        raise ValueError(f"supported ranks are {_SUPPORTED_RANKS}, got rank {ndim}")
+    if dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(f"unsupported pointwise dtype: {dtype}")
+    if layout_class not in _SUPPORTED_LAYOUTS:
+        raise ValueError(f"unsupported pointwise layout class: {layout_class!r}")
+
+    family = _family(op_name)
+    key = (family.name, ndim, dtype, layout_class)
+    cached = _PLANS_BY_KEY.get(key)
+    if cached is not None:
+        return cached
+
+    # PointwiseDynamic.prepare_args collapses equal-shape C-contiguous tensor
+    # operands to one physical task dimension.  Families with a scalar-tensor
+    # broadcast cannot take that fast path because not all tensor shapes match.
+    # Preserve that exact eager choice instead of merely using the input rank.
+    kernel_ndim = (
+        1
+        if layout_class == "contiguous_c" and not family.scalar_input_indices
+        else ndim
+    )
+    generated = family.source_pointwise.materialize(kernel_ndim)
+    if generated.runtime_chain != ("LibEntry", "JITFunction"):
+        raise RuntimeError(
+            "Transparent pointwise PT2 only supports the generated "
+            "LibEntry(JITFunction) chain; refusing to drop tuner/heuristic "
+            f"semantics from {generated.runtime_chain!r}"
+        )
+
+    plan = PointwisePlan(
+        token=_NEXT_PLAN_TOKEN,
+        op_name=family.name,
+        ndim=ndim,
+        kernel_ndim=kernel_ndim,
+        dtype=dtype,
+        layout_class=layout_class,
+        num_inputs=family.num_inputs,
+        scalar_input_indices=family.scalar_input_indices,
+        materialization=generated,
+        num_warps_policy=get_heuristics_for_num_warps_fn(),
+        tensor_stride_order=tuple(reversed(range(kernel_ndim))),
+        scalar_stride_order=tuple(range(kernel_ndim)),
+    )
+    _NEXT_PLAN_TOKEN += 1
+    _PLANS_BY_KEY[key] = plan
+    _PLANS_BY_TOKEN[plan.token] = plan
+    return plan
+
+
+def materialize_pointwise_family_plans(
+    op_names: Iterable[str],
+    *,
+    ranks: Iterable[int] = (2,),
+    dtypes: Iterable[torch.dtype] = _SUPPORTED_DTYPES,
+    layout_classes: Iterable[str] = _SUPPORTED_LAYOUTS,
+) -> tuple[PointwisePlan, ...]:
+    """Freeze a Cartesian product of structural plans before Dynamo capture."""
+
+    plans = []
+    for op_name in op_names:
+        for ndim in ranks:
+            for dtype in dtypes:
+                for layout_class in layout_classes:
+                    plans.append(
+                        materialize_pointwise_plan(
+                            op_name,
+                            ndim=ndim,
+                            dtype=dtype,
+                            layout_class=layout_class,
+                        )
+                    )
+    return tuple(plans)
+
+
+def materialize_silu_and_mul_plan(**kwargs) -> PointwisePlan:
+    return materialize_pointwise_plan(SILU_AND_MUL_FAMILY.name, **kwargs)
+
+
+def _gelu_family(approximate: str) -> PointwiseFamilySpec:
+    if approximate == "none":
+        return GELU_NONE_AND_MUL_FAMILY
+    if approximate == "tanh":
+        return GELU_TANH_AND_MUL_FAMILY
+    raise ValueError(f"Invalid approximate value: {approximate}")
+
+
+def materialize_gelu_and_mul_plan(
+    *, approximate: str = "none", **kwargs
+) -> PointwisePlan:
+    return materialize_pointwise_plan(_gelu_family(approximate).name, **kwargs)
+
+
+def materialize_silu_and_mul_with_clamp_plan(**kwargs) -> PointwisePlan:
+    return materialize_pointwise_plan(SILU_AND_MUL_WITH_CLAMP_FAMILY.name, **kwargs)
+
+
+def materialized_pointwise_plans(
+    op_name: str | None = None,
+) -> tuple[PointwisePlan, ...]:
+    """Return a stable diagnostic snapshot without exposing mutable caches."""
+
+    plans = tuple(_PLANS_BY_TOKEN[token] for token in sorted(_PLANS_BY_TOKEN))
+    if op_name is None:
+        return plans
+    return tuple(plan for plan in plans if plan.op_name == op_name)
+
+
+def _layout_class(family: PointwiseFamilySpec, inputs: tuple[torch.Tensor, ...]) -> str:
+    primary = tuple(inputs[i] for i in family.primary_input_indices)
+    if all(tensor.is_contiguous() for tensor in primary):
+        return "contiguous_c"
+    return "split_last_dim_c"
+
+
+def _resolve_plan_token(op_name: str, inputs: tuple[torch.Tensor, ...]) -> int:
+    """Resolve already-materialized metadata; never codegen on a cache miss."""
+
+    family = _family(op_name)
+    if len(inputs) != family.num_inputs:
+        raise RuntimeError(
+            f"{family.name!r} requires {family.num_inputs} inputs, got {len(inputs)}"
+        )
+    reference = inputs[family.primary_input_indices[0]]
+    for tensor in inputs:
+        if tensor.dtype != reference.dtype:
+            raise RuntimeError(f"{family.name!r} requires one input dtype")
+        if tensor.device != reference.device:
+            raise RuntimeError(f"{family.name!r} requires one input device")
+
+    key = (
+        family.name,
+        reference.ndim,
+        reference.dtype,
+        _layout_class(family, inputs),
+    )
+    plan = _PLANS_BY_KEY.get(key)
+    if plan is None:
+        raise RuntimeError(
+            "No materialized pointwise plan for "
+            f"op={key[0]!r}, rank={key[1]}, dtype={key[2]}, layout={key[3]!r}. "
+            "Materialize it outside Dynamo before compiling this specialization."
+        )
+    return plan.token
+
+
+def _check_contract(plan: PointwisePlan, inputs: tuple[torch.Tensor, ...]) -> None:
+    torch._check(len(inputs) == plan.num_inputs)
+    reference = inputs[plan.primary_input_indices[0]]
+    torch._check(reference.ndim == plan.ndim)
+
+    for index, tensor in enumerate(inputs):
+        torch._check(tensor.dtype == plan.dtype)
+        torch._check(tensor.device == reference.device)
+        if index in plan.scalar_input_indices:
+            torch._check(tensor.numel() == 1)
+            continue
+        torch._check(tensor.ndim == plan.ndim)
+        for axis in range(plan.ndim):
+            torch._check(tensor.shape[axis] == reference.shape[axis])
+        if plan.layout_class == "contiguous_c":
+            torch._check(tensor.is_contiguous())
+        else:
+            torch._check(not tensor.is_contiguous())
+            torch._check(tensor.stride(plan.ndim - 1) == 1)
+            for axis in range(plan.ndim - 1):
+                torch._check(tensor.stride(axis) >= tensor.stride(axis + 1))
+
+
+def _task_shape(plan: PointwisePlan, out: torch.Tensor):
+    if plan.kernel_ndim == plan.ndim:
+        return out.shape
+    torch._check(plan.kernel_ndim == 1)
+    return (out.numel(),)
+
+
+def _runtime_strides(plan: PointwisePlan, tensor: torch.Tensor, *, scalar: bool):
+    if scalar:
+        return (0,) * plan.kernel_ndim
+    if plan.kernel_ndim == plan.ndim:
+        return tensor.stride()
+    torch._check(plan.kernel_ndim == 1)
+    return (1,)
+
+
+def _partition(plan: PointwisePlan, out: torch.Tensor):
+    """PT2-safe transcription of the generated wrapper's launch policy."""
+
+    shape = _task_shape(plan, out)
+    num_tasks = out.numel()
+    if num_tasks == 0:
+        return None
+    if plan.materialization.prefer_block_pointer:
+        # Eager prepare_args selects a non-block-pointer ABI for larger tensors.
+        # That ABI must be materialized outside Dynamo as a different plan.
+        torch._check(num_tasks <= 2_147_483_647)
+
+    if plan.materialization.prefer_1d_tile:
+        tile_size = min(
+            plan.materialization.max_tile_size,
+            triton.next_power_of_2(num_tasks),
+        )
+        tile_sizes = (tile_size,)
+        num_tiles = triton.cdiv(num_tasks, tile_size)
+    else:
+        remaining = plan.materialization.max_tile_size
+        reversed_tiles = []
+        for axis in reversed(range(plan.kernel_ndim)):
+            tile_size = min(remaining, triton.next_power_of_2(shape[axis]))
+            reversed_tiles.append(tile_size)
+            remaining = max(1, remaining // tile_size)
+        tile_sizes = tuple(reversed(reversed_tiles))
+        num_tiles = 1
+        for size, tile_size in zip(shape, tile_sizes):
+            num_tiles *= triton.cdiv(size, tile_size)
+
+    num_ctas = min(plan.materialization.max_grid_size[0], num_tiles)
+    tiles_per_cta = triton.cdiv(num_tiles, num_ctas)
+    tile_volume = 1
+    for tile_size in tile_sizes:
+        tile_volume *= tile_size
+    num_warps = plan.num_warps_policy(tile_volume)
+    return (
+        (num_ctas, 1, 1),
+        num_tasks,
+        tiles_per_cta,
+        tile_sizes,
+        tiles_per_cta == 1,
+        num_warps,
+    )
+
+
+def _launch_plan(
+    plan: PointwisePlan,
+    inputs: tuple[torch.Tensor, ...],
+    out: torch.Tensor,
+    launch,
+) -> None:
+    grid, num_tasks, tiles_per_cta, tiles, one_tile, num_warps = launch
+    wrapped = torch.library.wrap_triton(plan.jit_function)
+    args = [*inputs, out]
+    for index, tensor in enumerate(inputs):
+        is_scalar = index in plan.scalar_input_indices
+        args.extend(_runtime_strides(plan, tensor, scalar=is_scalar))
+        if is_scalar:
+            stride_order = plan.scalar_stride_order
+        else:
+            stride_order = plan.tensor_stride_order
+        if plan.materialization.prefer_block_pointer:
+            args.extend(stride_order)
+
+    args.extend(_runtime_strides(plan, out, scalar=False))
+    if plan.materialization.prefer_block_pointer:
+        args.extend(plan.tensor_stride_order)
+    args.extend(_task_shape(plan, out))
+    args.append(num_tasks)
+
+    kwargs = {
+        "tiles_per_cta": tiles_per_cta,
+        "one_tile_per_cta": one_tile,
+        "num_warps": num_warps,
+    }
+    if plan.materialization.prefer_1d_tile:
+        kwargs["tile_size"] = tiles[0]
+    else:
+        for axis, tile_size in enumerate(tiles):
+            kwargs[f"tile_size{axis}"] = tile_size
+    wrapped[grid](*args, **kwargs)
+
+
+def _execute_plan(inputs: tuple[torch.Tensor, ...], plan_token: int) -> torch.Tensor:
+    plan = _PLANS_BY_TOKEN[plan_token]
+    _check_contract(plan, inputs)
+    reference = inputs[plan.primary_input_indices[0]]
+    out = torch.empty_like(reference)
+    launch = _partition(plan, out)
+    if launch is not None:
+        _launch_plan(plan, inputs, out, launch)
+    return out
+
+
+if _HAS_TRITON_OP:
+
+    @torch.library.triton_op("flag_gems_pt2::silu_and_mul_pointwise", mutates_args={})
+    def _silu_and_mul_pointwise_op(
+        gate: torch.Tensor, up: torch.Tensor, plan_token: int
+    ) -> torch.Tensor:
+        return _execute_plan((gate, up), plan_token)
+
+    @torch.library.triton_op("flag_gems_pt2::gelu_and_mul_pointwise", mutates_args={})
+    def _gelu_and_mul_pointwise_op(
+        gate: torch.Tensor, up: torch.Tensor, plan_token: int
+    ) -> torch.Tensor:
+        return _execute_plan((gate, up), plan_token)
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::silu_and_mul_with_clamp_pointwise", mutates_args={}
+    )
+    def _silu_and_mul_with_clamp_pointwise_op(
+        gate: torch.Tensor,
+        up: torch.Tensor,
+        limit: torch.Tensor,
+        plan_token: int,
+    ) -> torch.Tensor:
+        return _execute_plan((gate, up, limit), plan_token)
+
+else:
+    _silu_and_mul_pointwise_op = None
+    _gelu_and_mul_pointwise_op = None
+    _silu_and_mul_with_clamp_pointwise_op = None
+
+
+_POINTWISE_REQUIRES = (
+    "PointwiseDynamicFunction.materialize",
+    "torch.library.triton_op",
+    "torch.library.wrap_triton",
+)
+
+SILU_AND_MUL_POINTWISE_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::silu_and_mul_pointwise",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.silu_and_mul.silu_and_mul_kernel"
+            ".materialize(ndim).jit_function"
+        ),
+        dynamic_dims=("n_tokens",),
+        requires=_POINTWISE_REQUIRES,
+    )
+)
+
+GELU_AND_MUL_POINTWISE_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::gelu_and_mul_pointwise",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "guarded approximate selects flag_gems.fused.gelu_and_mul."
+            "gelu_{none,tanh}_and_mul_kernel.materialize(ndim).jit_function"
+        ),
+        dynamic_dims=("n_tokens",),
+        requires=_POINTWISE_REQUIRES,
+    )
+)
+
+SILU_AND_MUL_WITH_CLAMP_POINTWISE_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::silu_and_mul_with_clamp_pointwise",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.silu_and_mul_with_clamp."
+            "silu_and_mul_with_clamp_kernel.materialize(ndim).jit_function"
+        ),
+        dynamic_dims=("n_tokens",),
+        requires=_POINTWISE_REQUIRES,
+    )
+)
+
+
+def _missing_triton_op() -> RuntimeError:
+    return RuntimeError(
+        "This Torch build lacks triton_op/wrap_triton; the transparent "
+        "pointwise PT2 contract is unavailable"
+    )
+
+
+def silu_and_mul_pointwise(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Run the original generated SiLU-and-multiply kernel."""
+
+    if torch.compiler.is_compiling():
+        if _silu_and_mul_pointwise_op is None:
+            raise _missing_triton_op()
+        plan_token = _resolve_plan_token(SILU_AND_MUL_FAMILY.name, (gate, up))
+        return _silu_and_mul_pointwise_op(gate, up, plan_token)
+    return SILU_AND_MUL_FAMILY.source_pointwise(gate, up)
+
+
+def gelu_and_mul_pointwise(
+    gate: torch.Tensor, up: torch.Tensor, approximate: str = "none"
+) -> torch.Tensor:
+    """Run the guarded original GELU-none or GELU-tanh generated kernel."""
+
+    family = _gelu_family(approximate)
+    if torch.compiler.is_compiling():
+        if _gelu_and_mul_pointwise_op is None:
+            raise _missing_triton_op()
+        plan_token = _resolve_plan_token(family.name, (gate, up))
+        return _gelu_and_mul_pointwise_op(gate, up, plan_token)
+    return family.source_pointwise(gate, up)
+
+
+def silu_and_mul_with_clamp_pointwise(
+    gate: torch.Tensor, up: torch.Tensor, limit: torch.Tensor
+) -> torch.Tensor:
+    """Run the original generated clamped SiLU-and-multiply kernel."""
+
+    inputs = (gate, up, limit)
+    if torch.compiler.is_compiling():
+        if _silu_and_mul_with_clamp_pointwise_op is None:
+            raise _missing_triton_op()
+        plan_token = _resolve_plan_token(SILU_AND_MUL_WITH_CLAMP_FAMILY.name, inputs)
+        return _silu_and_mul_with_clamp_pointwise_op(gate, up, limit, plan_token)
+    return SILU_AND_MUL_WITH_CLAMP_FAMILY.source_pointwise(*inputs)
+
+
+__all__ = [
+    "ACTIVATION_POINTWISE_FAMILIES",
+    "GELU_AND_MUL_POINTWISE_SPEC",
+    "GELU_NONE_AND_MUL_FAMILY",
+    "GELU_TANH_AND_MUL_FAMILY",
+    "PointwiseFamilySpec",
+    "PointwisePlan",
+    "SILU_AND_MUL_FAMILY",
+    "SILU_AND_MUL_POINTWISE_SPEC",
+    "SILU_AND_MUL_WITH_CLAMP_FAMILY",
+    "SILU_AND_MUL_WITH_CLAMP_POINTWISE_SPEC",
+    "gelu_and_mul_pointwise",
+    "materialize_gelu_and_mul_plan",
+    "materialize_pointwise_family_plans",
+    "materialize_pointwise_plan",
+    "materialize_silu_and_mul_plan",
+    "materialize_silu_and_mul_with_clamp_plan",
+    "materialized_pointwise_plans",
+    "register_pointwise_family",
+    "silu_and_mul_pointwise",
+    "silu_and_mul_with_clamp_pointwise",
+]

--- a/src/flag_gems/pt2/rms_norm.py
+++ b/src/flag_gems/pt2/rms_norm.py
@@ -1,0 +1,263 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transparent PT2 contracts for the existing FlagGems RMSNorm kernels.
+
+The public FlagGems launchers mix tensor work with logging, contiguous
+conversion, output allocation, hidden-size dispatch, and ``LibEntry`` cache
+control.  Dynamo cannot trace those host-side Python responsibilities in a
+fullgraph, and the pt2 contracts are the compile-mode path used under
+torch.compile for these ops; eager callers keep the original launchers.
+
+There is no generated or compile-only mathematical kernel here: eager and
+compiled execution run the same kernel objects.
+
+* the small standalone path wraps ``rms_norm_kernel.jit_function``;
+* the large standalone path wraps the *same* Autotuner nested in
+  ``rms_norm_loop_kernel`` so all configs and its ``key=[\"N\"]`` survive;
+* the fused paths wrap the JITFunctions nested in the two original LibEntry
+  objects and preserve their in-place writes to ``x`` and ``residual``.
+
+The vLLM integration contract has one normalized dimension.  The standalone
+path matches the existing eager launcher by materializing strided inputs
+before the contiguous Triton ABI.  Hidden size chooses the small/loop family
+under a Dynamo guard, whereas leading token dimensions remain symbolic.  The
+fused path keeps its stricter contiguous contract so its mutation and alias
+semantics cannot be changed by an implicit copy.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+
+from flag_gems.fused.fused_add_rms_norm import (
+    fused_add_rms_norm as _eager_fused_add_rms_norm,
+)
+from flag_gems.fused.fused_add_rms_norm import (
+    fused_add_rms_norm_kernel as _fused_small_entry,
+)
+from flag_gems.fused.fused_add_rms_norm import (
+    fused_add_rms_norm_loop_kernel as _fused_loop_entry,
+)
+from flag_gems.ops.rms_norm import rms_norm as _eager_rms_norm
+from flag_gems.ops.rms_norm import rms_norm_kernel as _rms_small_entry
+from flag_gems.ops.rms_norm import rms_norm_loop_kernel as _rms_loop_entry
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+_SMALL_HIDDEN_LIMIT = 4096
+_FUSED_LOOP_BLOCK_SIZE = 1024
+
+# Preserve object identity with the eager launch chain.  LibEntry itself is a
+# Python dispatch/cache layer and is not understood by Dynamo.  For a direct
+# LibEntry(JITFunction) chain we expose that exact nested JITFunction.  The
+# standalone loop is LibEntry(Autotuner(JITFunction)), so the whole original
+# Autotuner is wrapped rather than silently choosing one configuration.
+RMS_NORM_SMALL_JIT = _rms_small_entry.jit_function
+RMS_NORM_LOOP_AUTOTUNER = _rms_loop_entry.fn
+FUSED_ADD_RMS_NORM_SMALL_JIT = _fused_small_entry.jit_function
+FUSED_ADD_RMS_NORM_LOOP_JIT = _fused_loop_entry.jit_function
+
+
+def supports_pt2_rms_norm() -> bool:
+    """Return whether transparent Triton operator APIs are available."""
+
+    return _HAS_TRITON_OP
+
+
+def _check_standard_contract(x: torch.Tensor, weight: torch.Tensor) -> tuple[int, int]:
+    """Validate the one-dimensional, contiguous kernel ABI."""
+
+    torch._check(x.ndim >= 1)
+    torch._check(weight.ndim == 1)
+    torch._check(x.dtype == weight.dtype)
+    torch._check(x.device == weight.device)
+    torch._check(x.is_contiguous())
+    torch._check(weight.is_contiguous())
+    hidden_size = weight.numel()
+    torch._check(hidden_size > 0)
+    torch._check(x.shape[-1] == hidden_size)
+    num_rows = x.numel() // hidden_size
+    return num_rows, hidden_size
+
+
+def _check_fused_contract(
+    x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor
+) -> tuple[int, int]:
+    num_rows, hidden_size = _check_standard_contract(x, weight)
+    torch._check(residual.ndim == x.ndim)
+    for axis in range(x.ndim):
+        torch._check(residual.shape[axis] == x.shape[axis])
+    torch._check(residual.dtype == x.dtype)
+    torch._check(residual.device == x.device)
+    torch._check(residual.is_contiguous())
+    return num_rows, hidden_size
+
+
+if _HAS_TRITON_OP:
+
+    @torch.library.triton_op("flag_gems_pt2::rms_norm", mutates_args={})
+    def _rms_norm_op(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+        num_rows, hidden_size = _check_standard_contract(x, weight)
+        out = torch.empty_like(x)
+        inv_rms = torch.empty((num_rows,), device=x.device, dtype=torch.float32)
+        if num_rows == 0:
+            return out
+        if hidden_size <= _SMALL_HIDDEN_LIMIT:
+            block_size = triton.next_power_of_2(hidden_size)
+            torch.library.wrap_triton(RMS_NORM_SMALL_JIT)[(num_rows,)](
+                out,
+                inv_rms,
+                x,
+                weight,
+                hidden_size,
+                1,
+                hidden_size,
+                1,
+                hidden_size,
+                eps,
+                block_size,
+            )
+        else:
+            torch.library.wrap_triton(RMS_NORM_LOOP_AUTOTUNER)[(num_rows,)](
+                out, inv_rms, x, weight, hidden_size, eps
+            )
+        return out
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::fused_add_rms_norm",
+        mutates_args={"x", "residual"},
+    )
+    def _fused_add_rms_norm_op(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float,
+    ) -> None:
+        num_rows, hidden_size = _check_fused_contract(x, residual, weight)
+        if num_rows == 0:
+            return
+        if hidden_size <= _SMALL_HIDDEN_LIMIT:
+            block_size = triton.next_power_of_2(hidden_size)
+            torch.library.wrap_triton(FUSED_ADD_RMS_NORM_SMALL_JIT)[(num_rows,)](
+                x,
+                residual,
+                weight,
+                hidden_size,
+                1,
+                hidden_size,
+                1,
+                hidden_size,
+                eps,
+                block_size,
+            )
+        else:
+            torch.library.wrap_triton(FUSED_ADD_RMS_NORM_LOOP_JIT)[(num_rows,)](
+                x,
+                residual,
+                weight,
+                hidden_size,
+                eps,
+                _FUSED_LOOP_BLOCK_SIZE,
+            )
+
+else:
+    _rms_norm_op = None
+    _fused_add_rms_norm_op = None
+
+
+_RMS_REQUIRES = (
+    "torch.library.triton_op",
+    "torch.library.wrap_triton",
+    "standalone inputs materialized to a contiguous one-dimensional shape",
+)
+
+_FUSED_RMS_REQUIRES = (
+    "torch.library.triton_op",
+    "torch.library.wrap_triton",
+    "contiguous one-dimensional normalized shape for mutation safety",
+)
+
+RMS_NORM_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::rms_norm",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.ops.rms_norm.{rms_norm_kernel.jit_function,"
+            "rms_norm_loop_kernel.fn}"
+        ),
+        dynamic_dims=("leading_token_dims",),
+        requires=_RMS_REQUIRES,
+    )
+)
+
+FUSED_ADD_RMS_NORM_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::fused_add_rms_norm",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.fused_add_rms_norm."
+            "{fused_add_rms_norm_kernel,fused_add_rms_norm_loop_kernel}."
+            "jit_function"
+        ),
+        mutates_args=("x", "residual"),
+        dynamic_dims=("leading_token_dims",),
+        requires=_FUSED_RMS_REQUIRES,
+    )
+)
+
+
+def _missing_triton_op() -> RuntimeError:
+    return RuntimeError(
+        "This Torch build lacks triton_op/wrap_triton; the transparent "
+        "FlagGems RMSNorm PT2 contract is unavailable"
+    )
+
+
+def rms_norm(
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run the original FlagGems RMSNorm family in eager or compiled mode."""
+
+    if torch.compiler.is_compiling():
+        if _rms_norm_op is None or _fused_add_rms_norm_op is None:
+            raise _missing_triton_op()
+        if residual is None:
+            # Match the original eager launcher.  Qwen-style Q/K projections
+            # are split views whose last dimension is dense but whose row
+            # stride still spans the complete QKV allocation.  Record the
+            # materialization in the outer FX graph, then keep the triton_op's
+            # contiguous checks as the fail-closed kernel ABI.
+            x = x.contiguous()
+            weight = weight.contiguous()
+            return _rms_norm_op(x, weight, eps)
+        _fused_add_rms_norm_op(x, residual, weight, eps)
+        return x, residual
+
+    normalized_shape = list(weight.size())
+    if residual is None:
+        return _eager_rms_norm(x, normalized_shape, weight, eps)
+    return _eager_fused_add_rms_norm(x, residual, normalized_shape, weight, eps)
+
+
+__all__ = [
+    "FUSED_ADD_RMS_NORM_LOOP_JIT",
+    "FUSED_ADD_RMS_NORM_SMALL_JIT",
+    "FUSED_ADD_RMS_NORM_SPEC",
+    "RMS_NORM_LOOP_AUTOTUNER",
+    "RMS_NORM_SMALL_JIT",
+    "RMS_NORM_SPEC",
+    "rms_norm",
+    "supports_pt2_rms_norm",
+]

--- a/src/flag_gems/pt2/rotary_embedding.py
+++ b/src/flag_gems/pt2/rotary_embedding.py
@@ -1,0 +1,139 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""PT2 contract for the existing FlagGems rotary embedding Triton kernel."""
+
+import torch
+import triton
+
+from flag_gems.fused.rotary_embedding import (
+    apply_rotary_pos_emb,
+    apply_rotary_pos_emb_inplace_kernel,
+)
+from flag_gems.pt2.manifest import CompileKind, CompileOpSpec, register_compile_spec
+
+_RAW_INPLACE_KERNEL = apply_rotary_pos_emb_inplace_kernel.jit_function
+_HAS_TRITON_OP = hasattr(torch.library, "triton_op") and hasattr(
+    torch.library, "wrap_triton"
+)
+
+
+def supports_pt2_triton() -> bool:
+    """Return whether this Torch build exposes the required PT2 Triton APIs."""
+
+    return _HAS_TRITON_OP
+
+
+if _HAS_TRITON_OP:
+
+    @torch.library.triton_op(
+        "flag_gems_pt2::rotary_embedding_inplace",
+        mutates_args={"query", "key"},
+    )
+    def _rotary_embedding_inplace_op(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool,
+    ) -> None:
+        """Launch the original FlagGems JITFunction with a traceable call."""
+
+        n_tokens = query.shape[0]
+        head_dim = query.shape[-1]
+        padded_head_dim = max(triton.next_power_of_2(head_dim), 16)
+
+        torch.library.wrap_triton(_RAW_INPLACE_KERNEL)[(n_tokens,)](
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            query.stride(0),
+            query.stride(1),
+            query.stride(2),
+            key.stride(0),
+            key.stride(1),
+            key.stride(2),
+            position_ids.stride(0),
+            cos.stride(0),
+            sin.stride(0),
+            0,  # seq_len is unused when position_ids is provided.
+            query.shape[-2],
+            key.shape[-2],
+            head_dim,
+            padded_head_dim,
+            rotary_interleaved,
+            MAX_POSITION_EMBEDDINGS=cos.shape[0],
+        )
+
+else:
+    _rotary_embedding_inplace_op = None
+
+
+ROTARY_EMBEDDING_INPLACE_SPEC = register_compile_spec(
+    CompileOpSpec(
+        op_name="flag_gems_pt2::rotary_embedding_inplace",
+        kind=CompileKind.TRITON_TRACEABLE,
+        source_kernel=(
+            "flag_gems.fused.rotary_embedding."
+            "apply_rotary_pos_emb_inplace_kernel.jit_function"
+        ),
+        mutates_args=("query", "key"),
+        dynamic_dims=("n_tokens",),
+        requires=("torch.library.triton_op", "torch.library.wrap_triton"),
+    )
+)
+
+
+def rotary_embedding_inplace(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+) -> None:
+    """Use one kernel body in eager and compiled execution.
+
+    Supported PT2 builds call the registered ``triton_op`` in both modes.  An
+    older vendor Torch build may still use the original LibEntry eager launch,
+    but compilation fails explicitly instead of substituting a native kernel.
+    """
+
+    if _rotary_embedding_inplace_op is not None:
+        _rotary_embedding_inplace_op(
+            query, key, cos, sin, position_ids, rotary_interleaved
+        )
+        return
+
+    if hasattr(torch, "compiler") and torch.compiler.is_compiling():
+        raise RuntimeError(
+            "This Torch build does not provide torch.library.triton_op and "
+            "torch.library.wrap_triton; FlagGems RoPE cannot enter a PT2 graph"
+        )
+
+    # Compatibility for eager-only vendor Torch builds.  This is still the
+    # exact same Triton kernel object; it is not a PyTorch-native fallback.
+    apply_rotary_pos_emb(
+        query,
+        key,
+        cos,
+        sin,
+        position_ids=position_ids,
+        rotary_interleaved=rotary_interleaved,
+        inplace=True,
+    )
+
+
+__all__ = [
+    "ROTARY_EMBEDDING_INPLACE_SPEC",
+    "rotary_embedding_inplace",
+    "supports_pt2_triton",
+]

--- a/src/flag_gems/utils/codegen_config_utils.py
+++ b/src/flag_gems/utils/codegen_config_utils.py
@@ -197,7 +197,18 @@ def get_codegen_config():
     return CODEGEN_COFIGS.get(device.vendor)
 
 
-def get_heuristics_for_num_warps(tile_size):
+def get_heuristics_for_num_warps_fn():
+    """Resolve the active backend's immutable pointwise warp policy.
+
+    Pointwise PT2 plans call this once while materializing outside Dynamo, then
+    retain the returned function as structural launch policy.  Runtime tile
+    buckets may remain symbolic without re-running backend dispatch in a graph.
+    """
+
     if device.vendor not in HEURISTICS_CONFIG:
-        return HEURISTICS_CONFIG.get(vendors.NVIDIA)(tile_size)
-    return HEURISTICS_CONFIG.get(device.vendor)(tile_size)
+        return HEURISTICS_CONFIG.get(vendors.NVIDIA)
+    return HEURISTICS_CONFIG.get(device.vendor)
+
+
+def get_heuristics_for_num_warps(tile_size):
+    return get_heuristics_for_num_warps_fn()(tile_size)

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -16,7 +16,7 @@ import importlib
 import os
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import torch
 import triton
@@ -549,7 +549,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_with_bptr(self, code):
-        code.writeline("num_ctas = ext.num_programs(0)")
+        code.writeline("num_ctas = num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -625,7 +625,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_without_bptr(self, code):
-        code.writeline("num_ctas = ext.num_programs(0)")
+        code.writeline("num_ctas = num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -644,7 +644,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = ext.program_id(0)")
+            code.writeline("pid = program_id(0)")
             self.gen_num_tiles(code)
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
@@ -670,7 +670,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = ext.program_id(0)")
+            code.writeline("pid = program_id(0)")
             self.gen_num_tiles(code)
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
@@ -744,7 +744,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_1d_tile(self, code):
-        code.writeline("num_ctas = ext.num_programs(0)")
+        code.writeline("num_ctas = num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -763,7 +763,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = ext.program_id(0)")
+            code.writeline("pid = program_id(0)")
             # code.writeline("num_ctas = te.num_programs(0)")
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
@@ -1188,7 +1188,9 @@ class ModuleGenerator:
         code.writeline(")")
         code.writeline("from flag_gems.utils.tensor_wrapper import StridedBuffer")
         code.writeline("from flag_gems.utils.libentry import libentry")
-        code.writeline("from flag_gems.utils import triton_lang_extension as ext")
+        code.writeline(
+            "from flag_gems.utils.triton_lang_extension import num_programs, program_id"
+        )
         code.writeline("from flag_gems.runtime import torch_device_fn")
 
         # Generate extra imports and local JIT deps of the scalar function
@@ -1227,6 +1229,37 @@ class KernelInfo:
     kernel_name: str
     wrapper_name: str
     ndim: int
+
+
+@dataclass(frozen=True)
+class PointwiseKernelMaterialization:
+    """Immutable handle to one generated pointwise kernel family.
+
+    ``PointwiseDynamicFunction.instantiate`` historically returned only the
+    generated Python launcher.  PT2 integration also needs the generated
+    tensor-level kernel, but reconstructing it from ``wrapper.__globals__``
+    would make compiler integration depend on a code-generation detail.  This
+    record is the supported bridge: materialization remains Python control
+    plane work, while the saved ``jit_function`` can be passed to
+    ``torch.library.wrap_triton`` after the Dynamo boundary.
+
+    The record snapshots every code-generation/launch-policy field that can
+    affect the generated ABI.  It deliberately contains no Tensor, data
+    pointer, output allocation, shape value, or launch grid.
+    """
+
+    cache_key: str
+    ndim: int
+    wrapper: Callable
+    entry: Any
+    jit_function: JITFunction
+    kernel_info: KernelInfo
+    runtime_chain: Tuple[str, ...]
+    max_tile_size: int
+    max_grid_size: Tuple[int, int, int]
+    max_num_warps_per_cta: int
+    prefer_block_pointer: bool
+    prefer_1d_tile: bool
 
 
 class ComplexMode(Enum):
@@ -1271,6 +1304,10 @@ class PointwiseDynamicFunction:
         self.overloads: Mapping[str, Callable] = {}
         # cached kernel info for C++ integration
         self._kernel_info_cache: Mapping[str, KernelInfo] = {}
+        # compiler-facing generated kernel handles.  These are populated by
+        # the same instantiate() call as ``overloads``; PT2 never codegens a
+        # second mathematical kernel.
+        self._materialization_cache: Mapping[str, PointwiseKernelMaterialization] = {}
 
         # complex dispatch support
         self.complex_strategy = ComplexStrategy()
@@ -1702,17 +1739,67 @@ class PointwiseDynamicFunction:
         m.__dict__[self._scalar_fn.__name__] = self._scalar_fn
 
         overload = getattr(m, wrapper_name)
+        entry = getattr(m, kernel_name)
         self.overloads[key] = overload
 
         # Cache kernel info for C++ integration
-        self._kernel_info_cache[key] = KernelInfo(
+        kernel_info = KernelInfo(
             file_path=file_path,
             kernel_name=kernel_name,
             wrapper_name=wrapper_name,
             ndim=ndim,
         )
+        self._kernel_info_cache[key] = kernel_info
+
+        # LibEntry intentionally exposes the innermost generated JITFunction.
+        # Preserve the whole wrapper chain in ``entry`` for eager execution and
+        # diagnostics; only the raw generated function crosses wrap_triton.
+        jit_function = getattr(entry, "jit_function", None)
+        if not isinstance(jit_function, JITFunction):
+            raise RuntimeError(
+                f"Generated pointwise entry {kernel_name!r} did not expose a "
+                "Triton JITFunction"
+            )
+        runtime_chain = []
+        runtime_fn = entry
+        seen = set()
+        while runtime_fn is not None and id(runtime_fn) not in seen:
+            seen.add(id(runtime_fn))
+            runtime_chain.append(type(runtime_fn).__name__)
+            if isinstance(runtime_fn, JITFunction):
+                break
+            runtime_fn = getattr(runtime_fn, "fn", None)
+
+        self._materialization_cache[key] = PointwiseKernelMaterialization(
+            cache_key=key,
+            ndim=ndim,
+            wrapper=overload,
+            entry=entry,
+            jit_function=jit_function,
+            kernel_info=kernel_info,
+            runtime_chain=tuple(runtime_chain),
+            max_tile_size=self.config.max_tile_size,
+            max_grid_size=tuple(self.config.max_grid_size),
+            max_num_warps_per_cta=self.config.max_num_warps_per_cta,
+            prefer_block_pointer=self.config.prefer_block_pointer,
+            prefer_1d_tile=self.config.prefer_1d_tile,
+        )
 
         return overload
+
+    def materialize(self, ndim: int) -> PointwiseKernelMaterialization:
+        """Generate once and return the compiler-facing structural handle.
+
+        This method is safe to call during backend registration or warmup.  It
+        must not be called from a Dynamo-traced function because it writes and
+        imports generated Python.  Runtime shape values are intentionally not
+        accepted, so different token counts reuse the same materialization.
+        """
+
+        key = f"{ndim}_{self.config.prefer_block_pointer}"
+        if key not in self._materialization_cache:
+            self.instantiate(ndim)
+        return self._materialization_cache[key]
 
     def get_kernel_info(self, ndim: int) -> KernelInfo:
         """Get kernel information for a given ndim.


### PR DESCRIPTION
### PR Category
Other

### Type of Change
New Feature

### Description
为 FlagGems 中会被 vLLM 0.24 及 vLLM 0.20.2 编译路径直接追踪的 kernel 提供透明的 torch.compile
契约（PT2 contracts），不修改任何 kernel 数学实现。

背景：vLLM 0.24 的 `custom_ops=all` 会以 fullgraph AOT 追踪 `CustomOp.forward_oot`。
当前 FlagGems 的公开启动器在该路径上不可追踪，会在 `profile_run` 阶段中断：
`LibEntry.run`（`Unsupported method call: __getitem__`）、入口处的裸 `logger.debug`
（`logging.Logger method not supported`）、以及 kernel 内的 `ext.` 模块别名
（Inductor 对非 triton 模块的闭包 dump 会丢失该别名，子进程重编译报
`NameError('ext is not defined')`；torch 2.11 上可复现）。

改动：

* `flag_gems/pt2/`（新增）——`torch.library.triton_op` + `wrap_triton` 包裹
  **原始** `LibEntry.jit_function` / Autotuner 对象：RMSNorm、fused-add RMSNorm、
  pointwise 族（SiLU/GELU-and-mul）、in-place RoPE、MoE 基础算子（`topk_softmax`、
  `moe_sum`、grouped-topk 路由）、MHC。附声明式 `CompileOpSpec` manifest；
  pointwise 的 plan 在图外物化。
* `utils/pointwise_dynamic.py`——新增 `PointwiseKernelMaterialization` 与
  `materialize()`；codegen 直接生成 `tl.program_id(0).to(tl.int64)` /
  `tl.num_programs(0).to(tl.int64)`，保留原 helper 的 64 位整数语义。
* `utils/codegen_config_utils.py`——新增 `get_heuristics_for_num_warps_fn()`。
* `ops/rms_norm.py`、`fused/fused_add_rms_norm.py`、`fused/rotary_embedding.py`——
  `ext.program_id(0)` 改为 `tl.program_id(0).to(tl.int64)`，移除对应 helper 导入；
  显式区分 Triton 原生函数和 FlagGems 原有的 64 位封装。
* `modules/{activation,normalization,rotary_embedding}.py`——删除入口路径上的
  裸 `logger.debug`（仅日志，数值/控制流不变）。

eager 行为与之前完全一致（`torch.equal` 验证）。设计与 `pt2/` 契约内容与内部
0.20.2 交付件（`flaggems_pt2_final_20260901`）逐字节一致，仅按本仓 lint 要求
（black/isort）做格式整理并更新部分注释。


### Issue
- Associated with flagos-ai/vllm-plugin-FL#298

### Related PR:
- https://github.com/flagos-ai/vllm-plugin-FL/pull/448

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue (flagos-ai/vllm-plugin-FL#298).
- [ ] Change is fully covered by a UT.


### Validation for the explicit int64 follow-up
本次追加提交涉及 4 个文件、13 处调用或代码生成模板。展开原 helper 函数体后，
修改前后的 AST 一致；pointwise 的 27 种生成组合通过源码语法与 AST 等价检查。
仓库配置的 pre-commit 检查通过（Flake8、isort、black、black-jupyter、空白及文件结尾检查）。
当前机器没有 PyTorch/Triton，未重新执行 GPU 数值、torch.compile 或端到端测试；
下方性能及 parity 数据来自此前的验证。

### Performance
未改动任何 kernel 数学实现；本 PR 不引入性能变化。compile 模式下 eager/compiled
parity（rms_norm、fused_add_rms_norm、silu_and_mul、gelu_and_mul、rope(in-place)、
topk_softmax、moe_sum，bf16，NVIDIA，torch 2.11 / triton 3.6）max|diff| = 0.0。
端到端（经 vllm-plugin-FL）：MiniCPM5-1B TP=2、`custom_ops=all` 冷编译 14.2 s，
51/51 PIECEWISE + 51/51 FULL CUDA graph 捕获；Qwen3.6-35B-A3B eager vs compile
tie-aware cross-phase 16/16 位置逐位一致。
