### PR TITLE
fix(index): cast pid_p to int64 to prevent int32 offset overflow

### DIFF
--- a/src/flag_gems/ops/index.py
+++ b/src/flag_gems/ops/index.py
@@ -451,7 +451,7 @@ def generate_index_linearized_kernel(
     code.writeline("):")
 
     with code.indent():
-        code.writeline("pid_p = tl.program_id(axis=0)")
+        code.writeline("pid_p = tl.program_id(axis=0).to(tl.int64)")
         code.writeline("pid_m = tl.program_id(axis=1)")
         code.writeline("pid_n = tl.program_id(axis=2)")
         code.newline()


### PR DESCRIPTION
## 问题

sglang-plugin-FL（FlagGems 全量替换 ATen 算子）在 nvidia H800 上对 Qwen3.6-35B-A3B 做大输入长度（16384）压测时，服务崩溃 `CUDA error: an illegal memory access`。详见 #6083。

## 根因

`generate_index_linearized_kernel`（线性化 adjacent index 路径）生成的 kernel，其源偏移公式**全程 int32**：

```python
src_offsets = (pid_p * indexed_volume + linear_index[:, None]) * suffix_size + suffix_offsets[None, :]
```

- `pid_p = tl.program_id(axis=0)` 为 int32；
- 当索引张量是 int32 时 `linear_index` 也是 int32（sglang mamba 状态池的 `req_index_to_mamba_index_mapping` 正是 `dtype=torch.int32`）。

对元素数 > 2^31 的张量（如 mamba temporal 状态 `(30, 1566, 8, 128, 128)` = 6,157,762,560 元素），`* suffix_size` 使偏移 int32 溢出 wrap 成负数 → 读越界 → illegal memory access。

## 修复

`pid_p` 转 int64，使整条偏移链提升为 int64：

```python
pid_p = tl.program_id(axis=0).to(tl.int64)
```

## 验证

本地最小复现（int32 索引 + `(12,1566,131072)` int8 张量，走 flag_gems index）：

- 修复前：`torch.AcceleratorError: CUDA error: an illegal memory access`
- 修复后：PASS（12 页全对）

sglang + Qwen3.6-35B-A3B i16k 压测端到端：修复后不再崩溃。

Fixes #6083
