### PR TITLE
fix(nextafter): propagate NaN when target operand is NaN

### DIFF
--- a/src/flag_gems/ops/nextafter.py
+++ b/src/flag_gems/ops/nextafter.py
@@ -38,11 +38,11 @@ def nextafter_func(input, other):
     if tl.constexpr(dtype == tl.float16) or tl.constexpr(dtype == tl.bfloat16):
         # NaN check: all exponent bits set and mantissa non-zero
         if tl.constexpr(dtype == tl.float16):
-            exp_mask = 0x7C00  # 5 exponent bits
-            frac_mask = 0x03FF  # 10 mantissa bits
+            exp_mask: tl.constexpr = 0x7C00  # 5 exponent bits
+            frac_mask: tl.constexpr = 0x03FF  # 10 mantissa bits
         else:  # bf16
-            exp_mask = 0x7F80  # 8 exponent bits
-            frac_mask = 0x007F  # 7 mantissa bits
+            exp_mask: tl.constexpr = 0x7F80  # 8 exponent bits
+            frac_mask: tl.constexpr = 0x007F  # 7 mantissa bits
 
         x_int = input.to(tl.uint16, bitcast=True)
         y_int = other.to(tl.uint16, bitcast=True)
@@ -92,10 +92,21 @@ def nextafter_func(input, other):
         neg_zero_up = ~is_positive & is_going_up & (x_int == 0x8000)
         is_zero_cross = pos_zero_down | neg_zero_up
 
+        # IEEE 754: nextafter(NaN, any) = NaN and nextafter(any, NaN) = NaN.
+        # Return a canonical quiet NaN bit pattern when either operand is NaN;
+        # this must take precedence over both is_equal and the increments.
+        # Fold the NaN bit pattern to a compile-time constant so OR-ing it with
+        # the uint16 tensor does not promote to int32 (see cross_const above).
+        nan_const: tl.constexpr = exp_mask | 0x0001  # smallest quiet NaN
+        nan_bits = uint_zero | nan_const
         result_int = tl.where(
-            is_nan | is_equal,
-            x_int,  # return input bits as-is (NaN or self)
-            tl.where(is_zero_cross, x_int + cross_const, x_int + normal_inc),
+            is_nan,
+            nan_bits,
+            tl.where(
+                is_equal,
+                x_int,  # same value: return input as-is
+                tl.where(is_zero_cross, x_int + cross_const, x_int + normal_inc),
+            ),
         )
 
         return result_int.to(input.dtype, bitcast=True)


### PR DESCRIPTION
## Summary

`tests/test_nextafter_.py` failed with **4 failed / 49 passed** (`test_nextafter_nan`, `test_nextafter_scalar_nan_y`, fp16 & bf16). IEEE 754 (and PyTorch) require `nextafter(any, NaN) = NaN` and `nextafter(NaN, any) = NaN`, but `nextafter(1.0, NaN)` returned `1.0`.

Root cause is in the fp16/bf16 uint16-bit-manipulation branch of `nextafter_func` (`src/flag_gems/ops/nextafter.py`):

```python
result_int = tl.where(
    is_nan | is_equal,
    x_int,          # returns the INPUT's bits on NaN
    ...
)
```

`is_nan = x_is_nan | y_is_nan` correctly detected NaN in either operand, but the "result" path just echoed `x_int`. That happens to be NaN when **x** is NaN, but when **y** is NaN and x is finite (e.g. `x=1.0, y=NaN`) it returns `1.0` unchanged instead of NaN. (float32/float64 go through `tl_extra_shim.nextafter`/libdevice and were already correct.)

## Fix

In the fp16/bf16 branch, emit a canonical quiet-NaN bit pattern whenever either operand is NaN, taking precedence over both the same-value case and the increments:

```python
nan_const: tl.constexpr = exp_mask | 0x0001   # smallest quiet NaN (0x7C01 fp16 / 0x7F81 bf16)
nan_bits = uint_zero | nan_const
result_int = tl.where(
    is_nan,
    nan_bits,
    tl.where(
        is_equal,
        x_int,          # same value: return input as-is
        tl.where(is_zero_cross, x_int + cross_const, x_int + normal_inc),
    ),
)
```

Two `: tl.constexpr` annotations were added (`exp_mask`, `frac_mask`, and the folded `nan_const`). Without them Triton traces `exp_mask | 0x0001` as an int32 scalar op, so `uint_zero | <int32>` promotes to int32 and the final `result_int.to(input.dtype, bitcast=True)` fails with `Cannot bitcast data-type of size 32 to data-type of size 16`. Folding to a constexpr keeps the OR in uint16 (same mechanism as the existing `cross_const = uint_zero | 0x8001`).

## Test

H20-3e (`CUDA_VISIBLE_DEVICES=7`):

```
$ python3 -m pytest tests/test_nextafter_.py -q
53 passed        # was 4 failed / 49 passed

$ python3 -m pytest tests/test_nextafter.py -q
135 passed       # out-of-place nextafter, shares the same kernel — no regression
```

Additional dtype spot-checks (fp16/bf16/fp32/fp64): `y=NaN` → NaN, `x=NaN` → NaN, `nextafter(NaN, NaN)` → NaN; normal ULP increments preserved in native precision (fp16 `1.0 → 1.0009765625`); `+0 → -1.0` / `-0 → +1.0` zero crossings return the smallest subnormal, matching torch's C nextafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
