### PR TITLE
fix(hygon): KeyError: 'BLOCK_M' triggered by flash attention operations when running ViT encoder inference

### DIFF
--- a/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Hygon internal implementation for attention
+from ._scaled_dot_product_flash_attention import _scaled_dot_product_flash_attention
 from .adaptive_max_pool3d_backward import adaptive_max_pool3d_backward
 from .addr import addr
 from .any import any, any_dim, any_dims
@@ -122,6 +124,7 @@ from .weight_norm import (
 )
 
 __all__ = [
+    "_scaled_dot_product_flash_attention",
     "_unique2",
     "adaptive_max_pool3d_backward",
     "avg_pool3d_backward",

--- a/src/flag_gems/runtime/backend/_hygon/ops/_scaled_dot_product_flash_attention.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/_scaled_dot_product_flash_attention.py
@@ -1,0 +1,60 @@
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Hygon-specific version that uses the optimized hygon flash_attention_forward
+import logging
+
+from flag_gems.runtime.backend._hygon.ops.attention import flash_attention_forward
+
+logger = logging.getLogger(__name__)
+
+
+def _scaled_dot_product_flash_attention(
+    query,
+    key,
+    value,
+    dropout_p=0.0,
+    is_causal=False,
+    return_debug_mask=False,
+    *,
+    scale=None,
+):
+    """Run scaled dot product FlashAttention through hygon's optimized implementation."""
+    logger.debug("GEMS _SCALED_DOT_PRODUCT_FLASH_ATTENTION (HYGON)")
+    max_q = query.shape[2]
+    max_k = key.shape[2]
+    output, logsumexp, rng_state, unused, debug_mask = flash_attention_forward(
+        query.transpose(1, 2),
+        key.transpose(1, 2),
+        value.transpose(1, 2),
+        None,
+        None,
+        max_q,
+        max_k,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale=scale,
+    )
+    return (
+        output.transpose(1, 2),
+        logsumexp,
+        None,
+        None,
+        max_q,
+        max_k,
+        rng_state,
+        unused,
+        debug_mask,
+    )

--- a/src/flag_gems/runtime/backend/_hygon/ops/_scaled_dot_product_flash_attention.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/_scaled_dot_product_flash_attention.py
@@ -31,7 +31,7 @@ def _scaled_dot_product_flash_attention(
     scale=None,
 ):
     """Run scaled dot product FlashAttention through hygon's optimized implementation."""
-    logger.debug("GEMS _SCALED_DOT_PRODUCT_FLASH_ATTENTION (HYGON)")
+    logger.debug("GEMS_HYGON _SCALED_DOT_PRODUCT_FLASH_ATTENTION")
     max_q = query.shape[2]
     max_k = key.shape[2]
     output, logsumexp, rng_state, unused, debug_mask = flash_attention_forward(


### PR DESCRIPTION
When running ViT encoder inference on the Hygon platform, flash attention operations trigger a KeyError: 'BLOCK_M' crash. The issue occurs inside FlagGems' internal vendor dispatch layer, not in vLLM-Plugin-FL's dispatch layer.

**Error Stack Trace**
```
File "/opt/vllm-src/FlagGems/src/flag_gems/utils/libentry.py", line 249, in launcher
    return compiled_kernel[grid](*all_args)
           ~~~~~~~~~~~~~~~^^^^^^
KeyError: 'BLOCK_M'
```

**Root Cause**

The keep function in the generic flash_kernel.py hard-codes the allowed configurations as:
return (BM, BN, w) in ((128, 32, 4), (128, 128, 8))
This filter rejects all Hygon-specific configurations (which use BLOCK_N=16), causing the Triton autotuner's candidate list to be empty. The autotuner then falls back to Config({}) — an empty configuration — and when the kernel is launched, it cannot find the BLOCK_M parameter, resulting in a KeyError.

The complete failure chain is:


_scaled_dot_product_flash_attention (generic)
  └─ flash_attention_forward (generic)
       └─ flash_kernel.py keep() filters out all Hygon configs (BLOCK_N=16)
            └─ Triton autotuner candidate list is empty
                 └─ Falls back to Config({})
                      └─ KeyError: 'BLOCK_M' at kernel launch ❌

The keep function in the generic flash_kernel.py hard-codes the allowed configurations as:


return (BM, BN, w) in ((128, 32, 4), (128, 128, 8))
This filter rejects all Hygon-specific configurations (which use BLOCK_N=16), causing the Triton autotuner's candidate list to be empty. The autotuner then falls back to Config({}) — an empty configuration — and when the kernel is launched, it cannot find the BLOCK_M parameter, resulting in a KeyError.

The complete failure chain is:
_scaled_dot_product_flash_attention (generic)
  └─ flash_attention_forward (generic)
       └─ flash_kernel.py keep() filters out all Hygon configs (BLOCK_N=16)
            └─ Triton autotuner candidate list is empty
                 └─ Falls back to Config({})
                      └─ KeyError: 'BLOCK_M' at kernel launch ❌

### PR Category
Model Test | CICD

### Type of Change
Bug Fix

### Description
Files Modified:

- Move _scaled_dot_product_flash_attention import to end of __init__.py to clearly separate internal implementations from public APIs
- Replace relative import with absolute import to avoid circular dependency risk between __init__.py and submodules
- Add comment marking it as Hygon-specific internal implementation

**How the Fix Works**

Via FlagGems' SpecOpRegistrar mechanism:

The Hygon-specific __init__.py exports _scaled_dot_product_flash_attention
At runtime, this automatically overrides the generic version
The call path becomes:
_scaled_dot_product_flash_attention (Hygon)
→ flash_attention_forward (Hygon)
→ flash_api.py (Hygon)
→ flash_kernel.py (Hygon, containing 30 valid autotuner configs)

### Issue

- Resolves #5897 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
