### PR TITLE
[QC][Benchmark] Use dedicated test_mm_w8a8_fp8 entry

### DIFF
--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -1547,13 +1547,6 @@ class ParallelSparseAttentionBenchmark(ParallelBenchmarkMixin, Benchmark):
             marks=pytest.mark.mm,
         ),
         pytest.param(
-            "mm_w8a8_fp8",
-            torch.Tensor.mm,
-            mm_input_fn,
-            ParallelMmW8A8Fp8Benchmark,
-            marks=pytest.mark.mm_w8a8_fp8,
-        ),
-        pytest.param(
             "baddbmm",
             torch.baddbmm,
             baddbmm_input_fn,
@@ -1569,10 +1562,20 @@ def test_blas_benchmark(op_name, torch_op, input_fn, bench_cls):
         torch_op=torch_op,
         dtypes=FLOAT_DTYPES,
     )
-    if op_name == "mm_w8a8_fp8":
-        if not hasattr(flag_gems, "mm_w8a8_fp8_out"):
-            pytest.skip("mm_w8a8_fp8 benchmark requires the Hopper W8A8 backend")
-        bench.set_gems(_mm_w8a8_fp8_out_cached)
+    bench.run()
+
+
+@pytest.mark.mm_w8a8_fp8
+def test_mm_w8a8_fp8():
+    if not hasattr(flag_gems, "mm_w8a8_fp8_out"):
+        pytest.skip("mm_w8a8_fp8 benchmark requires the Hopper W8A8 backend")
+    bench = ParallelMmW8A8Fp8Benchmark(
+        input_fn=mm_input_fn,
+        op_name="mm_w8a8_fp8",
+        torch_op=torch.Tensor.mm,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.set_gems(_mm_w8a8_fp8_out_cached)
     bench.run()
 
 


### PR DESCRIPTION
### PR Category
Benchmark

### Type of Change
Refactor

### Description
Expose the Hopper FP8 W8A8 MM benchmark as a standalone `test_mm_w8a8_fp8` function so it can be selected directly by pytest node ID and matches the accuracy test name in `tests/test_mm.py`.

Move the W8A8 case out of the generic `test_blas_benchmark` parametrization. Preserve the operator marker, torch BF16 baseline when running with BF16 inputs, CUDA Graph timing, cached output wrapper, and parallel worker support. The accuracy test already uses the required name and retains its ten shape cases.

Follow-up to merged PR #3821. Only `benchmark/test_blas_perf_parallel.py` changes.

### Validation
- Targeted pre-commit checks and `git diff --check` passed.
- On NVIDIA H20, marker-based collection selects exactly `benchmark/test_blas_perf_parallel.py::test_mm_w8a8_fp8`.
- `python -m pytest -q tests/test_mm.py::test_mm_w8a8_fp8`: 10 passed.
- BF16 benchmark smoke test with `(B,M,N,K)=(1,16,128,128)` and `(1,64,256,256)`, `--parallel 1`, `--warmup 10`, and `--iter 20`: 1 passed. This exercises worker subprocess selection using the new node ID.

The test node IDs are now:
```bash
python -m pytest -s benchmark/test_blas_perf_parallel.py::test_mm_w8a8_fp8 --dtypes bfloat16
python -m pytest -q tests/test_mm.py::test_mm_w8a8_fp8
```
