### PR TITLE
fix(benchmark): write convert_weight_to_int4pack results as structured JSON

### DIFF
--- a/benchmark/test_convert_weight_to_int4pack.py
+++ b/benchmark/test_convert_weight_to_int4pack.py
@@ -1,4 +1,5 @@
 import gc
+from dataclasses import asdict
 
 import pytest
 import torch
@@ -121,7 +122,7 @@ class ConvertWeightBenchmark(base.Benchmark):
                 result=metrics,
             )
             print(result)
-            update_result(self.op_name, result.to_json())
+            update_result(self.op_name, asdict(result))
             emit_record_logger(result.to_json())
 
 


### PR DESCRIPTION
## Summary

`benchmark/test_convert_weight_to_int4pack.py` recorded its results through
`update_result(self.op_name, result.to_json())` — passing the **already
`json.dumps`'d string** into `update_result`. When `benchmark/conftest.py`
later writes `benchmark_result.json`, it `json.dump`s the whole structure again,
so this operator's entry became a **double-encoded, escaped string** instead of
nested objects:

```json
"details": [ "{\"op_name\": \"convert_weight_to_int4pack\", \"dtype\": \"torch.uint8\", ...}" ]
```

Every other benchmark passes a dict via `asdict(result)` (`benchmark/base.py`),
so `convert_weight_to_int4pack` was the outlier and its JSON report couldn't be
consumed uniformly by tooling (consumers had to `json.loads` the inner string).

## Fix

`benchmark/test_convert_weight_to_int4pack.py` (2 lines):

```python
-            update_result(self.op_name, result.to_json())
+            update_result(self.op_name, asdict(result))
             emit_record_logger(result.to_json())   # unchanged — log channel consumes a string
```

+ `from dataclasses import asdict` import (isort-clean, placed with stdlib).

## Test

```
$ cd benchmark && CUDA_VISIBLE_DEVICES=7 python3 -m pytest -m "convert_weight_to_int4pack" --level core --record json
1 passed

$ python3 -c "import json; d=json.load(open('benchmark_result.json')); e=d['convert_weight_to_int4pack']['details'][0]; print(type(e).__name__, list(e.keys()))"
dict ['op_name', 'dtype', 'mode', 'level', 'result']   # structured, no escaped inner string
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
