### PR TITLE
[Bug] Fix SQLite database lock handling in SQLPersistantModel (#6065)

### DIFF
--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 from hashlib import md5
 from itertools import chain
 from typing import (
@@ -29,6 +30,7 @@ from typing import (
 )
 
 import sqlalchemy
+import sqlalchemy.exc
 import sqlalchemy.ext.automap
 import sqlalchemy.orm
 import triton
@@ -220,22 +222,52 @@ class SQLPersistantModel(PersistantModel):
             ModelCls = SQLPersistantModel.build_sql_model_by_py(
                 short_name, keys, values
             )
-            try:
-                with self.engine.begin() as conn:
-                    conn.execute(
-                        sqlalchemy.schema.CreateTable(
-                            ModelCls.__table__, if_not_exists=True
+
+            # Retry logic for handling transient SQLite database locks
+            max_retries = 5
+            base_delay = 0.05  # 50ms
+            for attempt in range(max_retries):
+                try:
+                    with self.engine.begin() as conn:
+                        conn.execute(
+                            sqlalchemy.schema.CreateTable(
+                                ModelCls.__table__, if_not_exists=True
+                            )
                         )
-                    )
-            except Exception as e:
-                # Because of concurrent execution, the same table/type name is
-                # attempted to be created multiple times; these errors can be safely ignored.
-                err_msg = str(e)
-                if "duplicate key value violates unique constraint" not in err_msg:
-                    # DuplicateObject (42710): e.g. type "xxx" already exists
-                    if 'type "' not in err_msg or '" already exists' not in err_msg:
+                    break  # Success, exit retry loop
+                except sqlalchemy.exc.OperationalError as e:
+                    err_msg = str(e)
+                    # Check if it's a SQLite database lock error
+                    if "database is locked" in err_msg:
+                        if attempt < max_retries - 1:
+                            # Exponential backoff
+                            delay = base_delay * (2 ** attempt)
+                            time.sleep(delay)
+                            # After sleeping, check if table was created by another process
+                            ModelCls_retry = SQLPersistantModel.build_sql_model_by_db(
+                                short_name, self.engine
+                            )
+                            if ModelCls_retry is not None:
+                                self.sql_model_pool[short_name] = ModelCls_retry
+                                return ModelCls_retry
+                            continue
+                        else:
+                            # Max retries exceeded, propagate the error
+                            raise
+                    else:
+                        # Not a lock error, re-raise immediately
                         raise
-            self.sql_model_pool[name] = ModelCls
+                except Exception as e:
+                    # Because of concurrent execution, the same table/type name is
+                    # attempted to be created multiple times; these errors can be safely ignored.
+                    err_msg = str(e)
+                    if "duplicate key value violates unique constraint" not in err_msg:
+                        # DuplicateObject (42710): e.g. type "xxx" already exists
+                        if 'type "' not in err_msg or '" already exists' not in err_msg:
+                            raise
+                    break  # Table exists, exit retry loop
+
+            self.sql_model_pool[short_name] = ModelCls
             return ModelCls
 
     @override


### PR DESCRIPTION
## Problem
SQLPersistantModel.get_sql_model() propagated transient SQLite "database is locked" errors when multiple autotuning workers tried to create benchmark tables concurrently, causing workers to crash during tensor-parallel inference.

## Solution
Implemented retry logic with exponential backoff for SQLite lock errors:
- Max 5 retries with 50ms base delay and exponential backoff
- Total max wait time ~1.55 seconds for bounded recovery
- After each retry, checks if another process created the table
- Only retries "database is locked" errors, other errors propagate immediately
- Preserves existing PostgreSQL error handling

Fixes #6065

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
