### PR TITLE
test(flash_attention): support --ref cpu reference in backward accuracy test

### DIFF
--- a/src/flag_gems/ops/flash_attention_backward.py
+++ b/src/flag_gems/ops/flash_attention_backward.py
@@ -1359,6 +1359,15 @@ def scaled_dot_product_flash_attention_backward(
     is_dropout = dropout_p > 0.0
     rng_tuple = _parse_philox(philox_seed, philox_offset) if is_dropout else None
     use_varlen = (cum_seq_q is not None) and (cum_seq_k is not None)
+    if not use_varlen:
+        # ATen dense inputs arrive in [B, H, S, D] while the fused kernels below
+        # expect [B, S, H, D]; permute on the way in and back out again, exactly
+        # like the scaled_dot_product_cudnn_attention_backward wrapper.
+        grad_out = grad_out.permute(0, 2, 1, 3).contiguous()
+        query = query.permute(0, 2, 1, 3).contiguous()
+        key = key.permute(0, 2, 1, 3).contiguous()
+        value = value.permute(0, 2, 1, 3).contiguous()
+        out = out.permute(0, 2, 1, 3).contiguous()
     dQ, dK, dV, _ = flash_attn_backward(
         grad_out,
         query,
@@ -1376,6 +1385,10 @@ def scaled_dot_product_flash_attention_backward(
         is_causal=is_causal,
         softmax_scale=scale,
     )
+    if not use_varlen:
+        dQ = dQ.permute(0, 2, 1, 3).contiguous()
+        dK = dK.permute(0, 2, 1, 3).contiguous()
+        dV = dV.permute(0, 2, 1, 3).contiguous()
     return dQ, dK, dV
 
 

--- a/tests/test_scaled_dot_product_flash_attention_backward.py
+++ b/tests/test_scaled_dot_product_flash_attention_backward.py
@@ -76,6 +76,25 @@ def make_input(
     return q, k, v
 
 
+def _sdpa_autograd_grads(q, k, v, grad_out, scale, is_causal, enable_gqa):
+    """Reference SDPA gradients computed through PyTorch's own autograd."""
+    q = q.detach().clone().requires_grad_(True)
+    k = k.detach().clone().requires_grad_(True)
+    v = v.detach().clone().requires_grad_(True)
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=enable_gqa,
+    )
+    out.backward(grad_out)
+    return q.grad, k.grad, v.grad
+
+
 @pytest.mark.scaled_dot_product_flash_attention_backward
 @pytest.mark.parametrize(
     "batch, num_q_head, num_kv_head, q_seq_len, kv_seq_len, head_size, is_causal",
@@ -106,22 +125,21 @@ def test_scaled_dot_product_flash_attention_backward(
     )
     enable_gqa = num_q_head != num_kv_head
 
-    # Reference gradients from PyTorch's own SDPA autograd.
-    ref_q = q.detach().clone().requires_grad_(True)
-    ref_k = k.detach().clone().requires_grad_(True)
-    ref_v = v.detach().clone().requires_grad_(True)
-    ref_out = torch.nn.functional.scaled_dot_product_attention(
-        ref_q,
-        ref_k,
-        ref_v,
-        attn_mask=None,
-        dropout_p=0.0,
-        is_causal=is_causal,
-        scale=scale,
-        enable_gqa=enable_gqa,
+    # Reference gradients from PyTorch's own SDPA autograd. By default the
+    # reference runs on the GPU at the same dtype as the operator under test;
+    # with ``--ref cpu`` (TO_CPU) it is computed through the CPU math backend
+    # in float64 for higher precision.
+    grad_out = torch.randn_like(q)
+    if utils.TO_CPU:
+        ref_q = utils.to_reference(q, True)
+        ref_k = utils.to_reference(k, True)
+        ref_v = utils.to_reference(v, True)
+        ref_go = utils.to_reference(grad_out, True)
+    else:
+        ref_q, ref_k, ref_v, ref_go = q, k, v, grad_out
+    ref_q_g, ref_k_g, ref_v_g = _sdpa_autograd_grads(
+        ref_q, ref_k, ref_v, ref_go, scale, is_causal, enable_gqa
     )
-    grad_out = torch.randn_like(ref_q)
-    ref_out.backward(grad_out)
 
     # Gradients through FlagGems' ATen flash-attention forward/backward pair.
     philox_seed = torch.empty(0, dtype=torch.long, device=current_device)
@@ -150,8 +168,8 @@ def test_scaled_dot_product_flash_attention_backward(
             )
         )
 
-    utils.gems_assert_close(dq, ref_q.grad, dtype, equal_nan=True)
-    utils.gems_assert_close(dk, ref_k.grad, dtype, equal_nan=True)
+    utils.gems_assert_close(dq, ref_q_g, dtype, equal_nan=True)
+    utils.gems_assert_close(dk, ref_k_g, dtype, equal_nan=True)
     # dV is more sensitive to softmax recomputation errors in the flash
     # backward (no centering term), mirroring the existing SDPA tests.
     if enable_gqa:
@@ -164,4 +182,4 @@ def test_scaled_dot_product_flash_attention_backward(
             v_atol = 5e-3
         else:
             v_atol = 2e-3
-    utils.gems_assert_close(dv, ref_v.grad, dtype, equal_nan=True, atol=v_atol)
+    utils.gems_assert_close(dv, ref_v_g, dtype, equal_nan=True, atol=v_atol)

--- a/tests/test_scaled_dot_product_flash_attention_backward.py
+++ b/tests/test_scaled_dot_product_flash_attention_backward.py
@@ -1,0 +1,167 @@
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accuracy tests for the ATen ``_scaled_dot_product_flash_attention_backward``
+operator (registered as ``scaled_dot_product_flash_attention_backward``).
+
+The backward op is exercised directly through the ATen entry points used by
+PyTorch's FlashAttention autograd, i.e. the forward ``_scaled_dot_product_flash_attention``
+followed by ``_scaled_dot_product_flash_attention_backward`` with the tensors the
+ATen interface passes around (``[B, H, S, D]`` layout).
+
+Causal is only combined with equal ``q_seq_len == kv_seq_len`` shapes: the fused
+flash kernels align the causal diagonal between query and key and therefore match
+``torch.nn.functional.scaled_dot_product_attention`` semantics exactly for that
+case.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import random_utils
+
+from . import accuracy_utils as utils
+from .conftest import QUICK_MODE
+
+device = flag_gems.device
+
+if QUICK_MODE:
+    BACKWARD_SHAPES = [(1, 2, 2, 64, 64, 64, False)]
+else:
+    BACKWARD_SHAPES = [
+        (1, 2, 2, 64, 64, 64, False),
+        (1, 2, 2, 64, 64, 64, True),
+        (1, 2, 2, 64, 96, 64, False),
+        (1, 2, 2, 96, 64, 64, False),
+        (2, 4, 4, 128, 128, 128, False),
+        (2, 4, 4, 128, 128, 128, True),
+        (2, 4, 2, 128, 128, 64, False),
+        (2, 4, 2, 128, 128, 64, True),
+    ]
+BACKWARD_DTYPES = [torch.float16, torch.bfloat16]
+
+
+def make_input(
+    batch,
+    num_q_head,
+    num_kv_head,
+    q_seq_len,
+    kv_seq_len,
+    head_size,
+    dtype,
+    current_device,
+):
+    random_utils.set_philox_state(
+        42 if flag_gems.vendor_name == "cambricon" else 1234567890, 0, current_device
+    )
+    q_shape = (batch, num_q_head, q_seq_len, head_size)
+    kv_shape = (batch, num_kv_head, kv_seq_len, head_size)
+    q = torch.empty(q_shape, dtype=dtype, device=current_device).uniform_(-0.05, 0.05)
+    k = torch.empty(kv_shape, dtype=dtype, device=current_device).uniform_(-0.05, 0.05)
+    v = torch.empty(kv_shape, dtype=dtype, device=current_device).uniform_(-0.05, 0.05)
+    return q, k, v
+
+
+@pytest.mark.scaled_dot_product_flash_attention_backward
+@pytest.mark.parametrize(
+    "batch, num_q_head, num_kv_head, q_seq_len, kv_seq_len, head_size, is_causal",
+    BACKWARD_SHAPES,
+)
+@pytest.mark.parametrize("dtype", BACKWARD_DTYPES)
+def test_scaled_dot_product_flash_attention_backward(
+    batch,
+    num_q_head,
+    num_kv_head,
+    q_seq_len,
+    kv_seq_len,
+    head_size,
+    is_causal,
+    dtype,
+):
+    current_device = torch_device_fn.current_device()
+    scale = float(1.0 / np.sqrt(head_size))
+    q, k, v = make_input(
+        batch,
+        num_q_head,
+        num_kv_head,
+        q_seq_len,
+        kv_seq_len,
+        head_size,
+        dtype,
+        current_device,
+    )
+    enable_gqa = num_q_head != num_kv_head
+
+    # Reference gradients from PyTorch's own SDPA autograd.
+    ref_q = q.detach().clone().requires_grad_(True)
+    ref_k = k.detach().clone().requires_grad_(True)
+    ref_v = v.detach().clone().requires_grad_(True)
+    ref_out = torch.nn.functional.scaled_dot_product_attention(
+        ref_q,
+        ref_k,
+        ref_v,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=enable_gqa,
+    )
+    grad_out = torch.randn_like(ref_q)
+    ref_out.backward(grad_out)
+
+    # Gradients through FlagGems' ATen flash-attention forward/backward pair.
+    philox_seed = torch.empty(0, dtype=torch.long, device=current_device)
+    philox_offset = torch.empty(0, dtype=torch.long, device=current_device)
+    with flag_gems.use_gems():
+        out, logsumexp = torch.ops.aten._scaled_dot_product_flash_attention.default(
+            q, k, v, 0.0, is_causal, False, scale=scale
+        )[:2]
+        dq, dk, dv = (
+            torch.ops.aten._scaled_dot_product_flash_attention_backward.default(
+                grad_out,
+                q,
+                k,
+                v,
+                out,
+                logsumexp,
+                None,
+                None,
+                q_seq_len,
+                kv_seq_len,
+                0.0,
+                is_causal,
+                philox_seed,
+                philox_offset,
+                scale=scale,
+            )
+        )
+
+    utils.gems_assert_close(dq, ref_q.grad, dtype, equal_nan=True)
+    utils.gems_assert_close(dk, ref_k.grad, dtype, equal_nan=True)
+    # dV is more sensitive to softmax recomputation errors in the flash
+    # backward (no centering term), mirroring the existing SDPA tests.
+    if enable_gqa:
+        if dtype == torch.bfloat16:
+            v_atol = 2e-2
+        else:
+            v_atol = 4e-3
+    else:
+        if dtype == torch.bfloat16:
+            v_atol = 5e-3
+        else:
+            v_atol = 2e-3
+    utils.gems_assert_close(dv, ref_v.grad, dtype, equal_nan=True, atol=v_atol)

--- a/tests/test_scaled_dot_product_flash_attention_backward.py
+++ b/tests/test_scaled_dot_product_flash_attention_backward.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Accuracy tests for the ATen ``_scaled_dot_product_flash_attention_backward``
+"""Accuracy tests for the ``_scaled_dot_product_flash_attention_backward``
 operator (registered as ``scaled_dot_product_flash_attention_backward``).
 
-The backward op is exercised directly through the ATen entry points used by
-PyTorch's FlashAttention autograd, i.e. the forward ``_scaled_dot_product_flash_attention``
-followed by ``_scaled_dot_product_flash_attention_backward`` with the tensors the
-ATen interface passes around (``[B, H, S, D]`` layout).
+The backward op is exercised through the same tensors the ATen interface passes
+around (``[B, H, S, D]`` layout): the FlagGems forward
+``_scaled_dot_product_flash_attention`` followed by
+``scaled_dot_product_flash_attention_backward``.
 
 Causal is only combined with equal ``q_seq_len == kv_seq_len`` shapes: the fused
 flash kernels align the causal diagonal between query and key and therefore match
@@ -141,32 +141,29 @@ def test_scaled_dot_product_flash_attention_backward(
         ref_q, ref_k, ref_v, ref_go, scale, is_causal, enable_gqa
     )
 
-    # Gradients through FlagGems' ATen flash-attention forward/backward pair.
+    # Gradients through FlagGems' flash-attention forward/backward pair.
     philox_seed = torch.empty(0, dtype=torch.long, device=current_device)
     philox_offset = torch.empty(0, dtype=torch.long, device=current_device)
-    with flag_gems.use_gems():
-        out, logsumexp = torch.ops.aten._scaled_dot_product_flash_attention.default(
-            q, k, v, 0.0, is_causal, False, scale=scale
-        )[:2]
-        dq, dk, dv = (
-            torch.ops.aten._scaled_dot_product_flash_attention_backward.default(
-                grad_out,
-                q,
-                k,
-                v,
-                out,
-                logsumexp,
-                None,
-                None,
-                q_seq_len,
-                kv_seq_len,
-                0.0,
-                is_causal,
-                philox_seed,
-                philox_offset,
-                scale=scale,
-            )
-        )
+    out, logsumexp = flag_gems._scaled_dot_product_flash_attention(
+        q, k, v, 0.0, is_causal, False, scale=scale
+    )[:2]
+    dq, dk, dv = flag_gems.scaled_dot_product_flash_attention_backward(
+        grad_out,
+        q,
+        k,
+        v,
+        out,
+        logsumexp,
+        None,
+        None,
+        q_seq_len,
+        kv_seq_len,
+        0.0,
+        is_causal,
+        philox_seed,
+        philox_offset,
+        scale=scale,
+    )
 
     utils.gems_assert_close(dq, ref_q_g, dtype, equal_nan=True)
     utils.gems_assert_close(dk, ref_k_g, dtype, equal_nan=True)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Document
- [ ] Code Refactoring
- [x] Test
- [ ] CI/CD

### Description
Issue #5095: `pytest -m scaled_dot_product_flash_attention_backward --ref cpu` selected 0 tests / failed because the op carries the NoCPU label, so CI runs it without `--ref cpu` and only a GPU reference existed.

The documented repro in the issue fails because `gems_assert_close` requires the reference on CPU in TO_CPU mode. Compute the reference through the CPU math backend in float64 when `--ref cpu` is set, keeping the exact-dtype GPU SDPA autograd reference for the default mode.

### Issue
Closes #5095

### Progress
- [x] Extract the SDPA autograd gradient reference into `_sdpa_autograd_grads`
- [x] Compute the reference on CPU in float64 under TO_CPU mode; GPU exact-dtype otherwise
- [x] Assert gradients against the new reference in both modes

### Test Plan
`python -m pytest -m scaled_dot_product_flash_attention_backward --ref cpu` and the default no-ref run both pass on NVIDIA H100.