### PR TITLE
[MTHREADS] Optimize avg_pool2d backward

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -20,6 +20,7 @@ from .amax import amax
 from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmin import argmin
+from .avg_pool2d import avg_pool2d_backward
 from .batch_norm import batch_norm, batch_norm_backward
 from .bucketize import bucketize
 from .celu import celu
@@ -117,6 +118,7 @@ __all__ = [
     "arange",
     "arange_start",
     "argmin",
+    "avg_pool2d_backward",
     "batch_norm",
     "batch_norm_backward",
     "bucketize",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/avg_pool2d.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/avg_pool2d.py
@@ -1,0 +1,635 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""MTHREADS avg_pool2d implementations.
+
+The generic FlagGems backward kernel maps one program to an input tile and
+enumerates every KxK tap.  That is particularly expensive on MTT because the
+receiver test contains vector integer modulo/division.  The kernels here use
+the inverse pooling relation instead: an input element directly computes the
+small output interval that can produce it.
+"""
+
+import logging
+
+# Triton is optional in some backend environments; keep this import block
+# stable across isort's installed-module classification.
+# isort: off
+import triton
+import triton.language as tl
+import torch
+from flag_gems.ops.avg_pool2d import _parse_pool_params
+from flag_gems.ops.avg_pool2d import avg_pool2d_backward as _generic_avg_pool2d_backward
+from flag_gems.utils import libentry
+
+# isort: on
+
+logger = logging.getLogger(
+    f"flag_gems.runtime.backend._mthreads.ops.{__name__.split('.')[-1]}"
+)
+
+
+@triton.jit
+def _k3_divisor(
+    oh,
+    ow,
+    in_h,
+    in_w,
+    CEIL_TAIL_H: tl.constexpr,
+    CEIL_TAIL_W: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    divisor = tl.full((BLOCK_H, BLOCK_W), 9.0, tl.float32)
+    if CEIL_TAIL_H:
+        hs = oh * 2 - 1
+        pool_h = tl.maximum(tl.minimum(hs + 3, in_h + 1) - hs, 0)
+        divisor = divisor * tl.where(hs + 3 > in_h + 1, pool_h, 3).to(tl.float32) / 3.0
+    if CEIL_TAIL_W:
+        ws = ow * 2 - 1
+        pool_w = tl.maximum(tl.minimum(ws + 3, in_w + 1) - ws, 0)
+        divisor = divisor * tl.where(ws + 3 > in_w + 1, pool_w, 3).to(tl.float32) / 3.0
+    return divisor
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 32}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 16}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+    ],
+    key=[
+        "in_h",
+        "in_w",
+        "out_h",
+        "out_w",
+        "kernel_h",
+        "kernel_w",
+        "stride_h",
+        "stride_w",
+    ],
+)
+@triton.jit
+def _avg_pool2d_backward_direct_range_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_h,
+    out_stride_w,
+    kernel_h: tl.constexpr,
+    kernel_w: tl.constexpr,
+    stride_h: tl.constexpr,
+    stride_w: tl.constexpr,
+    padding_h: tl.constexpr,
+    padding_w: tl.constexpr,
+    COUNT_INCLUDE_PAD: tl.constexpr,
+    CEIL_TAIL_H: tl.constexpr,
+    CEIL_TAIL_W: tl.constexpr,
+    DIVISOR_OVERRIDE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    h_block = tl.program_id(1)
+    w_block = tl.program_id(2)
+
+    h = h_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    w = w_block * BLOCK_W + tl.arange(0, BLOCK_W)
+    h2 = h[:, None]
+    w2 = w[None, :]
+    in_mask = (h2 < in_h) & (w2 < in_w)
+
+    # oh_min = ceil((h + p - (k - 1)) / s), oh_max=floor((h+p)/s).
+    # The numerator of oh_min can be negative, so use a sign-safe ceil-div.
+    h_min_num = h2 + padding_h - (kernel_h - 1)
+    w_min_num = w2 + padding_w - (kernel_w - 1)
+    h_min = tl.where(
+        h_min_num >= 0,
+        (h_min_num + stride_h - 1) // stride_h,
+        -((-h_min_num) // stride_h),
+    )
+    w_min = tl.where(
+        w_min_num >= 0,
+        (w_min_num + stride_w - 1) // stride_w,
+        -((-w_min_num) // stride_w),
+    )
+    h_max = (h2 + padding_h) // stride_h
+    w_max = (w2 + padding_w) // stride_w
+
+    # At most ceil(K/S) producers exist in each dimension.  All loops are
+    # compile-time unrolled and masked by the exact direct range.
+    grad_acc = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.float32)
+    go_base = grad_output_ptr + pid_nc * out_h * out_w
+    for dh in tl.static_range(0, (kernel_h + stride_h - 1) // stride_h):
+        oh = h_min + dh
+        oh_mask = (oh >= h_min) & (oh <= h_max) & (oh >= 0) & (oh < out_h)
+        if DIVISOR_OVERRIDE != 0:
+            divisor_h = tl.full((BLOCK_H, BLOCK_W), float(DIVISOR_OVERRIDE), tl.float32)
+        elif COUNT_INCLUDE_PAD:
+            if CEIL_TAIL_H:
+                h_start = oh * stride_h - padding_h
+                pool_h = tl.minimum(h_start + kernel_h, in_h + padding_h) - h_start
+                pool_h = tl.maximum(pool_h, 0)
+                # PyTorch counts explicit padding, but not the shortened tail
+                # introduced solely by ceil_mode.
+                divisor_h = tl.where(
+                    h_start + kernel_h > in_h + padding_h, pool_h, kernel_h
+                ).to(tl.float32)
+            else:
+                divisor_h = tl.full((BLOCK_H, BLOCK_W), float(kernel_h), tl.float32)
+        else:
+            h_start = oh * stride_h - padding_h
+            valid_h = tl.minimum(h_start + kernel_h, in_h) - tl.maximum(h_start, 0)
+            valid_h = tl.maximum(valid_h, 0)
+            divisor_h = valid_h.to(tl.float32)
+
+        for dw in tl.static_range(0, (kernel_w + stride_w - 1) // stride_w):
+            ow = w_min + dw
+            ow_mask = (ow >= w_min) & (ow <= w_max) & (ow >= 0) & (ow < out_w)
+            producer_mask = in_mask & oh_mask & ow_mask
+            if DIVISOR_OVERRIDE != 0:
+                divisor = divisor_h
+            elif COUNT_INCLUDE_PAD:
+                if CEIL_TAIL_W:
+                    w_start = ow * stride_w - padding_w
+                    pool_w = tl.minimum(w_start + kernel_w, in_w + padding_w) - w_start
+                    pool_w = tl.maximum(pool_w, 0)
+                    divisor = divisor_h * tl.where(
+                        w_start + kernel_w > in_w + padding_w, pool_w, kernel_w
+                    ).to(tl.float32)
+                else:
+                    divisor = divisor_h * kernel_w
+            else:
+                w_start = ow * stride_w - padding_w
+                valid_w = tl.minimum(w_start + kernel_w, in_w) - tl.maximum(w_start, 0)
+                valid_w = tl.maximum(valid_w, 0)
+                divisor = divisor_h * valid_w.to(tl.float32)
+            divisor = tl.where(divisor == 0, 1.0, divisor)
+            go_ptr = go_base + oh * out_stride_h + ow * out_stride_w
+            go = tl.load(go_ptr, mask=producer_mask, other=0.0).to(tl.float32)
+            grad_acc += tl.where(producer_mask, go / divisor, 0.0)
+
+    gi_base = grad_input_ptr + pid_nc * in_h * in_w
+    gi_ptr = gi_base + h2 * in_stride_h + w2 * in_stride_w
+    tl.store(gi_ptr, grad_acc, mask=in_mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 4, "BLOCK_W": 8}, num_stages=2, num_warps=1),
+        triton.Config({"BLOCK_H": 4, "BLOCK_W": 16}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 8}, num_stages=2, num_warps=1),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 8}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 16}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 32}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 16}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+    ],
+    key=["in_h", "in_w", "out_h", "out_w"],
+)
+@triton.jit
+def _avg_pool2d_backward_k3s2p1_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_h,
+    out_stride_w,
+    CEIL_TAIL_H: tl.constexpr,
+    CEIL_TAIL_W: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    h_block = tl.program_id(1)
+    w_block = tl.program_id(2)
+
+    h = h_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    w = w_block * BLOCK_W + tl.arange(0, BLOCK_W)
+    h2 = h[:, None]
+    w2 = w[None, :]
+    in_mask = (h2 < in_h) & (w2 < in_w)
+
+    # For K=3,S=2,P=1, the inverse range is exactly [h//2,(h+1)//2]
+    # (and analogously for W).  This removes both modulo and general divide.
+    oh0 = h2 >> 1
+    oh1 = (h2 + 1) >> 1
+    ow0 = w2 >> 1
+    ow1 = (w2 + 1) >> 1
+    go_base = grad_output_ptr + pid_nc * out_h * out_w
+    grad_acc = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.float32)
+    m00 = in_mask & (oh0 < out_h) & (ow0 < out_w)
+    m01 = in_mask & (oh0 < out_h) & (ow1 < out_w) & (ow1 != ow0)
+    m10 = in_mask & (oh1 < out_h) & (ow0 < out_w) & (oh1 != oh0)
+    m11 = in_mask & (oh1 < out_h) & (ow1 < out_w) & (oh1 != oh0) & (ow1 != ow0)
+
+    g00 = tl.load(
+        go_base + oh0 * out_stride_h + ow0 * out_stride_w, mask=m00, other=0.0
+    )
+    g01 = tl.load(
+        go_base + oh0 * out_stride_h + ow1 * out_stride_w, mask=m01, other=0.0
+    )
+    g10 = tl.load(
+        go_base + oh1 * out_stride_h + ow0 * out_stride_w, mask=m10, other=0.0
+    )
+    g11 = tl.load(
+        go_base + oh1 * out_stride_h + ow1 * out_stride_w, mask=m11, other=0.0
+    )
+    if not CEIL_TAIL_H and not CEIL_TAIL_W:
+        inv9 = 1.0 / 9.0
+        grad_acc = (
+            g00.to(tl.float32) * inv9
+            + g01.to(tl.float32) * inv9
+            + g10.to(tl.float32) * inv9
+            + g11.to(tl.float32) * inv9
+        )
+    else:
+        grad_acc += g00.to(tl.float32) / _k3_divisor(
+            oh0, ow0, in_h, in_w, CEIL_TAIL_H, CEIL_TAIL_W, BLOCK_H, BLOCK_W
+        )
+        grad_acc += g01.to(tl.float32) / _k3_divisor(
+            oh0, ow1, in_h, in_w, CEIL_TAIL_H, CEIL_TAIL_W, BLOCK_H, BLOCK_W
+        )
+        grad_acc += g10.to(tl.float32) / _k3_divisor(
+            oh1, ow0, in_h, in_w, CEIL_TAIL_H, CEIL_TAIL_W, BLOCK_H, BLOCK_W
+        )
+        grad_acc += g11.to(tl.float32) / _k3_divisor(
+            oh1, ow1, in_h, in_w, CEIL_TAIL_H, CEIL_TAIL_W, BLOCK_H, BLOCK_W
+        )
+
+    gi_base = grad_input_ptr + pid_nc * in_h * in_w
+    tl.store(gi_base + h2 * in_stride_h + w2 * in_stride_w, grad_acc, mask=in_mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_OH": 4, "BLOCK_OW": 8}, num_stages=2, num_warps=1),
+        triton.Config({"BLOCK_OH": 4, "BLOCK_OW": 16}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_OH": 8, "BLOCK_OW": 8}, num_stages=2, num_warps=1),
+        triton.Config({"BLOCK_OH": 8, "BLOCK_OW": 8}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_OH": 8, "BLOCK_OW": 16}, num_stages=2, num_warps=2),
+        triton.Config({"BLOCK_OH": 8, "BLOCK_OW": 32}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_OH": 16, "BLOCK_OW": 16}, num_stages=2, num_warps=4),
+    ],
+    key=["in_h", "in_w", "out_h", "out_w"],
+)
+@triton.jit
+def _avg_pool2d_backward_k3s2p1_quad_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_h,
+    out_stride_w,
+    BLOCK_OH: tl.constexpr,
+    BLOCK_OW: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    oh_block = tl.program_id(1)
+    ow_block = tl.program_id(2)
+
+    oh = oh_block * BLOCK_OH + tl.arange(0, BLOCK_OH)
+    ow = ow_block * BLOCK_OW + tl.arange(0, BLOCK_OW)
+    oh2 = oh[:, None]
+    ow2 = ow[None, :]
+    oh1 = oh2 + 1
+    ow1 = ow2 + 1
+
+    go_base = grad_output_ptr + pid_nc * out_h * out_w
+    m00 = (oh2 < out_h) & (ow2 < out_w)
+    m01 = (oh2 < out_h) & (ow1 < out_w)
+    m10 = (oh1 < out_h) & (ow2 < out_w)
+    m11 = (oh1 < out_h) & (ow1 < out_w)
+
+    g00 = tl.load(
+        go_base + oh2 * out_stride_h + ow2 * out_stride_w, mask=m00, other=0.0
+    )
+    g01 = tl.load(
+        go_base + oh2 * out_stride_h + ow1 * out_stride_w, mask=m01, other=0.0
+    )
+    g10 = tl.load(
+        go_base + oh1 * out_stride_h + ow2 * out_stride_w, mask=m10, other=0.0
+    )
+    g11 = tl.load(
+        go_base + oh1 * out_stride_h + ow1 * out_stride_w, mask=m11, other=0.0
+    )
+
+    inv9 = 1.0 / 9.0
+    s00 = g00.to(tl.float32) * inv9
+    s01 = g01.to(tl.float32) * inv9
+    s10 = g10.to(tl.float32) * inv9
+    s11 = g11.to(tl.float32) * inv9
+
+    h0 = oh2 << 1
+    h1 = h0 + 1
+    w0 = ow2 << 1
+    w1 = w0 + 1
+    gi_base = grad_input_ptr + pid_nc * in_h * in_w
+
+    tl.store(
+        gi_base + h0 * in_stride_h + w0 * in_stride_w,
+        s00,
+        mask=(h0 < in_h) & (w0 < in_w),
+    )
+    tl.store(
+        gi_base + h0 * in_stride_h + w1 * in_stride_w,
+        s00 + s01,
+        mask=(h0 < in_h) & (w1 < in_w),
+    )
+    tl.store(
+        gi_base + h1 * in_stride_h + w0 * in_stride_w,
+        s00 + s10,
+        mask=(h1 < in_h) & (w0 < in_w),
+    )
+    tl.store(
+        gi_base + h1 * in_stride_h + w1 * in_stride_w,
+        s00 + s01 + s10 + s11,
+        mask=(h1 < in_h) & (w1 < in_w),
+    )
+
+
+def _launch_backward(
+    kernel,
+    grad_output,
+    grad_input,
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    kernel_h,
+    kernel_w,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+):
+    if kernel is _avg_pool2d_backward_k3s2p1_quad_kernel:
+        grid = lambda meta: (
+            grad_input.shape[0] * grad_input.shape[1],
+            triton.cdiv(out_h, meta["BLOCK_OH"]),
+            triton.cdiv(out_w, meta["BLOCK_OW"]),
+        )
+    elif kernel is _avg_pool2d_backward_k3s2p1_kernel:
+        grid = lambda meta: (
+            grad_input.shape[0] * grad_input.shape[1],
+            triton.cdiv(in_h, meta["BLOCK_H"]),
+            triton.cdiv(in_w, meta["BLOCK_W"]),
+        )
+    else:
+        grid = lambda meta: (
+            grad_input.shape[0] * grad_input.shape[1],
+            triton.cdiv(in_h, meta["BLOCK_H"]),
+            triton.cdiv(in_w, meta["BLOCK_W"]),
+        )
+    args = [
+        grad_output,
+        grad_input,
+        in_c,
+        in_h,
+        in_w,
+        out_h,
+        out_w,
+        grad_input.stride(0),
+        grad_input.stride(1),
+        grad_input.stride(2),
+        grad_input.stride(3),
+        grad_output.stride(0),
+        grad_output.stride(1),
+        grad_output.stride(2),
+        grad_output.stride(3),
+    ]
+    if kernel is _avg_pool2d_backward_k3s2p1_quad_kernel:
+        kernel[grid](*args)
+    elif kernel is _avg_pool2d_backward_direct_range_kernel:
+        args += [kernel_h, kernel_w, stride_h, stride_w, padding_h, padding_w]
+        ceil_tail_h = bool(
+            ceil_mode
+            and out_h > 0
+            and (out_h - 1) * stride_h - padding_h + kernel_h > in_h + padding_h
+        )
+        ceil_tail_w = bool(
+            ceil_mode
+            and out_w > 0
+            and (out_w - 1) * stride_w - padding_w + kernel_w > in_w + padding_w
+        )
+        kernel[grid](
+            *args,
+            COUNT_INCLUDE_PAD=count_include_pad,
+            CEIL_TAIL_H=ceil_tail_h,
+            CEIL_TAIL_W=ceil_tail_w,
+            DIVISOR_OVERRIDE=divisor_override or 0,
+        )
+    else:
+        ceil_tail_h = bool(
+            ceil_mode
+            and out_h > 0
+            and (out_h - 1) * stride_h - padding_h + kernel_h > in_h + padding_h
+        )
+        ceil_tail_w = bool(
+            ceil_mode
+            and out_w > 0
+            and (out_w - 1) * stride_w - padding_w + kernel_w > in_w + padding_w
+        )
+        kernel[grid](*args, CEIL_TAIL_H=ceil_tail_h, CEIL_TAIL_W=ceil_tail_w)
+
+
+def avg_pool2d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+):
+    """MTHREADS dispatch with a semantics-preserving generic fallback."""
+    if divisor_override is not None and divisor_override == 0:
+        raise ValueError("divisor_override cannot be zero")
+
+    # Keep the existing implementation for layouts/dtypes outside the tuned
+    # FP32 contiguous contract.  In particular this preserves arbitrary
+    # strides and all PyTorch corner-case behavior.
+    if input.dtype != torch.float32 or grad_output.dtype != torch.float32:
+        return _generic_avg_pool2d_backward(
+            grad_output,
+            input,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+
+    kernel_h, kernel_w, stride_h, stride_w, padding_h, padding_w = _parse_pool_params(
+        kernel_size, stride, padding
+    )
+    # With no spatial decimation the inverse range has exactly K^2 producers,
+    # so the extra range/divisor arithmetic costs more than the old kernel.
+    # A runtime divisor override is likewise already a cheap constant path;
+    # retain the established implementation for these non-winning cases.
+    if (stride_h == 1 and stride_w == 1) or divisor_override is not None:
+        return _generic_avg_pool2d_backward(
+            grad_output,
+            input,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    if not input.is_contiguous() or not grad_output.is_contiguous():
+        return _generic_avg_pool2d_backward(
+            grad_output,
+            input,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+
+    in_n, in_c, in_h, in_w = input.shape
+    out_h, out_w = grad_output.shape[2], grad_output.shape[3]
+    # The kernel writes every input element, including receivers with no
+    # producer, so no zero-initialization launch is needed.
+    grad_input = torch.empty_like(input, dtype=torch.float32)
+    if grad_output.numel() == 0:
+        return grad_input
+
+    if (
+        kernel_h == 3
+        and kernel_w == 3
+        and stride_h == 2
+        and stride_w == 2
+        and padding_h == 1
+        and padding_w == 1
+        and count_include_pad
+        and divisor_override is None
+        and not ceil_mode
+        and in_n * in_c >= 1024
+        and in_h * in_w > 64
+    ):
+        _launch_backward(
+            _avg_pool2d_backward_k3s2p1_quad_kernel,
+            grad_output,
+            grad_input,
+            in_c,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    elif (
+        kernel_h == 3
+        and kernel_w == 3
+        and stride_h == 2
+        and stride_w == 2
+        and padding_h == 1
+        and padding_w == 1
+        and count_include_pad
+        and divisor_override is None
+    ):
+        _launch_backward(
+            _avg_pool2d_backward_k3s2p1_kernel,
+            grad_output,
+            grad_input,
+            in_c,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    else:
+        _launch_backward(
+            _avg_pool2d_backward_direct_range_kernel,
+            grad_output,
+            grad_input,
+            in_c,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    return grad_input
+
+
+__all__ = ["avg_pool2d_backward"]


### PR DESCRIPTION
## What

Optimizes the MTHREADS `aten.avg_pool2d_backward` backend implementation for the FP32 contiguous path, with conservative fallback for unsupported layouts/dtypes/parameters.

Final head: `0638c5f57f4094c8ceaf4a8e97766bfd143937ce`

## Bottleneck

The original MTHREADS path spent too much work per `grad_input` receiver:

- general K^2-style producer enumeration and boundary arithmetic
- program-level integer div/rem from flattened program ids
- repeated divisor work on the hot K3/S2/P1 path
- poor utilization on some spatial shapes
- zero-fill work before a fully overwritten output

After the kernel work, local full autograd/operator E2E is mostly framework/runtime dominated (`autograd -> ATen dispatch -> Python backend -> LibEntry/autotune/runtime/allocator -> launch`) rather than device-kernel dominated.

## Architecture

The optimized implementation keeps receiver ownership and a single backend kernel launch for the supported fast path:

- direct producer-range gather instead of enumerating the whole pooling window
- K3/S2/P1 residue specialization for the common path
- 3D grid mapping `(N*C, H blocks, W blocks)` to remove program-id div/rem
- contiguous plane-base addressing for the fast path
- O(1) divisor logic for `count_include_pad=False`
- `empty_like` allocation because the kernel fully overwrites `grad_input`
- redundant contiguous/to(FP32) cleanup on the already-gated FP32 contiguous path
- conservative fallback to the generic implementation for unsupported cases

## Instruction-level optimization

Final P0 K3/S2/P1 hot path IR audit on local MTT S5000 / MUSA 4.3.5:

| Property | Result |
|---|---:|
| Integer div | 0 |
| Integer rem | 0 |
| FP div | 0 |
| Atomic | 0 |
| Barrier | 0 |
| Explicit shared-memory staging | 0 |
| Kernel launches in backend backward fast path | 1 |

The constant `/9` path now scales each producer before accumulation. This preserves the no-FP-div property while avoiding FP32 sum-before-scale overflow cases such as large finite `grad_output` values.

## Hardware-level optimization

This update adds a structural 2x2 receiver-quad kernel for the official K3/S2/P1 P0 path when there is enough `N*C` parallelism and spatial size is above the tiny-shape crossover.

The quad mapping owns four neighboring `grad_input` receivers from one output-space tile and reuses four loaded `grad_output` values in registers:

- old logical producer loads: `9 loads / 4 grad_input`
- quad logical producer loads: `4 loads / 4 grad_input`
- logical producer-load reduction in the quad region: ~55.6%
- no atomics, no barriers, no shared-memory staging

The 224x224 official shape keeps the old receiver path because its `N*C` is small and the quad grid underfills the device. 7x7 also keeps the old small-spatial receiver path because quad was not faster at that crossover.

## Performance

Local development benchmark, MTT S5000 / MUSA 4.3.5. This is the repository original benchmark file:

`python3 -m pytest -s benchmark/test_avg_pool2d.py -m avg_pool2d_backward --level core --record log`

The benchmark reports kernel-mode latency for the official core shapes.

| Shape | Torch us | Previous PR Gems us | Final Gems us | Gems Speedup (Torch / Final) | Optimization Speedup (Previous / Final) |
|---|---:|---:|---:|---:|---:|
| 4x3x224x224 | 27.68 | 5.56 | 6.12 | 4.523x | 0.908x |
| 16x64x56x56 | 82.28 | 47.92 | 28.56 | 2.881x | 1.678x |
| 32x128x28x28 | 85.48 | 51.16 | 28.96 | 2.952x | 1.767x |
| 64x256x14x14 | 86.28 | 52.20 | 31.84 | 2.710x | 1.639x |
| 128x512x7x7 | 88.72 | 64.76 | 69.48 | 1.277x | 0.932x |

Geomean:

- Gems Speedup (Torch / Final): `2.660x`
- Optimization Speedup (Previous PR Gems / Final Gems): `1.327x`

The 224 and 7 kernel-mode rows are slower than the previous unsafe `/9` accumulation because the final code fixes sum-before-scale overflow semantics. The 56/28/14 rows are the primary quad-kernel win region.

Local autograd/operator E2E p50 for the same official shapes remains framework-bound:

| Shape | Torch E2E us | Previous PR Gems E2E us | Final Gems E2E us | Gems Speedup | Optimization Speedup |
|---|---:|---:|---:|---:|---:|
| 4x3x224x224 | 42.50 | 93.60 | 93.84 | 0.453x | 0.997x |
| 16x64x56x56 | 88.94 | 94.30 | 92.21 | 0.965x | 1.023x |
| 32x128x28x28 | 91.88 | 94.78 | 92.09 | 0.998x | 1.029x |
| 64x256x14x14 | 93.79 | 94.58 | 94.51 | 0.992x | 1.001x |
| 128x512x7x7 | 95.53 | 94.54 | 96.37 | 0.991x | 0.981x |

E2E geomean:

- Gems Speedup (Torch / Final): `0.844x`
- Optimization Speedup (Previous PR Gems / Final Gems): `1.006x`

This is why the performance claim is scoped to the backend kernel. The remaining Torch-parity gap at full autograd/operator level is runtime/framework overhead, especially for the small kernel-time rows.

## Correctness

Final-head local validation:

- `pytest -svx -m avg_pool2d_backward --ref cpu`: `24/24 PASS`
- special FP32 cases: `1e38`, `-1e38`, `FLT_MAX/4`, mixed large signs, `+inf`, `-inf`, `nan`, zero, subnormal: `PASS`
- empty forward-derived cases: `PASS`
- non-contiguous and unsupported cases remain on fallback

Previous semantic validation during development included `11,571,368` legal configurations with `0` mismatch after the ceil/count divisor fix. That historical exhaustive harness is not part of this final local rerun; the final-head local proof is the official 24/24 test suite plus targeted special-value and fallback smoke.

## Kernel characteristics

MCU / IR evidence on local MTT S5000 / MUSA 4.3.5:

- MCU compatible: yes (`Moore Perf Compute 1.2.0`)
- MSYS compatible for whole-process tracing: yes (`Moore Perf System 1.8.0`)
- P0 old receiver and quad TTIR/TTGIR/LLIR: int div/rem `0`, FP div `0`, atomic `0`, barrier `0`
- 56x56 quad region halves launched threads versus the receiver mapping and raises L2 hit rate to ~99.97% in the local MCU run
- memory bandwidth utilization is low on the profiled official shapes; shared-memory staging is not justified by local counters

Representative MCU root-limit readout:

- 224x224: launch/latency and low parallelism dominated (`waves/MP ~0.82`, low memory utilization)
- 56x56: instruction/scheduling dominated after quad (`L2 hit ~99.97%`, low DDR utilization)
- 7x7: instruction/scheduling dominated (`compute throughput ~63%`, memory throughput ~5%`, L2 hit ~99.99%`)

## Fallback / Semantics

The fast path is gated to FP32 contiguous tensors and supported pooling parameters. Generic, non-contiguous, unsupported dtype/layout/parameter cases continue to use the conservative fallback.

Ceil-mode and non-constant divisor paths keep the existing safe divisor logic; the new quad kernel is only used for `K=3, S=2, P=1, ceil_mode=False, count_include_pad=True, divisor_override=None` with structural parallelism/spatial gates.

## Scope

Production diff is limited to MTHREADS avg-pool backward registration and implementation:

- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/avg_pool2d.py`

No benchmark files, public tests, generic ops, or other vendor backends are changed.

## Validation

Local validation environment:

- MTT S5000
- MUSA 4.3.5 (`torch.version.musa = 40305`)
- `torch = 2.7.1`
- `torch_musa = 2.7.1+5ee0a64`
- `triton = 3.6.0`

Checks run on final head `0638c5f57f4094c8ceaf4a8e97766bfd143937ce`:

- `pytest -svx -m avg_pool2d_backward --ref cpu`: PASS (`24 passed`)
- `python3 -m py_compile src/flag_gems/runtime/backend/_mthreads/ops/avg_pool2d.py`: PASS
- `black --check`: PASS
- `isort --check-only --profile black`: PASS
- `flake8`: PASS
- `git diff --check`: PASS
- `pre-commit run --files .../avg_pool2d.py .../__init__.py`: PASS
- repository original `benchmark/test_avg_pool2d.py -m avg_pool2d_backward --level core`: PASS

MUSA 5.2 validation is delegated to upstream CI; no local MUSA 5.2 result is claimed here.
