### PR TITLE
fix(attention): prevent _attn_bwd runtime crashes on Hopper sm90

### DIFF
--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -578,10 +578,46 @@ def _attn_bwd_dq(
 config_backward = runtime.get_tuned_config("attention_bwd")
 
 
+def _prune_attn_bwd_configs(configs, nargs, **kwargs):
+    """Restrict _attn_bwd tuning candidates that crash on Hopper (sm90).
+
+    Empirically verified runtime "illegal memory access" faults (memcheck-clean,
+    deterministic per shape/dtype/prior-allocations, and never triggered by
+    pure kernel indexing):
+    - BLOCK_DMODEL <= 32 (head_dim <= 32): the num_warps >= 4 WGMMA path faults
+      (num_warps <= 2, the non-WGMMA path, is always safe) - a Triton WGMMA
+      codegen defect.
+    - BLOCK_DMODEL > 32: the single-warpgroup (num_warps = 4) path faults for
+      some M2 = 128 tiles depending on allocation layout; num_warps = 8 (two
+      warpgroups) is stable across every shape/dtype/order tried.
+
+    Rewriting candidates keeps the autotuner from ever benchmarking/selecting
+    a crashing config.
+    """
+    pruned = []
+    for config in configs:
+        if kwargs.get("BLOCK_DMODEL", 64) <= 32:
+            num_warps = min(config.num_warps, 2)
+        else:
+            num_warps = max(config.num_warps, 8)
+        if num_warps != config.num_warps:
+            config = triton.Config(
+                config.kwargs,
+                num_warps=num_warps,
+                num_stages=config.num_stages,
+                num_ctas=config.num_ctas,
+                maxnreg=config.maxnreg,
+                pre_hook=config.pre_hook,
+            )
+        pruned.append(config)
+    return pruned
+
+
 @libentry()
 @libtuner(
     configs=config_backward,
     key=["KV_CTX", "BLOCK_DMODEL"],
+    prune_configs_by={"early_config_prune": _prune_attn_bwd_configs},
 )
 @triton.jit
 def _attn_bwd(
@@ -764,7 +800,13 @@ def _attn_bwd(
         m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
         m = m[:, None]
 
-        MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+        # _attn_bwd_dq requires BLOCK_M2 % BLOCK_N2 == 0. When AABS shrinks
+        # BLOCK_M2 below BLOCK_N2 (small Q_CTX), clamp the KV tile to a divisor
+        # of BLOCK_M2 instead of letting the static_assert fire.
+        MASK_BLOCK_N2: tl.constexpr = min(BLOCK_N2 // BLK_SLICE_FACTOR, BLOCK_M2)
+        stage2_block_n: tl.constexpr = (
+            BLOCK_N2 if BLOCK_M2 % BLOCK_N2 == 0 else MASK_BLOCK_N2
+        )
 
         if IS_CAUSAL:
             # Masked diagonal phase: KV columns [diag_n, end_n)
@@ -799,10 +841,10 @@ def _attn_bwd(
                 )
 
             # Unmasked phase: KV columns [0, diag_n), all fully visible.
-            stage2_num_steps = (diag_n + BLOCK_N2 - 1) // BLOCK_N2
+            stage2_num_steps = (diag_n + stage2_block_n - 1) // stage2_block_n
         else:
             # Non-causal: single unmasked pass over all KV columns.
-            stage2_num_steps = (KV_CTX + BLOCK_N2 - 1) // BLOCK_N2
+            stage2_num_steps = (KV_CTX + stage2_block_n - 1) // stage2_block_n
 
         if stage2_num_steps > 0:
             dq = _attn_bwd_dq(
@@ -819,7 +861,7 @@ def _attn_bwd(
                 Q_CTX,  #
                 KV_CTX,  #
                 BLOCK_M2,
-                BLOCK_N2,
+                stage2_block_n,
                 BLOCK_DMODEL,  #
                 start_m,
                 0,


### PR DESCRIPTION
## Summary

`test_scaled_dot_product_attention.py` was failing with **128 failed / 112 passed**, all `RuntimeError: CUDA error: an illegal memory access`, only in the **backward** pass (`_attn_bwd`). Forward passed.

Investigation (per-shape isolated subprocesses, config-cache/AABS bypassed, `compute-sanitizer memcheck` showing **0 errors**) pinned down **three independent faults**, none of them static out-of-bounds accesses in the kernel — all are Triton Hopper (sm90) WGMMA codegen/layout defects, plus one AABS interaction:

1. **`head_dim <= 32` (`BLOCK_DMODEL <= 32`) with `num_warps >= 4` (WGMMA path) always faults.** `num_warps <= 2` (non-WGMMA path) is always safe.
2. **`head_dim > 32` with `num_warps = 4` (single warpgroup WGMMA) faults for `M2 = 128` tiles depending on allocation layout** — e.g. always when the reference torch SDPA backward has run first (the real test order), never in a fresh process. `num_warps = 8` (two warpgroups) is stable across every shape/dtype/order tried.
3. **AABS shrinks `BLOCK_M2` below `BLOCK_N2` for tiny `Q_CTX`**, violating `static_assert(BLOCK_M2 % BLOCK_N2 == 0)` in `_attn_bwd_dq` → `CompilationError`.

The bulk of the 128 pytest failures was a CUDA-context-poisoning cascade: the first genuine crash (an early head32 shape) made every later kernel in the same process error out, including shapes that pass in isolation.

## Fix

Single file, `src/flag_gems/ops/attention.py` (+48/-4):

**A. Config pruning** — new `_prune_attn_bwd_configs` wired as
`prune_configs_by={"early_config_prune": _prune_attn_bwd_configs}` on `_attn_bwd`'s `@libtuner` (precedent: `flash_kernel.py` `prune_fwd_configs`). It *rewrites* candidates so the autotuner never benchmarks or selects a crashing config (a bench-time async fault would poison the whole process):
- `BLOCK_DMODEL <= 32` → `num_warps = min(num_warps, 2)`
- `BLOCK_DMODEL > 32` → `num_warps = max(num_warps, 8)` (drop the single-warpgroup `w=4` WGMMA path)

**B. AABS tile clamp** — in the dQ phase, when AABS shrinks `BLOCK_M2` below `BLOCK_N2`, clamp the stage-2 KV tile to a divisor of `BLOCK_M2` instead of letting the static_assert fire:
```python
MASK_BLOCK_N2 = min(BLOCK_N2 // BLK_SLICE_FACTOR, BLOCK_M2)
stage2_block_n = BLOCK_N2 if BLOCK_M2 % BLOCK_N2 == 0 else MASK_BLOCK_N2
```
(`stage2_num_steps` and the stage-2 `_attn_bwd_dq` call now use `stage2_block_n`.)

## Test

H20-3e (`CUDA_VISIBLE_DEVICES=7`):

```
$ python3 -m pytest tests/test_scaled_dot_product_attention.py -q
240 passed          # was 128 failed / 112 passed
```
- All 96 `legacy_backward` nodes also pass in isolated subprocesses, with `FLAGTREE_AABS` both on and off.
- The 6 previously deterministic crashes (fp16/bf16 causal head64 families) re-tested individually: all pass.

```
$ python3 -m pytest benchmark/test_scaled_dot_product_attention.py
3 passed, speedups 1.30–2.23   # forward path untouched by this change
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
