### PR TITLE
Fix slice_scatter writes for noncontiguous outputs

### DIFF
--- a/src/flag_gems/ops/slice_scatter.py
+++ b/src/flag_gems/ops/slice_scatter.py
@@ -34,6 +34,8 @@ def slice_scatter_kernel(
     start,
     step,
     src_dim_size,
+    OUT_SHAPE: tl.constexpr,
+    OUT_STRIDES: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -60,7 +62,17 @@ def slice_scatter_kernel(
     )
     src_data = tl.load(src_ptr + src_idx, mask=mask & slice_mask)
     result = tl.where(slice_mask, src_data, inp_data)
-    tl.store(out_ptr + idx, result, mask=mask)
+
+    out_idx = idx
+    if len(OUT_SHAPE) > 0:
+        # Inputs are contiguous, but the output can retain the original strides.
+        remaining = idx
+        out_idx = tl.full((BLOCK_SIZE,), 0, tl.int64)
+        for axis in tl.static_range(len(OUT_SHAPE) - 1, -1, -1):
+            coordinate = remaining % OUT_SHAPE[axis]
+            out_idx += coordinate.to(tl.int64) * OUT_STRIDES[axis]
+            remaining = remaining // OUT_SHAPE[axis]
+    tl.store(out_ptr + out_idx, result, mask=mask)
 
 
 def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
@@ -102,6 +114,13 @@ def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
     BLOCK_SIZE = 1024
     grid = (triton.cdiv(total_elements, BLOCK_SIZE),)
 
+    # Empty metadata keeps the existing linear store for contiguous outputs.
+    out_shape = ()
+    out_strides = ()
+    if not out.is_contiguous():
+        out_shape = tuple(out.shape)
+        out_strides = out.stride()
+
     slice_scatter_kernel[grid](
         out,
         inp,
@@ -112,6 +131,8 @@ def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
         start,
         step,
         src_dim_size,
+        OUT_SHAPE=out_shape,
+        OUT_STRIDES=out_strides,
         BLOCK_SIZE=BLOCK_SIZE,
     )
 

--- a/tests/test_slice_scatter.py
+++ b/tests/test_slice_scatter.py
@@ -75,6 +75,52 @@ def test_slice_scatter(shape, stride, dim, dtype, start, end, step):
 
 
 @pytest.mark.slice_scatter
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize(
+    "shape,stride,dim,start,end,step",
+    [
+        ((3, 2), (1, 3), 1, 0, 1, 1),
+        ((3, 2), (1, 3), 0, 1, 3, 1),
+        ((3, 4), (8, 2), 1, 1, 4, 2),
+        ((3, 2, 4), (4, 12, 1), 2, 1, 4, 2),
+        ((2, 3, 4), (24, 8, 2), 1, 0, 3, 2),
+        ((3, 517), (1, 3), 1, 1, 516, 2),
+    ],
+)
+def test_slice_scatter_noncontiguous_input(shape, stride, dim, dtype, start, end, step):
+    inp = torch.empty_strided(shape, stride, dtype=dtype, device=flag_gems.device)
+    # Vary the unchanged values too, so misplaced writes cannot pass unnoticed.
+    inp.copy_(
+        torch.arange(inp.numel(), dtype=torch.float32, device=flag_gems.device).reshape(
+            shape
+        )
+    )
+    src_shape = list(shape)
+    src_shape[dim] = (end - start + step - 1) // step
+    src = torch.empty(src_shape, dtype=dtype, device=flag_gems.device)
+    src.copy_(
+        -torch.arange(
+            1, src.numel() + 1, dtype=torch.float32, device=flag_gems.device
+        ).reshape(src_shape)
+    )
+
+    ref_out = torch.slice_scatter(
+        utils.to_reference(inp),
+        utils.to_reference(src),
+        dim=dim,
+        start=start,
+        end=end,
+        step=step,
+    )
+    res_out = flag_gems.slice_scatter(
+        inp, src, dim=dim, start=start, end=end, step=step
+    )
+
+    utils.gems_assert_equal(res_out, ref_out)
+    assert res_out.stride() == inp.stride()
+
+
+@pytest.mark.slice_scatter
 def testslice_scatter_with_self_overlapping_input():
     inp = torch.randn((3, 1), device=flag_gems.device).broadcast_to((3, 8))
     src = torch.rand((3, 4), device=flag_gems.device)


### PR DESCRIPTION
### PR Category

Operator, OP Test

### Type of Change

Bug Fix

### Description

`slice_scatter` preserves non-overlapping input strides in the output allocation, but makes its inputs contiguous and stores the result using linear output offsets. For transposed or stepped inputs, this writes values to the wrong logical positions and can leave valid output elements unwritten.

For example, on master `6e9839ecfb2d427a00a9dd39827ef52ea5cf264e`:

```python
inp = torch.arange(6, dtype=torch.float32, device="cuda").reshape(2, 3).T
src = torch.tensor([[100.], [200.], [300.]], device="cuda")
flag_gems.slice_scatter(inp, src, dim=1, start=0, end=1, step=1)
# Expected: [[100, 3], [200, 4], [300, 5]]
# Before:   [[100, 4], [3, 300], [200, 5]]
```

Map each flattened logical output index through the output shape and strides before storing. Contiguous outputs pass empty metadata and retain the linear store path. Output allocation and stride preservation remain intact; noncontiguous offsets accumulate in 64-bit integers.

Add regressions for 2D transposes, stepped layouts, 3D permutations, different slice dimensions/steps, and a partial final block spanning multiple programs. Input values vary outside the replaced slice as well, and tests check both exact values and preserved strides.

Validation on NVIDIA GeForce RTX 4090, PyTorch 2.13.0+cu130, Triton 3.7.1:

- Before the fix: `PYTHONPATH=src python3 -m pytest tests/test_slice_scatter.py -k noncontiguous_input --quick -q` — all 6 new float32 cases fail.
- After the fix: `PYTHONPATH=src python3 -m pytest tests/test_slice_scatter.py -q` — 67 passed, including the existing contiguous/self-overlapping cases and new float16/float32/bfloat16 cases.
- The small example also reproduces through the full package and `torch.slice_scatter` inside `flag_gems.use_gems(include=["slice_scatter"])`; both paths match PyTorch after the fix. The regression tests use the explicit `flag_gems.slice_scatter` API.
- Black 26.5.1 (`--target-version py310`), isort 5.12.0, flake8 and `git diff --check` pass.

Other hardware backends have not been run locally.

### Issue

No existing issue. Found while checking noncontiguous tensor layouts.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

Contiguous float32 microbenchmarks use `triton.testing.do_bench_cudagraph` with `rep=100`, three trials with alternating before/after order, and `dim=1, start=0, end=width, step=2`. The baseline is the unmodified master implementation; both versions match PyTorch on these inputs.

| Input shape | Before median (ms) | After median (ms) |
| --- | ---: | ---: |
| 64 × 64 | 0.00128451 | 0.00128486 |
| 1024 × 1024 | 0.00337290 | 0.00337858 |
| 4096 × 4096 | 0.17772218 | 0.17774587 |

These local GPU replay measurements exclude Python dispatch overhead and are not a cross-backend performance claim.
