### PR TITLE
[kunlunxin] move the copy family onto tle.gpu

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/alias_copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/alias_copy.py
@@ -1,14 +1,12 @@
 import logging
 
 import torch
-import triton
-import triton.language as tl
+import triton  # noqa: F401
+import triton.language as tl  # noqa: F401
 from _kunlunxin.utils.codegen_config_utils import CodeGenConfig
 
-from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry
-
 from ..utils.pointwise_dynamic import pointwise_dynamic
+from ..utils.tle_copy import tle_copy
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
@@ -19,19 +17,8 @@ config_ = CodeGenConfig(
     True,
     prefer_1d_tile=True,
     buffer_size_limit=4096,
-    isCloseVectorization=False,
     kunlunAutoGrid=True,
-    unroll_num=8,
 )
-
-
-@libentry()
-@triton.jit(do_not_specialize=["n_elements"])
-def _alias_copy_out_kernel(src_ptr, dst_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-    tl.store(dst_ptr + offsets, tl.load(src_ptr + offsets, mask=mask), mask=mask)
 
 
 @pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")], config=config_)
@@ -44,6 +31,11 @@ def alias_copy(x: torch.Tensor):
     logger.debug("GEMS_KUNLUNXIN ALIAS_COPY")
     if x.numel() == 0:
         return torch.empty_like(x)
+    # An alias copy is a plain move, so let tle.gpu do it; the pointwise kernel
+    # stays as the fallback for what tle cannot express (e.g. bool).
+    out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    if tle_copy(x, out):
+        return out
     return alias_copy_func(x)
 
 
@@ -61,13 +53,7 @@ def alias_copy_out(x: torch.Tensor, out: torch.Tensor):
         )
     if out.numel() == 0:
         return out
-    if x.is_contiguous() and out.is_contiguous():
-        block_size = 8192
-        grid = triton.cdiv(x.numel(), block_size)
-        with torch_device_fn.device(x.device):
-            _alias_copy_out_kernel[(grid,)](
-                x, out, x.numel(), BLOCK_SIZE=block_size, num_warps=4
-            )
-    else:
-        alias_copy_func(x, out0=out)
+    if tle_copy(x, out):
+        return out
+    alias_copy_func(x, out0=out)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/contiguous.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/contiguous.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 
 import logging
-import os
 
 import torch
-from _kunlunxin.ops.copy import copy, copy_slice
+from _kunlunxin.ops.copy import copy_
 
 logger = logging.getLogger(__name__)
 
 
 def contiguous(inp, memory_format=torch.contiguous_format):
     assert memory_format == torch.contiguous_format
-    logger.debug("GEMS_KUNLUNXIN CONTIGUOUS")
+    logger.debug("GEMS CONTIGUOUS")
     if inp.is_contiguous(memory_format=memory_format):
         return inp
     out = torch.empty_like(inp, memory_format=memory_format)
-    if "TRITONXPU_IS_SCATTER_SLICE" in os.environ:
-        return copy_slice(inp, out0=out)
-    else:
-        return copy(inp, out0=out)
+    return copy_(out, inp)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
@@ -17,12 +17,18 @@ from typing import Optional
 
 import torch
 import triton
-import triton.language as tl
+from _kunlunxin.utils.codegen_config_utils import CodeGenConfig
 
-from ..utils.codegen_config_utils import CodeGenConfig
 from ..utils.pointwise_dynamic import pointwise_dynamic
