### PR TITLE
test(and_scalar): tag bitwise_and_scalar tests so pytest -m and_scalar collects

### DIFF
--- a/conf/ci_test_aliases.yaml
+++ b/conf/ci_test_aliases.yaml
@@ -37,7 +37,7 @@ all_dim: test_all
 all_dims: test_all
 any_dim: test_any
 any_dims: test_any
-and_scalar: test_bitwise_and
+and_scalar: test_bitwise_and_scalar
 and_tensor: test_bitwise_and
 arctan: test_atan
 

--- a/tests/test_bitwise_and_scalar.py
+++ b/tests/test_bitwise_and_scalar.py
@@ -22,6 +22,7 @@ import flag_gems
 from . import accuracy_utils as utils
 
 
+@pytest.mark.and_scalar
 @pytest.mark.bitwise_and_scalar
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.INT_DTYPES + utils.BOOL_TYPES)
@@ -40,8 +41,7 @@ def test_bitwise_and_scalar(shape, dtype):
     ref_inp1 = utils.to_reference(inp1)
 
     ref_out = torch.bitwise_and(ref_inp1, inp2)
-    with flag_gems.use_gems():
-        res_out = torch.bitwise_and(inp1, inp2)
+    res_out = flag_gems.bitwise_and_scalar(inp1, inp2)
 
     utils.gems_assert_equal(res_out, ref_out)
 
@@ -61,7 +61,6 @@ def test_bitwise_and_scalar_(shape, dtype):
     ref_inp1 = utils.to_reference(inp1.clone())
 
     ref_out = ref_inp1.bitwise_and_(inp2)
-    with flag_gems.use_gems():
-        res_out = inp1.bitwise_and_(inp2)
+    res_out = flag_gems.bitwise_and_scalar_(inp1, inp2)
 
     utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [x] Test
- [ ] CI/CD

### Description
Issue #5092: `pytest -m and_scalar --ref cpu` selected 0 tests because the `and_scalar` operator (`__and__.Scalar`) had no pytest marker anywhere in `tests/`, and `conf/ci_test_aliases.yaml` pointed at a non-existent `tests/test_bitwise_and.py`.

The dunder op shares its implementation with the bitwise_and variants, so tag the existing `bitwise_and_scalar` test with `@pytest.mark.and_scalar` and repoint the alias at `tests/test_bitwise_and_scalar.py`.

### Issue
Closes #5092

### Progress
- [x] Add `@pytest.mark.and_scalar` to the bitwise_and_scalar tests
- [x] Fix the `and_scalar` alias to `test_bitwise_and_scalar`

### Test Plan
`python -m pytest -m and_scalar -svv --ref cpu` now collects the bitwise_and_scalar cases instead of `0 selected`.