### PR TITLE
fix(amp): compare finitef result to zero instead of bitwise-not (#5887)

### DIFF
--- a/src/flag_gems/ops/_amp_foreach_non_finite_check_and_unscale_.py
+++ b/src/flag_gems/ops/_amp_foreach_non_finite_check_and_unscale_.py
@@ -48,8 +48,13 @@ def _amp_foreach_non_finite_check_and_unscale_kernel(
     inp_fp32 = inp.to(tl.float32)
     scale_fp32 = scale.to(tl.float32)
 
-    # Check for non-finite values (inf or nan) using float32
-    is_non_finite = ~tl_extra_shim.finitef(inp_fp32)
+    # Check for non-finite values (inf or nan) using float32.
+    # finitef() may be lowered to an int1 (triton >= 3.6) or to a wider int
+    # (0/1) on other versions/backends.  Bitwise-not (~) is only equivalent to
+    # logical negation for int1; on a wider int it yields -1/-2, which is always
+    # non-zero, so the tl.where below would never scale finite values.
+    # Comparing against zero gives the correct predicate on every variant.
+    is_non_finite = tl_extra_shim.finitef(inp_fp32) == 0
 
     # Scale the values: only finite values are scaled
     # Non-finite values stay as-is (in original dtype)


### PR DESCRIPTION
body written
xes #5887.

`_amp_foreach_non_finite_check_and_unscale_kernel` computes the non-finite predicate with

```python
is_non_finite = ~tl_extra_shim.finitef(inp_fp32)
```

`finitef()` returns a 0/1 predicate. On triton >= 3.6 the CUDA libdevice shim coerces the result to `int1`, where bitwise-not coincides with logical negation, so the current code happens to work. On triton versions/backends where the predicate is surfaced as a wider integer, `~1 == -2` and `~0 == -1` are always non-zero, so `tl.where(is_non_finite, inp_fp32, inp_fp32 * scale_fp32)` always keeps the original value and `inv_scale` is never applied.

### Reproduction status

We ran the existing suite (`tests/test_amp_foreach_non_finite_check_and_unscale_.py`) plus direct operator probes on NVIDIA H100 / triton 3.6.0 against current `master` (ece4713ae). With the `int1` coercion in this triton build the current expression is correct there, so the runtime failure could not be reproduced on this stack; the defect is exposed on configurations where `finitef` keeps a wider integer return type.

### Fix

```python
is_non_finite = tl_extra_shim.finitef(inp_fp32) == 0
```

`== 0` yields the correct predicate on every variant (int1 or wider 0/1 integer) and does not change behavior on the `int1` path.

### Verification

- `tests/test_amp_foreach_non_finite_check_and_unscale_.py`: 6 passed before and after the change on NVIDIA H100.
- Direct probe: an all-finite fp32 tensor scaled with `inv_scale = 2.0` produces `[2.0, 4.0, 8.0]`; tensors containing `inf`/`nan` keep those elements and scale the finite ones, and `found_inf` is set, matching the PyTorch reference.