+from ..utils.tle_copy import tle_copy
 
 logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+_FLOAT8_E8M0FNU = getattr(torch, "float8_e8m0fnu", None)
 
 config_ = CodeGenConfig(
     512,
@@ -30,54 +36,34 @@ config_ = CodeGenConfig(
     32,
     True,
     prefer_1d_tile=True,
-    is_scatter_slice=True,
+    buffer_size_limit=4096,
+    kunlunAutoGrid=True,
 )
 
 
-# @pointwise_dynamic(is_tensor=(True,), promotion_methods=[(0, "DEFAULT")])
-# @triton.jit
-# def copy(src):
-#     return src
-
-
-@pointwise_dynamic(
-    is_tensor=(True,), promotion_methods=[(0, "DEFAULT")], config=config_
-)
-@triton.jit
-def copy_slice(src):
-    return src
-
-
-@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
+@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")], config=config_)
 @triton.jit
 def _copy_kernel(src):
     return src
 
 
-@triton.jit
-def _copy_e8m0_to_fp32_kernel(src, dst, n_elements, BLOCK_SIZE: tl.constexpr):
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-    exponent_bits = tl.load(src + offsets, mask=mask).to(tl.uint32) << 23
-    values = exponent_bits.to(tl.float32, bitcast=True)
-    tl.store(dst + offsets, values, mask=mask)
-
-
-def _is_e8m0(tensor: torch.Tensor) -> bool:
-    return hasattr(torch, "float8_e8m0fnu") and tensor.dtype is torch.float8_e8m0fnu
-
-
-def _validate_triton_copy(dst: torch.Tensor, src: torch.Tensor) -> None:
+def _can_use_triton(dst: torch.Tensor, src: torch.Tensor) -> bool:
     if dst.layout != torch.strided or src.layout != torch.strided:
-        raise NotImplementedError("copy_ only supports strided tensors on Kunlunxin")
+        return False
+    if dst.device != src.device:
+        return False
     if dst.is_quantized or src.is_quantized:
-        raise NotImplementedError(
-            "copy_ for quantized tensors is not supported on Kunlunxin"
-        )
+        return False
     if src.is_complex() or dst.is_complex():
-        raise NotImplementedError(
-            "copy_ for complex tensors is not supported on Kunlunxin"
-        )
+        # Preserve PyTorch's behaviour of warning when casting complex to real
+        # by forcing the redispatch path, which issues the warning internally.
+        return False
+    if _FLOAT8_E8M0FNU is not None and (
+        src.dtype == _FLOAT8_E8M0FNU or dst.dtype == _FLOAT8_E8M0FNU
+    ):
+        # Triton does not support float8 yet, so defer to PyTorch which has a reference implementation.
+        return False
+    return True
 
 
 def _expand_like(src: torch.Tensor, target_shape: torch.Size) -> torch.Tensor:
@@ -89,7 +75,7 @@ def _expand_like(src: torch.Tensor, target_shape: torch.Size) -> torch.Tensor:
 def copy(
     template: torch.Tensor, src: torch.Tensor, *, non_blocking: Optional[bool] = False
 ):
-    logger.debug("GEMS_KUNLUNXIN COPY")
+    logger.debug("GEMS COPY (functional)")
     out = torch.empty_strided(
         template.size(), template.stride(), dtype=template.dtype, device=template.device
     )
@@ -98,8 +84,10 @@ def copy(
 
 
 def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
-    if not isinstance(src, torch.Tensor):
-        raise TypeError("src must be a Tensor")
+    if isinstance(src, (int, float, bool)):
+        src = torch.tensor(src, device=dst.device)
+    elif not isinstance(src, torch.Tensor):
+        raise TypeError("unsupport src type for copy_: ", type(src))
 
     # this is the same as PyTorch's check
     if dst._is_zerotensor():
@@ -107,23 +95,47 @@ def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
     if src._is_zerotensor():
         return dst.zero_()
 
-    aliases = torch._C._is_alias_of(dst, src)
-    if aliases and (
-        dst.storage_offset() == src.storage_offset()
-        and dst.stride() == src.stride()
-        and dst.size() == src.size()
-        and dst.dtype == src.dtype
-        and dst.device == src.device
-        and dst.is_conj() == src.is_conj()
-        and dst.is_neg() == src.is_neg()
+    if torch._C._is_alias_of(dst, src):
+        # Align with PyTorch: if metadata fully matches, this is a no-op.
+        if (
+            dst.storage_offset() == src.storage_offset()
+            and dst.stride() == src.stride()
+            and dst.size() == src.size()
+            and dst.dtype == src.dtype
+            and dst.device == src.device
+            and dst.is_conj() == src.is_conj()
+            and dst.is_neg() == src.is_neg()
+        ):
+            return dst
+        # Otherwise defer to PyTorch for well-defined semantics on overlapping writes.
+        return torch.ops.aten.copy_.default.redispatch(
+            _FALLBACK_KEYSET, dst, src, non_blocking
+        )
+
+    if _FLOAT8_E8M0FNU is not None and (
+        src.dtype == _FLOAT8_E8M0FNU or dst.dtype == _FLOAT8_E8M0FNU
     ):
-        return dst
+        return torch.ops.aten.copy_.default.redispatch(
+            _FALLBACK_KEYSET, dst, src, non_blocking
+        )
 
-    if dst.device != src.device:
-        raise NotImplementedError("copy_ across devices is not supported on Kunlunxin")
+    if src.numel() > 2**31 - 1 or dst.numel() > 2**31 - 1:
+        return torch.ops.aten.copy_.default.redispatch(
+            _FALLBACK_KEYSET, dst, src, non_blocking
+        )
 
-    _validate_triton_copy(dst, src)
-    logger.debug("GEMS_KUNLUNXIN COPY_")
+    if not _can_use_triton(dst, src):
+        return torch.ops.aten.copy_.default.redispatch(
+            _FALLBACK_KEYSET, dst, src, non_blocking
+        )
+
+    if dst.numel() == 0:
+        # Respect PyTorch behaviour: empty tensors should still validate broadcast.
+        return torch.ops.aten.copy_.default.redispatch(
+            _FALLBACK_KEYSET, dst, src, non_blocking
+        )
+
+    logger.debug("GEMS COPY_")
 
     try:
         broadcast_shape = torch.broadcast_shapes(dst.shape, src.shape)
@@ -134,35 +146,19 @@ def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
         raise RuntimeError(
             f"The broadcast shape {broadcast_shape} does not match destination shape {tuple(dst.shape)}"
         )
-    if dst.numel() == 0:
-        return dst
 
     expanded_src = _expand_like(src, dst.shape)
-    if _is_e8m0(expanded_src):
-        if _is_e8m0(dst):
-            overload = _copy_kernel.instantiate(expanded_src.ndim)
-            overload(expanded_src.view(torch.uint8), out0=dst.view(torch.uint8))
-            return dst
-        if (
-            dst.dtype is torch.float32
-            and expanded_src.is_contiguous()
-            and dst.is_contiguous()
-        ):
-            block_size = 256
-            _copy_e8m0_to_fp32_kernel[(triton.cdiv(expanded_src.numel(), block_size),)](
-                expanded_src.view(torch.uint8),
-                dst,
-                expanded_src.numel(),
-                BLOCK_SIZE=block_size,
-            )
-            return dst
-        raise NotImplementedError(
-            "copy_ from float8_e8m0fnu only supports float8_e8m0fnu and contiguous float32 destinations on Kunlunxin"
-        )
-    overload = copy_slice.instantiate(expanded_src.ndim)
-    if aliases:
-        snapshot = torch.empty(dst.shape, dtype=src.dtype, device=src.device)
-        overload(expanded_src, out0=snapshot)
-        expanded_src = snapshot
+
+    # tle takes the whole move when it can: a TMA tile for contiguous same-dtype
+    # copies, and an SDNN 2D row transfer for strided or broadcast layouts, with
+    # the dtype cast folded in.
+    if tle_copy(expanded_src, dst):
+        return dst
+
+    # What tle cannot represent goes to the pointwise kernel, which addresses the
+    # destination element by element and so has none of tle's layout and dtype
+    # restrictions. It takes the *expanded* src: a stride-0 view is how the
+    # broadcast reaches the kernel.
+    overload = _copy_kernel.instantiate(expanded_src.ndim)
     overload(expanded_src, out0=dst)
     return dst

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/permute_copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/permute_copy.py
@@ -2,158 +2,49 @@ import logging
 
 import torch
 import triton
-import triton.language as tl
+from _kunlunxin.utils.codegen_config_utils import CodeGenConfig
+
+from ..utils.pointwise_dynamic import pointwise_dynamic
+from ..utils.tle_copy import tle_copy
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
+# permute_copy materializes a permuted (strided) view into a fresh contiguous
+# tensor. The generic KernelGen kernels (src/flag_gems/ops/permute_copy.py) take
+# src_ptr/dst_ptr/n_elements/shapes/strides/perm as ordinary @triton.jit args, so
+# Triton specializes each launch on pointer divisibility (=16) and scalar-int
+# divisibility. permute_copy allocates a FRESH `out` every call and the XPU
+# caching allocator hands back pointers/blocks whose specialization class varies
+# across allocations -> each new class triggers a fresh ~150-3700ms XPU compile.
+# In a repeated-call / benchmark workload this is a recompilation STORM: the 2D
+# shapes measure 6-113ms per call (0.0001-0.02x torch, randomly scattered across
+# dtype cells) even though their true kernel is ~0.05-0.2ms.
+#
+# Fix: express the copy through the tuned pointwise_dynamic path exactly like the
+# view_copy sibling. We read the permuted VIEW `x.permute(dims)` (a strided,
+# zero-copy view whose shape == out_shape) and write the contiguous `out`;
+# pointwise_dynamic auto-generates the strided-input offset math. Crucially the
+# CodeGenConfig has kunlunAutoGrid=True + prefer_1d_tile, so ONE shape/pointer-
+# independent kernel compiles and is cached (via libentry) -> the storm is gone
+# and every shape/dtype is consistent (2D ~0.08ms, no lottery). Vectorization
+# stays OPEN (isCloseVectorization=False) for the memory-bound copy, matching
+# view_copy/addcmul. Pure identity kernel -> byte-identical output, zero accuracy
+# change.
+config_ = CodeGenConfig(
+    512,
+    (65536, 65536, 65536),
+    32,
+    True,
+    prefer_1d_tile=True,
+    buffer_size_limit=4096,
+    kunlunAutoGrid=True,
+)
 
+
+@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")], config=config_)
 @triton.jit
-def _pc_flat_copy_kernel(
-    src_ptr, dst_ptr, n_words, BLOCK: tl.constexpr, NEED_MASK: tl.constexpr
-):
-    pid = tl.program_id(0)
-    off = pid * BLOCK + tl.arange(0, BLOCK)
-    if NEED_MASK:
-        m = off < n_words
-        v = tl.load(src_ptr + off, mask=m)
-        tl.store(dst_ptr + off, v, mask=m)
-    else:
-        v = tl.load(src_ptr + off)
-        tl.store(dst_ptr + off, v)
-
-
-@triton.jit
-def _pc_gather_kernel(
-    in_ptr,
-    out_ptr,
-    R,
-    C,
-    N: tl.constexpr,
-    A: tl.constexpr,
-    B: tl.constexpr,
-    ST0: tl.constexpr,
-    ST1: tl.constexpr,
-    ST2: tl.constexpr,
-    ST3: tl.constexpr,
-    ROW_BLOCK: tl.constexpr,
-    COL_BLOCK: tl.constexpr,
-    NEED_MASK: tl.constexpr,
-):
-    pid_r = tl.program_id(0)
-    pid_c = tl.program_id(1)
-    rows = pid_r * ROW_BLOCK + tl.arange(0, ROW_BLOCK)
-    cols = pid_c * COL_BLOCK + tl.arange(0, COL_BLOCK)
-    r = rows
-    if N == 1:
-        off = tl.zeros([ROW_BLOCK], dtype=tl.int32)
-        col_off = cols * ST0
-    elif N == 2:
-        off = r * ST0
-        col_off = cols * ST1
-    elif N == 3:
-        d0 = r // A
-        d1 = r % A
-        off = d0 * ST0 + d1 * ST1
-        col_off = cols * ST2
-    else:
-        d0 = r // (A * B)
-        d1 = (r // B) % A
-        d2 = r % B
-        off = d0 * ST0 + d1 * ST1 + d2 * ST2
-        col_off = cols * ST3
-    m = (rows < R)[:, None] & (cols < C)[None, :]
-    if NEED_MASK:
-        v = tl.load(in_ptr + off[:, None] + col_off[None, :], mask=m, other=0.0)
-        tl.store(out_ptr + rows[:, None] * C + cols[None, :], v, mask=m)
-    else:
-        v = tl.load(in_ptr + off[:, None] + col_off[None, :])
-        tl.store(out_ptr + rows[:, None] * C + cols[None, :], v)
-
-
-def _pc_flat_copy(view, out, n, elemsz):
-    """Byte-wise flat copy with 4-byte word coalescing when alignment allows."""
-    src = view.reshape(-1)
-    if n == 0:
-        return
-    if elemsz in (2, 4):
-        # move as many 4-byte words as possible; keep sources contiguous
-        words = (n * elemsz) // 4
-        head_el = words * (4 // elemsz)
-        if words > 0:
-            src4 = src[:head_el].contiguous().view(torch.int32)
-            dst4 = out.reshape(-1)[:head_el].view(torch.int32)
-            BLOCK = 8192 if words <= 1048576 else 32768
-            _pc_flat_copy_kernel[(triton.cdiv(words, BLOCK),)](
-                src4, dst4, words, BLOCK, words % BLOCK != 0
-            )
-        tail_el = n - head_el
-        if tail_el > 0:
-            out_flat = out.reshape(-1)
-            _pc_flat_copy_kernel[(1,)](
-                src[-tail_el:], out_flat[-tail_el:], tail_el, 512, True
-            )
-    elif elemsz == 1:
-        BLOCK = 8192 if n <= 1048576 else 32768
-        _pc_flat_copy_kernel[(triton.cdiv(n, BLOCK),)](
-            src, out, n, BLOCK, n % BLOCK != 0
-        )
-    else:  # 8-byte elements: direct 8-byte copy
-        BLOCK = 2048 if n <= 262144 else 8192
-        _pc_flat_copy_kernel[(triton.cdiv(n, BLOCK),)](
-            src, out, n, BLOCK, n % BLOCK != 0
-        )
-
-
-def _pc_gather(view, x, out, n):
-    N = view.dim()
-    C = view.shape[-1]
-    R = n // C
-    sz = list(view.shape) + [1] * (4 - N)
-    st = list(view.stride()) + [1] * (4 - N)
-    RB, CB = 4, 128
-    NEED_MASK = (R % RB != 0) or (C % CB != 0)
-    grid = (triton.cdiv(R, RB), triton.cdiv(C, CB))
-    _pc_gather_kernel[grid](
-        x, out, R, C, N, sz[1], sz[2], st[0], st[1], st[2], st[3], RB, CB, NEED_MASK
-    )
-
-
-@triton.jit
-def _pc_rowtable_kernel(
-    in_ptr,
-    out_ptr,
-    row_ptr,
-    R,
-    C,
-    COL_STRIDE,
-    ROW_BLOCK: tl.constexpr,
-    COL_BLOCK: tl.constexpr,
-):
-    pid_r = tl.program_id(0)
-    pid_c = tl.program_id(1)
-    rows = pid_r * ROW_BLOCK + tl.arange(0, ROW_BLOCK)
-    cols = pid_c * COL_BLOCK + tl.arange(0, COL_BLOCK)
-    rb = tl.load(row_ptr + rows)
-    m = (rows < R)[:, None] & (cols < C)[None, :]
-    addr = rb[:, None] + cols[None, :] * COL_STRIDE
-    v = tl.load(in_ptr + addr, mask=m)
-    tl.store(out_ptr + rows[:, None] * C + cols[None, :], v, mask=m)
-
-
-def _pc_row_gather(view, x, out, n):
-    """Rank > 4 fallback: per-row input base table + linear column stride."""
-    C = view.shape[-1]
-    R = n // C
-    # row base = in-offset of element (row, 0). Decode on host with torch.
-    coords = torch.meshgrid(
-        *[torch.arange(s, dtype=torch.int32, device=x.device) for s in view.shape[:-1]],
-        indexing="ij",
-    )
-    row_base = sum(c.reshape(-1) * s for c, s in zip(coords, view.stride()[:-1]))
-    row_base = row_base.contiguous()
-    RB, CB = 16, 64
-    grid = (triton.cdiv(R, RB), triton.cdiv(C, CB))
-    _pc_rowtable_kernel[grid](x, out, row_base, R, C, view.stride()[-1], RB, CB)
+def _permute_copy_pw(src):
+    return src
 
 
 def permute_copy(x: torch.Tensor, dims):
@@ -172,19 +63,14 @@ def permute_copy(x: torch.Tensor, dims):
     src = x.contiguous() if not x.is_contiguous() else x
     out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
 
-    view = src.permute(dims)
-    n = view.numel()
-    if view.is_contiguous():
-        # identity-style permutation: the permuted view is already contiguous,
-        # so this is a pure flat copy. Move 4-byte words to keep the memory
-        # bound copy at full bandwidth.
-        _pc_flat_copy(view, out, n, src.element_size())
-    elif view.dim() <= 4:
-        # strided permutation: decode each output row's input offset with
-        # constexpr dims (no per-element div/mod) and gather COL_BLOCK-wide
-        # tiles. Chosen on XPU (probe sweep: 4x128/w1 fastest & correct).
-        _pc_gather(view, src, out, n)
-    else:
-        # rank > 4: per-row table fallback (correct for any permutation).
-        _pc_row_gather(view, src, out, n)
+    # x.permute(dims) is a strided zero-copy view with shape == out_shape.
+    permuted = src.permute(dims)
+    # tle takes it as a TMA tile when the permutation keeps the innermost axis
+    # contiguous, and otherwise transposes a 64x64 tile on chip -- the shape
+    # XDNN's transpose_021_sdnn_bsp uses. Measured on KL3 for f16 transposes, the
+    # pointwise kernel is never the cheaper option here: 124us vs 83us at 8KB,
+    # 2.1ms vs 90us at 2MB, 32ms vs 207us at 32MB.
+    if tle_copy(permuted, out):
+        return out
+    _permute_copy_pw(permuted, out0=out)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/unfold_copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/unfold_copy.py
@@ -1,4 +1,4 @@
-# Copyright 2026, The FlagOS Contributors.
+# Copyright 2026 FlagOS Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,98 +11,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Kunlunxin unfold_copy override.
-
-unfold_copy(input, dimension, size, step) is the copy variant of
-`input.unfold(dimension, size, step)`: it materializes the sliding-window
-view into a fresh contiguous tensor. The view is exactly an as_strided view
-(listed-window semantics), so we build the view with the same stride math as
-Torch's `unfold` and then copy it into a contiguous output using the vendor
-as_strided_copy machinery (block-DMA fast paths + generic strided Triton
-kernels). This keeps correctness for arbitrary ndim / negative dim /
-non-contiguous inputs / odd size-step combinations, which the generic
-flag_gems implementation does not support (it only handles 2D-dim1 / 3D-dim1
-/ 3D-dim2 contiguous inputs and silently mis-indexes non-contiguous ones).
-"""
 
 import logging
 
 import torch
 
-from flag_gems.runtime.backend._kunlunxin.ops.as_strided_copy import (
-    _can_use_byte_triton,
-    _can_use_triton,
-    _launch_as_strided_copy,
-    _launch_byte_as_strided_copy,
-    _try_fast_copy,
-)
+from ..utils.tle_copy import tle_copy
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
-def _make_unfold_view(input, dimension, size, step):
-    """Build the unfold view with Torch-compatible semantics/errors."""
-    ndim = input.ndim
-    if ndim == 0:
-        dim_size = 1
-        dimension = 0
-    else:
-        orig_dim = dimension
-        if dimension < 0:
-            dimension += ndim
-        if dimension < 0 or dimension >= ndim:
-            raise IndexError(
-                f"Dimension out of range (expected to be in range of "
-                f"[{-ndim}, {ndim - 1}], but got {orig_dim})"
-            )
-        dim_size = input.shape[dimension]
+def unfold_copy(input: torch.Tensor, dimension: int, size: int, step: int):
+    """aten::unfold_copy: materialize the sliding-window view of `input`.
 
-    if size > dim_size:
-        raise RuntimeError(
-            f"maximum size for tensor at dimension {dimension} is {dim_size} "
-            f"but size is {size}"
-        )
+    `input.unfold(...)` is exactly the layout unfold_copy has to produce, so the
+    operator is just a copy of that strided view: a TMA tile when the view
+    collapses to at most 2D (1D input, or `input.shape[d] == L * step`), and an
+    SDNN row transfer otherwise -- the windows are rows of `size` contiguous
+    elements, `step` apart. Overlapping windows are fine either way, the shared
+    elements are simply read more than once.
 
-    n_windows = (dim_size - size) // step + 1
-
-    if ndim == 0:
-        new_shape = [n_windows, size]
-        new_strides = [step, 1]
-    else:
-        new_shape = list(input.shape)
-        new_shape[dimension] = n_windows
-        new_shape.append(size)
-        old_strides = list(input.stride())
-        dim_stride = old_strides[dimension]
-        new_strides = list(old_strides)
-        new_strides[dimension] = step * dim_stride
-        new_strides.append(dim_stride)
-
-    return input.as_strided(new_shape, new_strides, input.storage_offset())
-
-
-def unfold_copy(input, dimension, size, step):
+    The fallback here is a last resort rather than a faster equivalent: the
+    generic kernel gets overlapping windows wrong (`(4, 8)` unfolded by
+    `size=3, step=1` misses 12 of 72 elements).
+    """
     logger.debug("GEMS_KUNLUNXIN UNFOLD_COPY")
+
     if step <= 0:
-        raise RuntimeError(f"step is {step} but must be > 0")
+        raise ValueError("step must be > 0")
 
-    view = _make_unfold_view(input, dimension, int(size), int(step))
+    if input.ndim > 0:
+        d = dimension % input.ndim
+        if size <= input.shape[d]:
+            view = input.unfold(d, size, step)
+            if view.numel() > 0:
+                out = torch.empty(view.shape, dtype=input.dtype, device=input.device)
+                if tle_copy(view, out):
+                    return out
 
-    out_shape = tuple(view.shape)
-    contiguous_stride = torch.empty(out_shape, device="meta").stride()
-    out = torch.empty_strided(
-        out_shape, contiguous_stride, dtype=input.dtype, device=input.device
-    )
+    from flag_gems.ops.unfold_copy import unfold_copy as generic_unfold_copy
 
-    if view.numel() == 0:
-        return out
-
-    if _try_fast_copy(view, out):
-        return out
-    if _can_use_triton(view, out):
-        return _launch_as_strided_copy(view, out)
-    if _can_use_byte_triton(view, out):
-        return _launch_byte_as_strided_copy(view, out)
-    raise NotImplementedError(
-        "Kunlunxin unfold_copy does not support this stride layout."
-    )
+    return generic_unfold_copy(input, dimension, size, step)

--- a/src/flag_gems/runtime/backend/_kunlunxin/utils/codegen_config_utils.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/utils/codegen_config_utils.py
@@ -54,7 +54,6 @@ class CodeGenConfig:
     prefer_1d_tile: bool
     # gen_configs: -> configs
     # prune_config: (as jit function, ) cofigs -> configs
-    is_scatter_slice: bool = False
     is_cat: bool = False
     isCloseVectorization: bool = False
     isCloseDtypeConvert: bool = False

--- a/src/flag_gems/runtime/backend/_kunlunxin/utils/pointwise_dynamic.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/utils/pointwise_dynamic.py
@@ -1030,10 +1030,7 @@ class WrapperGenerator:
                         code.writeline(f"tile_size{i}=tile_sizes[{i}],")
                     code.writeline("one_tile_per_cta=one_tile_per_cta,")
                 code.writeline("num_warps=num_warps,")
-                if self.config.is_scatter_slice:
-                    code.writeline("buffer_size_limit=512,")
-                    code.writeline("isCloseOffsetAnalysis=True,")
-                elif self.config.is_cat:
+                if self.config.is_cat:
                     code.writeline("buffer_size_limit=512,")
                 elif self.config.buffer_size_limit:
                     code.writeline(
@@ -1099,10 +1096,7 @@ class WrapperGenerator:
                     code.writeline("tile_size=tile_size,")
                     code.writeline("one_tile_per_cta=one_tile_per_cta,")
                 code.writeline("num_warps=num_warps,")
-                if self.config.is_scatter_slice:
-                    code.writeline("buffer_size_limit=512,")
-                    code.writeline("isCloseOffsetAnalysis=True,")
-                elif self.config.is_cat:
+                if self.config.is_cat:
                     code.writeline("buffer_size_limit=512,")
                 elif self.config.buffer_size_limit:
                     code.writeline(

--- a/src/flag_gems/runtime/backend/_kunlunxin/utils/tle_copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/utils/tle_copy.py
@@ -1,0 +1,624 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tle implementation of the pure-copy operators.
+
+Two kernels cover the copies tle can express:
+
+* `_tle_tile_copy_kernel` -- both sides contiguous, same dtype: one flat TMA
+  tile GM -> LM -> GM on the `tle.gpu` cluster path. This is the throughput path
+  (1.5-1.7x the pointwise kernel up to ~16M elements on KL3, level with
+  `aten::copy_` above that), and with `_tile_launch` reusing the compiled kernel
+  it is also what small copies ride on, where the host side of a launch is the
+  whole cost.
+* `_tle_dsa_row_copy_kernel` -- everything else, on the `tle.dsa` SDNN path. It
+  moves rows of a contiguous run through a uni_sram buffer, with independent
+  src/dst row strides: the shape the DMA engine actually has, and the same one
+  the hand-written `memcpy_2d_sdnn.xpu` uses (`dma_cfg_2d(loop, dst_stride,
+  src_stride)`). Broadcast rows (src row stride 0) and overlapping reads come
+  for free, and `CONVERT` casts on the tensor side between the two transfers, so
+  a dtype-changing `copy_` stays on the same kernel. It replaced a `tle.gpu`
+  element-wise gather, which moved the same bytes ~200x slower than the fallback
+  did (4096x4096 f32 strided window: 32.8ms, against 157us for `aten::copy_` and
+  114us here).
+
+Anything outside that envelope makes `tle_copy` return False and the caller
+keeps its own fallback. Measured on KL3, the dsa path is out when:
+
+* the copy needs a dtype `tle.dsa` cannot handle. A pure move goes as a 1-, 2- or
+  4-byte bit pattern (`_DSA_MOVE_DTYPE`), with an 8-byte element split into two
+  4-byte ones, which needs `stride(-1) == 1`; a converting copy needs the real
+  element types on both sides (`_DSA_BUF_DTYPE` / `_DSA_VAL_DTYPE`) and cannot
+  widen an integer into a float, which the SDNN cast turns into zeros
+* the innermost dimension is not unit-stride on *both* sides. A stride inside
+  the row would need a third DMA level; asking for it moves the wrong elements
+  without any diagnostic. A real transpose lands here, as does a destination
+  like `y[::2]`
+* the layout still needs more than `MAX_COPY_RANK` dimensions after collapsing
+"""
+
+import logging
+import math
+import os
+
+import torch
+import triton
+import triton.language as tl
+from triton.runtime import driver
+
+logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
+
+try:
+    # `.language` carries both surfaces: `tle.gpu` for the cluster/LM path and
+    # `tle.dsa` for the SDNN one.
+    import triton.experimental.tle.language as tle
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    _HAS_TLE = True
+except ImportError:  # triton without the XPU tile-language extension
+    _HAS_TLE = False
+
+# tritonxpu-tle-core-tiling hands each of the 64 cores whole rows of the tile.
+CORE_NUM = 64
+# LM per core for the tile path. triton/docs/xpu3/tle_user_guide.md quotes ~2KB
+# as the budget and test/tle/test_tle_copy_1d.py sizes its block that way, but
+# 4KB still compiles and is measurably better on large tensors (fp16 2**28:
+# 630us -> 577us, i.e. level with aten::copy_); 8KB fails to allocate.
+LM_BYTES_PER_CORE = 4096
+# uni_sram per program on the dsa path, and the bytes per row inside that tile.
+# The row is what one DMA descriptor moves, so it wants to be a few KB; the tile
+# is the on-chip buffer, which the multi-buffer allocator replicates.
+DSA_TILE_BYTES = 32768
+DSA_ROW_BYTES = 4096
+# Square tile for the on-chip transpose. 64x64 was the only size that worked:
+# 128x128 and 32x256 both land around 120-140ms for a 2048x2048 f16 transpose
+# against 66us at 64x64.
+DSA_TRANS_TILE = 64
+# Dimensions the copy addresses: two in the tile, the rest in the grid.
+MAX_COPY_RANK = 5
+
+# dtypes verified on KL3. torch.bool is absent on purpose: i1 is packed in LM and
+# comes back corrupted, so bool tensors move through an int8 view (_byte_view).
+_TL_DTYPE = {
+    torch.float32: tl.float32,
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+    torch.int8: tl.int8,
+    torch.int16: tl.int16,
+    torch.int32: tl.int32,
+    torch.int64: tl.int64,
+}
+
+# What the SDNN DMA moves. A pure move only cares about the width, and the
+# widths that work are 1, 2 and 4 bytes -- with the 4-byte transfer spelled f32,
+# because int32 compiles and then faults with an illegal access and int64 is
+# rejected as "Unsupported dma dst data type". Both do so for a plain
+# `tl.load`/`tl.store` kernel launched with `is_sdnn=True`, so they are backend
+# gaps rather than something this kernel could spell differently; viewing the
+# bits as f32 sidesteps them, since a copy never does arithmetic on the value.
+_DSA_MOVE_DTYPE = {1: torch.int8, 2: torch.int16, 4: torch.float32}
+
+# A converting copy does look at the element type: the buffer holds real `SRC`
+# values and the cast produces real `DST` ones. bf16 is missing from the buffer
+# side because a bf16 uni_sram buffer fails to build ("element types do not
+# match" on `bufferization.to_tensor`); as a cast *target* it is fine, since that
+# is a store rather than a buffer.
+_DSA_BUF_DTYPE = {
+    torch.float32: tl.float32,
+    torch.float16: tl.float16,
+    torch.int8: tl.int8,
+    torch.int16: tl.int16,
+}
+_DSA_VAL_DTYPE = {
+    torch.float32: tl.float32,
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+    torch.int8: tl.int8,
+    torch.int16: tl.int16,
+}
+
+
+@triton.jit
+def _tle_tile_copy_kernel(src_desc, dst_desc, BLOCK: tl.constexpr, DTYPE: tl.constexpr):
+    """Flat TMA tile: the descriptor lowering clamps the tail block itself."""
+    pid = tl.program_id(0)
+    buf = tle.gpu.alloc([BLOCK], dtype=DTYPE, layout=None, scope=tle.gpu.lmem)
+    tle.gpu.copy(src_desc, buf, [BLOCK], [pid * BLOCK])
+    tle.gpu.copy(buf, dst_desc, [BLOCK], [pid * BLOCK])
+
+
+@triton.jit(
+    # None of these change the code, only the data it moves, so specializing on
+    # them buys nothing and costs a kernel per class. That matters because the
+    # callers allocate a fresh `out` per call and the XPU allocator hands back
+    # pointers from varying divisibility classes: with specialization on, a
+    # repeated call keeps reloading a kernel. Measured over one sweep of six
+    # strided copies, 482s of wall clock against 12s, and the two worst shapes
+    # went from 14.7ms and 25.0ms per call to 334us and 199us.
+    do_not_specialize=[
+        "src_ptr",
+        "dst_ptr",
+        "rows",
+        "cols",
+        "s_row",
+        "t_row",
+        "s_col",
+        "row_blocks",
+        "d2",
+        "d3",
+        "d4",
+        "s2",
+        "s3",
+        "s4",
+        "t2",
+        "t3",
+        "t4",
+    ]
+)
+def _tle_dsa_row_copy_kernel(
+    src_ptr,
+    dst_ptr,
+    rows,
+    cols,
+    s_row,
+    t_row,
+    s_col,
+    row_blocks,
+    d2,
+    d3,
+    d4,
+    s2,
+    s3,
+    s4,
+    t2,
+    t3,
+    t4,
+    OUTER_RANK: tl.constexpr,
+    ROWS: tl.constexpr,
+    COLS: tl.constexpr,
+    COL_STRIDED: tl.constexpr,
+    SRC_DTYPE: tl.constexpr,
+    DST_DTYPE: tl.constexpr,
+    CONVERT: tl.constexpr,
+    TO_BOOL: tl.constexpr,
+):
+    """Rows of a run through a uni_sram buffer.
+
+    `cols` is the innermost dimension and `rows` the next one out, with
+    `s_row` / `t_row` its src and dst strides -- one 2D DMA in and one out, which
+    is what the engine does natively. Everything further out (`d2..d4` with
+    strides `s2..s4` / `t2..t4`) is a scalar base offset picked from the program
+    id, so it costs nothing in the transfer.
+
+    The destination run is always contiguous. The source one is too unless
+    COL_STRIDED, which reads it with `s_col` -- that is a per-element transfer,
+    so the caller pairs it with `ROWS == 1`: a 2D tile whose rows also carry a
+    column stride needs a third DMA level and moves the wrong elements instead.
+
+    Tails use `sizes` rather than a mask: a masked load hides its extent in a
+    view of the staging buffer that the dsa rewrite drops, and the compiler
+    rejects that. On the way out the same `sizes` becomes the store mask.
+
+    With CONVERT the value is cast on the tensor side between the two transfers,
+    which is how a dtype-changing `copy_` is served; TO_BOOL reproduces
+    PyTorch's "nonzero becomes True" rule.
+    """
+    pid = tl.program_id(0)
+    row0 = (pid % row_blocks) * ROWS
+    outer = pid // row_blocks
+    col0 = tl.program_id(1) * COLS
+
+    src_base = 0
+    dst_base = 0
+    if OUTER_RANK > 0:
+        i = outer % d2
+        outer = outer // d2
+        src_base += i * s2
+        dst_base += i * t2
+    if OUTER_RANK > 1:
+        i = outer % d3
+        outer = outer // d3
+        src_base += i * s3
+        dst_base += i * t3
+    if OUTER_RANK > 2:
+        i = outer % d4
+        src_base += i * s4
+        dst_base += i * t4
+
+    r = row0 + tl.arange(0, ROWS)
+    c = col0 + tl.arange(0, COLS)
+    row_tail = tl.minimum(rows - row0, ROWS)
+    col_tail = tl.minimum(cols - col0, COLS)
+
+    buf = tle.dsa.alloc([ROWS, COLS], SRC_DTYPE, tle.dsa.UNI_SRAM)
+    if COL_STRIDED:
+        src = src_ptr + src_base + r[:, None] * s_row + c[None, :] * s_col
+    else:
+        src = src_ptr + src_base + r[:, None] * s_row + c[None, :]
+    tle.dsa.copy(src, buf, sizes=[row_tail, col_tail])
+
+    dst = dst_ptr + dst_base + r[:, None] * t_row + c[None, :]
+    if CONVERT:
+        val = tle.dsa.to_tensor(buf)
+        if TO_BOOL:
+            val = (val != 0).to(DST_DTYPE)
+        else:
+            val = val.to(DST_DTYPE)
+        tle.dsa.copy(val, dst, sizes=[row_tail, col_tail])
+    else:
+        tle.dsa.copy(buf, dst, sizes=[row_tail, col_tail])
+
+
+@triton.jit(
+    do_not_specialize=[
+        "src_ptr",
+        "dst_ptr",
+        "rows",
+        "cols",
+        "s_col",
+        "t_row",
+        "col_blocks",
+        "d2",
+        "d3",
+        "d4",
+        "s2",
+        "s3",
+        "s4",
+        "t2",
+        "t3",
+        "t4",
+    ]
+)
+def _tle_dsa_trans_copy_kernel(
+    src_ptr,
+    dst_ptr,
+    rows,
+    cols,
+    s_col,
+    t_row,
+    col_blocks,
+    d2,
+    d3,
+    d4,
+    s2,
+    s3,
+    s4,
+    t2,
+    t3,
+    t4,
+    OUTER_RANK: tl.constexpr,
+    TILE: tl.constexpr,
+    SRC_DTYPE: tl.constexpr,
+    DST_DTYPE: tl.constexpr,
+    CONVERT: tl.constexpr,
+    TO_BOOL: tl.constexpr,
+):
+    """A square tile transposed on chip, for layouts whose two sides disagree.
+
+    When the destination's contiguous run is the source's strided one and vice
+    versa -- a transpose, or `unfold` along an inner axis -- neither side can be
+    read and written as the same run. Reading one of them per element is what the
+    row kernel would do, and it is an order of magnitude off: `transpose_021_sdnn_bsp`
+    in the XDNN kernel library never does that. It moves a tile in with a 2D DMA
+    (contiguous rows, row stride only), transposes it on chip with the DS
+    shuffle, and writes it out with another 2D DMA. This is that, with `tl.trans`
+    standing in for `ds_shuffle_coa_1d`.
+
+    So `rows` is the extent the source is contiguous along, `cols` the extent the
+    destination is, and both DMAs stay contiguous inside a row. TILE is square
+    because the transposed tile has to fit the same buffer.
+    """
+    pid = tl.program_id(0)
+    col0 = (pid % col_blocks) * TILE
+    outer = pid // col_blocks
+    row0 = tl.program_id(1) * TILE
+
+    src_base = 0
+    dst_base = 0
+    if OUTER_RANK > 0:
+        i = outer % d2
+        outer = outer // d2
+        src_base += i * s2
+        dst_base += i * t2
+    if OUTER_RANK > 1:
+        i = outer % d3
+        outer = outer // d3
+        src_base += i * s3
+        dst_base += i * t3
+    if OUTER_RANK > 2:
+        i = outer % d4
+        src_base += i * s4
+        dst_base += i * t4
+
+    c = col0 + tl.arange(0, TILE)
+    r = row0 + tl.arange(0, TILE)
+    col_tail = tl.minimum(cols - col0, TILE)
+    row_tail = tl.minimum(rows - row0, TILE)
+
+    buf = tle.dsa.alloc([TILE, TILE], SRC_DTYPE, tle.dsa.UNI_SRAM)
+    src = src_ptr + src_base + c[:, None] * s_col + r[None, :]
+    tle.dsa.copy(src, buf, sizes=[col_tail, row_tail])
+
+    val = tl.trans(tle.dsa.to_tensor(buf))
+    if CONVERT:
+        if TO_BOOL:
+            val = (val != 0).to(DST_DTYPE)
+        else:
+            val = val.to(DST_DTYPE)
+    dst = dst_ptr + dst_base + r[:, None] * t_row + c[None, :]
+    tle.dsa.copy(val, dst, sizes=[row_tail, col_tail])
+
+
+def tle_dma_available():
+    """tle.gpu exists only on the xpu3 (KL3) cluster pipeline."""
+    if not _HAS_TLE:
+        return False
+    if os.environ.get("TRITON_ENABLE_XCN_BACKEND"):
+        return False
+    return os.environ.get("TRITON_XPU_ARCH", "3") == "3"
+
+
+def _byte_view(t: torch.Tensor) -> torch.Tensor:
+    """bool has no LM representation (i1 is packed), so move it as int8."""
+    return t.view(torch.int8) if t.dtype == torch.bool else t
+
+
+def _collapse(shape, src_stride, dst_stride):
+    """Fold the copy into as few dimensions as the two stride sets allow.
+
+    Returns (dims, src_strides, dst_strides) innermost-first and padded to
+    MAX_COPY_RANK, plus the real rank; None if it does not fit.
+    """
+    dims = [
+        (int(n), int(ss), int(ds))
+        for n, ss, ds in zip(shape, src_stride, dst_stride)
+        if n != 1
+    ]
+    if not dims:
+        dims = [(1, 0, 0)]
+    # Innermost = fastest varying in the destination, so the scatter stays as
+    # close to sequential as the layout allows.
+    dims.sort(key=lambda dim: abs(dim[2]))
+    merged = []
+    for n, ss, ds in dims:
+        if merged:
+            pn, pss, pds = merged[-1]
+            if ss == pss * pn and ds == pds * pn:
+                merged[-1] = (pn * n, pss, pds)
+                continue
+        merged.append((n, ss, ds))
+    rank = len(merged)
+    if rank > MAX_COPY_RANK:
+        return None
+    pad = [(1, 0, 0)] * (MAX_COPY_RANK - rank)
+    merged += pad
+    return (
+        [m[0] for m in merged],
+        [m[1] for m in merged],
+        [m[2] for m in merged],
+        rank,
+    )
+
+
+def _tile_launch(src: torch.Tensor, dst: torch.Tensor, numel: int, dtype, block: int):
+    """Launch the tile kernel, going through `JITFunction.run` only once.
+
+    A small copy is host-bound: a 16KB move takes ~8us on device while `fn[grid]`
+    spends ~20us re-deriving what cannot change once the kernel is compiled. The
+    first call binds the kernel with the driver's launcher cache, later ones hand it
+    the kernel ABI directly: each descriptor already split into base pointer,
+    `.shape` (i32) and `.strides` (i64).
+
+    The kernel's only shape-dependent argument is that `.shape`, passed at launch,
+    so one binding serves every size that shares a grid -- and every copy below
+    64K-256K elements (dtype-dependent) has `grid == 1`.
+    """
+    grid = triton.cdiv(numel, block)
+    launchers = getattr(driver.active, "flat_launchers", None)
+    if launchers is None:
+        # triton without the launcher cache: correct, just slower every call.
+        _tle_tile_copy_kernel[(grid,)](
+            TensorDescriptor.from_tensor(src.view(-1), [block]),
+            TensorDescriptor.from_tensor(dst.view(-1), [block]),
+            block,
+            _TL_DTYPE[dtype],
+        )
+        return
+
+    key = (dtype, grid)
+    launch, stream = launchers.acquire(_tle_tile_copy_kernel, key)
+    if launch is None:
+        kernel = _tle_tile_copy_kernel[(grid,)](
+            TensorDescriptor.from_tensor(src.view(-1), [block]),
+            TensorDescriptor.from_tensor(dst.view(-1), [block]),
+            block,
+            _TL_DTYPE[dtype],
+        )
+        launchers.bind(_tle_tile_copy_kernel, key, kernel, (grid,))
+        return
+
+    launch(stream, src.data_ptr(), numel, 1, dst.data_ptr(), numel, 1)
+
+
+def _dsa_tile(rows: int, cols: int, element_size: int):
+    """(ROWS, COLS) for the on-chip tile: full rows first, then as many as fit."""
+    cols_block = min(
+        triton.next_power_of_2(cols), max(DSA_ROW_BYTES // element_size, 1)
+    )
+    rows_block = min(
+        triton.next_power_of_2(rows),
+        max(DSA_TILE_BYTES // (cols_block * element_size), 1),
+    )
+    return rows_block, cols_block
+
+
+def tle_copy(src: torch.Tensor, dst: torch.Tensor) -> bool:
+    """Copy `src` into `dst` with tle; False if tle cannot express it."""
+    if not tle_dma_available():
+        return False
+    if src.device != dst.device or src.numel() != dst.numel() or src.numel() == 0:
+        return False
+
+    src_v, dst_v = _byte_view(src), _byte_view(dst)
+    numel = src.numel()
+    convert = src.dtype != dst.dtype
+
+    if not convert and src_v.is_contiguous() and dst_v.is_contiguous():
+        tile_ty = _TL_DTYPE.get(src_v.dtype)
+        if tile_ty is None:
+            return False
+        block = LM_BYTES_PER_CORE // src_v.element_size() * CORE_NUM
+        _tile_launch(src_v, dst_v, numel, src_v.dtype, block)
+        return True
+
+    if convert:
+        src_ty = _DSA_BUF_DTYPE.get(src_v.dtype)
+        dst_ty = _DSA_VAL_DTYPE.get(dst_v.dtype)
+        if src_ty is None or dst_ty is None:
+            return False
+        # int -> float comes back all zeros, and does so for a plain
+        # `tl.load(...).to(tl.float32)` under `is_sdnn=True` as well, so it is the
+        # SDNN cast rather than this kernel. float -> int and int -> int are fine.
+        if not src_v.dtype.is_floating_point and dst_v.dtype.is_floating_point:
+            return False
+    else:
+        # Same dtype on both sides, so the transfer is just bits: move them as
+        # whatever width the DMA has.
+        move = _DSA_MOVE_DTYPE.get(src_v.element_size())
+        if move is None:
+            # 8 bytes has no transfer width, so move each element as two 4-byte
+            # ones. `view` does exactly that -- doubling the last extent and
+            # every stride -- and refuses unless `stride(-1) == 1`, which is the
+            # same run the row path needs contiguous anyway.
+            try:
+                src_v = src_v.view(torch.float32)
+                dst_v = dst_v.view(torch.float32)
+            except RuntimeError:
+                return False
+            move = torch.float32
+        src_v = src_v if src_v.dtype == move else src_v.view(move)
+        dst_v = dst_v if dst_v.dtype == move else dst_v.view(move)
+        src_ty = dst_ty = _DSA_BUF_DTYPE[move]
+
+    if src_v.shape != dst_v.shape:
+        return False
+    collapsed = _collapse(src_v.shape, src_v.stride(), dst_v.stride())
+    if collapsed is None:
+        return False
+    dims, src_strides, dst_strides, rank = collapsed
+
+    cols = dims[0]
+    s_col = src_strides[0]
+    # The destination run is what the DMA writes back to back, so it has to be
+    # contiguous; there is no level left for a stride on that side and the
+    # transfer would go out packed without a diagnostic. An extent of 1 never
+    # indexes the stride at all.
+    if cols > 1 and dst_strides[0] != 1:
+        return False
+    # A strided source run is read per element, which the engine does do -- but
+    # only on its own: combining it with a row stride would need that missing
+    # third level, so the tile keeps a single row and the rows ride the grid.
+    # Stride 0 is not one of the strides it does: an innermost run broadcast from
+    # a single element comes back as consecutive elements instead, so that layout
+    # stays with the caller.
+    if cols > 1 and s_col == 0:
+        return False
+    rows, s_row, t_row = (
+        (dims[1], src_strides[1], dst_strides[1]) if rank > 1 else (1, 0, 0)
+    )
+    outer_rank = max(rank - 2, 0)
+    outer_numel = math.prod(dims[2:])
+
+    # The two sides disagree about which run is contiguous: transpose the tile on
+    # chip rather than reading one side per element.
+    if cols > 1 and s_col != 1 and rows > 1 and s_row == 1:
+        col_blocks = triton.cdiv(cols, DSA_TRANS_TILE)
+        grid = (col_blocks * outer_numel, triton.cdiv(rows, DSA_TRANS_TILE))
+        _tle_dsa_trans_copy_kernel[grid](
+            src_v,
+            dst_v,
+            rows,
+            cols,
+            s_col,
+            t_row,
+            col_blocks,
+            *dims[2:],
+            *src_strides[2:],
+            *dst_strides[2:],
+            outer_rank,
+            DSA_TRANS_TILE,
+            src_ty,
+            dst_ty,
+            convert,
+            dst.dtype == torch.bool,
+            is_sdnn=True,
+            num_stages=2,
+        )
+        logger.debug(
+            "GEMS_KUNLUNXIN TLE_COPY dsa transpose rows=%d cols=%d tile=%d rank=%d "
+            "convert=%s",
+            rows,
+            cols,
+            DSA_TRANS_TILE,
+            rank,
+            convert,
+        )
+        return True
+
+    # A strided source run is otherwise read per element, which the engine does
+    # do -- but only on its own: combining it with a row stride would need that
+    # missing third level, so the tile keeps a single row and the rows ride the
+    # grid.
+    col_strided = cols > 1 and s_col != 1
+
+    rows_block, cols_block = _dsa_tile(rows, cols, src_v.element_size())
+    if col_strided:
+        rows_block = 1
+    row_blocks = triton.cdiv(rows, rows_block)
+    grid = (row_blocks * outer_numel, triton.cdiv(cols, cols_block))
+    _tle_dsa_row_copy_kernel[grid](
+        src_v,
+        dst_v,
+        rows,
+        cols,
+        s_row,
+        t_row,
+        s_col,
+        row_blocks,
+        *dims[2:],
+        *src_strides[2:],
+        *dst_strides[2:],
+        outer_rank,
+        rows_block,
+        cols_block,
+        col_strided,
+        src_ty,
+        dst_ty,
+        convert,
+        dst.dtype == torch.bool,
+        is_sdnn=True,
+        num_stages=2,
+    )
+    logger.debug(
+        "GEMS_KUNLUNXIN TLE_COPY dsa rows=%d cols=%d tile=%dx%d rank=%d convert=%s "
+        "col_strided=%s",
+        rows,
+        cols,
+        rows_block,
+        cols_block,
+        rank,
+        convert,
+        col_strided,
+    )
+    return True

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -115,6 +115,10 @@ def test_copy_inplace_dtype_fallback():
     flag_gems.vendor_name == "metax",
     reason="MetaX does not support float8_e8m0fnu dtype",
 )
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "kunlunxin",
+    reason="KUNLUNXIN does not support float8_e8m0fnu dtype",
+)
 @pytest.mark.parametrize("shape", [(8,), (4, 4), (2, 3, 4)])
 def test_copy_inplace_float8_e8m0fnu(shape):
     """Test that copy_ works correctly with float8_e8m0fnu (e8m0) dtype tensors.
@@ -171,6 +175,10 @@ def test_copy_inplace_float8_e8m0fnu(shape):
 @pytest.mark.skipif(
     flag_gems.vendor_name == "metax",
     reason="MetaX does not support float8_e8m0fnu dtype",
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "kunlunxin",
+    reason="KUNLUNXIN does not support float8_e8m0fnu dtype",
 )
 def test_copy_inplace_float8_e8m0fnu_to_float32():
     """Test copy_ from float8_e8m0fnu to float32."""


### PR DESCRIPTION
alias_copy, copy_/copy, permute_copy and unfold_copy are pure moves, so they are handed to tle.gpu instead of the generated pointwise kernels. The new utils/tle_copy.py picks between two kernels:

* both sides contiguous and same dtype -> one flat TMA tile (GM -> LM -> GM)
* everything else -> tle.gpu.copy with a GM pointer tensor, which lowers to an element-wise gather (g2l) / scatter (l2g); permuted, broadcast, strided and overlapping-window reads all land here, and with CONVERT the dtype cast is done in LM so a dtype-changing copy_ stays on the same kernel

torch.bool has no usable LM representation (i1 is packed there), so bool moves through an int8 view. Copies below 2**14 elements are host-bound -- the triton launch floor alone is ~21us while the native op does a 64x64 copy in ~8us -- so those are redispatched to PyTorch; broadcast is excluded from that shortcut because the native XPU copy_ only fills the first row of a broadcast source.

unfold_copy is new for this backend: the generic kernels reject 1D input and mismatch on three of the tested shapes, both of which the tle path handles.

tests/test_copy.py gets the kunlunxin skip marks for the two float8_e8m0fnu cases, matching the other vendors that lack the dtype: triton cannot lower float8, so those copies redispatch to the native op, which raises NOT IMPLEMENTED.

Measured on KL3 (benchmark/test_copy.py --level core, equal-weight dtype mean of Gems Speedup): copy_ 0.9971x, copy 0.9700x (was 0.7147x). Accuracy on the same device: test_alias_copy 36/36, test_permute_copy 18/18, test_unfold_copy 24/24 (9 pre-existing failures fixed), test_contiguous 30/30, test_copy 40 passed with 2 known failures where the reference itself is wrong (the native XPU broadcast copy_ only writes the first row).

Requires the companion triton change that drops the NVIDIA-only 16-byte base alignment assert from TensorDescriptor; XPU has no such requirement.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
