### PR TITLE
fix(flagtune): fall back when FlagTune Manifest URL is not configured

### DIFF
--- a/src/flag_gems/flagtune/runtime/model_package.py
+++ b/src/flag_gems/flagtune/runtime/model_package.py
@@ -64,14 +64,28 @@ def _is_unversioned_platform_miss(exc: FileNotFoundError, platform_key: str) -> 
     return str(exc).startswith(prefix)
 
 
+def _is_absent_manifest_error(exc: RuntimeError) -> bool:
+    """Recognize an absent (not malformed) FlagTune Manifest.
+
+    FlagTree's manifest loader raises ``ManifestFetchError`` — a
+    ``RuntimeError`` subclass, not ``FileNotFoundError`` — when no
+    ``FLAGTUNE_MANIFEST_URL`` is configured and no Manifest is cached. That is
+    the common "FlagTune not set up" case and should fall back to the Default
+    config space instead of crashing model loading. Keyed on the message
+    because ``ManifestFetchError`` lives in FlagTree and may not be importable.
+    """
+    return str(exc).startswith("FLAGTUNE_MANIFEST_URL is not configured")
+
+
 def platform_model_package_available() -> bool:
     """Return whether the active platform resolves to an outer model package.
 
     Resolution follows FlagTree's existing user-directory, package-cache,
-    Manifest, and download rules. Only an unversioned Manifest miss means the
-    platform is unadapted. Fixed-version misses, disabled remote access,
-    malformed Manifests, download failures, checksum mismatches, and invalid
-    archives continue to raise their original exceptions.
+    Manifest, and download rules. An unversioned Manifest miss (no entry for
+    the platform) or an absent Manifest (no URL configured) means the platform
+    is unadapted. Fixed-version misses, disabled remote access, malformed
+    Manifests, download failures, checksum mismatches, and invalid archives
+    continue to raise their original exceptions.
     """
     platform_key = _discover_platform_key()
     cache_key = _availability_cache_key(platform_key)
@@ -89,6 +103,10 @@ def platform_model_package_available() -> bool:
         )
     except FileNotFoundError as exc:
         if not _is_unversioned_platform_miss(exc, platform_key):
+            raise
+        available = False
+    except RuntimeError as exc:
+        if not _is_absent_manifest_error(exc):
             raise
         available = False
     else:

--- a/tests/flagtune/test_model_package.py
+++ b/tests/flagtune/test_model_package.py
@@ -67,6 +67,24 @@ def test_unversioned_manifest_miss_marks_platform_unadapted(monkeypatch):
     assert model_package.platform_model_package_available() is False
 
 
+def test_absent_manifest_marks_platform_unadapted(monkeypatch):
+    """Treat an absent Manifest (no URL configured) as unavailable, not a crash."""
+    error = RuntimeError(
+        "FLAGTUNE_MANIFEST_URL is not configured and no cached FlagTune "
+        "Manifest exists at /root/.flagtree/flagtune_models/manifest.json"
+    )
+    manager = _manager_raising(error)
+    monkeypatch.setattr(
+        model_package,
+        "_discover_platform_key",
+        lambda: "hygon-bw1000",
+    )
+    monkeypatch.setattr(model_package, "_get_model_manager", lambda: manager)
+
+    assert model_package.platform_model_package_available() is False
+    assert model_package.platform_model_package_available() is False
+
+
 @pytest.mark.parametrize(
     "error",
     [


### PR DESCRIPTION
## Problem

`platform_model_package_available()` only catches `FileNotFoundError`, but FlagTree's manifest loader raises `ManifestFetchError` — a `RuntimeError` subclass — when no `FLAGTUNE_MANIFEST_URL` is configured and no Manifest is cached. That is the common "FlagTune not set up" case, and it crashes model loading instead of falling back to the Default config space.

Observed crash (FlagGems 5.4.0-rc1, Hygon empty mode, model load):

```
triton.flagtune.runtime.model_sources.ManifestFetchError: FLAGTUNE_MANIFEST_URL is not configured and no cached FlagTune Manifest exists at /root/.flagtree/flagtune_models/manifest.json
```

## Root cause

FlagTree's `_load_manifest()` reports a *missing Manifest entry* (Manifest present, no entry for this platform) as `FileNotFoundError`, but a *completely absent Manifest* (no URL configured / nothing cached) as `ManifestFetchError`. #5678's fallback only handled the former (`except FileNotFoundError`), so the latter still propagates and crashes.

## Fix

Add a `RuntimeError` branch that recognizes the absent-Manifest message and treats it as "platform unadapted", consistent with the existing `_is_unversioned_platform_miss` message-keyed approach. Download failures, checksum mismatches, disabled-remote policy, and malformed Manifests still propagate (matching #5678's intent).

Keyed on the message because `ManifestFetchError` lives in FlagTree and may not be importable from FlagGems.

## Test

Added `test_absent_manifest_marks_platform_unadapted` covering the `FLAGTUNE_MANIFEST_URL is not configured` case.

## Related

- #5678 (original fallback, only covered unversioned miss)
- #5762 (added Mul cost model; triggered this on rc1) / #6043 (revert)
- #6058 (RC1 bug report for the crash)
