### PR TITLE
[KernelGen] align cudnn_attention_forward logsumexp shape with PyTorch version

### DIFF
--- a/src/flag_gems/ops/cudnn_attention_forward.py
+++ b/src/flag_gems/ops/cudnn_attention_forward.py
@@ -17,6 +17,7 @@ import logging
 import math
 
 import torch
+from packaging import version
 
 from flag_gems.ops.attention import scaled_dot_product_attention_forward
 
@@ -86,8 +87,12 @@ def cudnn_attention_forward(
             dtype=torch.float32,
         )
 
-    # cuDNN convention: logsumexp shape is [B, H, S_q, 1]
-    lse = lse.unsqueeze(-1)
+    # Match PyTorch aten::_cudnn_attention_forward behavior.
+    # PyTorch < 2.9 returns [B, H, S_q], while PyTorch >= 2.9
+    # returns [B, H, S_q, 1].
+    torch_version = version.parse(torch.__version__.split("+")[0])
+    if torch_version.release[:2] >= (2, 9):
+        lse = lse.unsqueeze(-1)
 
     # Philox seed / offset: the Triton kernel does not produce these
     # (dropout is not supported), so return scalar zero tensors.


### PR DESCRIPTION
PyTorch's aten::_cudnn_attention_forward returns different logsumexp
shapes across versions:

- PyTorch < 2.9: [B, H, S_q]
- PyTorch >= 2.9: [B, H, S_q, 1]

Align the FlagGems output shape with the installed PyTorch version
instead of always forcing either 3-D or 4-D behavior.

Verified locally with PyTorch 2.8:
48 passed, 16 skipped.