### PR TITLE
test(clone): add clone accuracy tests so pytest -m clone collects cases

### DIFF
--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,0 +1,50 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.clone
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_clone(shape, dtype):
+    """clone copies the tensor contents into an independent storage."""
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = utils.to_reference(x)
+    ref_out = ref_x.clone()
+    res_out = x.clone()
+
+    utils.gems_assert_equal(res_out, ref_out)
+    # clone must not alias the source storage
+    assert res_out.data_ptr() != x.data_ptr()
+
+
+@pytest.mark.clone
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_clone_memory_format(dtype):
+    """clone(preserve_format) keeps the source memory layout."""
+    base = torch.randn((16, 8), dtype=dtype, device=flag_gems.device)
+    x = base.t().contiguous().t()[:12]  # non-contiguous view
+    ref_x = utils.to_reference(x)
+    ref_out = ref_x.clone(memory_format=torch.preserve_format)
+    res_out = x.clone(memory_format=torch.preserve_format)
+
+    utils.gems_assert_equal(res_out, ref_out)
+    assert res_out.is_contiguous() == x.is_contiguous()
+    assert res_out.data_ptr() != x.data_ptr()


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [x] Test
- [ ] CI/CD

### Description
Issue #5093: `pytest -m clone --ref cpu` selected 0 tests because no test in `tests/` carried the `@pytest.mark.clone` marker.

Add `tests/test_clone.py` covering the clone semantics used by the register: element-wise value equality and independent (non-aliased) storage for both contiguous and preserve-format memory layouts.

### Issue
Closes #5093

### Progress
- [x] Add `tests/test_clone.py` with `@pytest.mark.clone` cases
- [x] Verify value equality and storage independence for contiguous + preserve-format layouts

### Test Plan
`python -m pytest -m clone -svv --ref cpu` now collects the clone accuracy cases instead of `0 selected`.