### PR TITLE
fix(benchmark): write int4pack_mm_with_scales_and_zeros results as structured JSON

### DIFF
--- a/benchmark/test_weight_int4pack_mm_with_scales_and_zeros.py
+++ b/benchmark/test_weight_int4pack_mm_with_scales_and_zeros.py
@@ -1,4 +1,5 @@
 import gc
+from dataclasses import asdict
 
 import pytest
 import torch
@@ -122,7 +123,7 @@ class WeightInt4packMmWithScalesAndZerosBenchmark(base.Benchmark):
                 result=metrics,
             )
             print(result)
-            update_result(self.op_name, result.to_json())
+            update_result(self.op_name, asdict(result))
             emit_record_logger(result.to_json())
 
 


### PR DESCRIPTION
## Summary

Same double-encoding fix as `convert_weight_to_int4pack` (#6101): `benchmark/test_weight_int4pack_mm_with_scales_and_zeros.py` recorded results through `update_result(self.op_name, result.to_json())`, passing an **already-`json.dumps`'d string** into `update_result`. `benchmark/conftest.py` `json.dump`s the structure again when writing `benchmark_result.json`, so this operator's entry became an **escaped inner string** (`"{\"op_name\": ...}"`) instead of nested objects — unlike every other benchmark, which passes `asdict(result)` (`benchmark/base.py`).

## Fix

`benchmark/test_weight_int4pack_mm_with_scales_and_zeros.py` (2 lines):

```python
-            update_result(self.op_name, result.to_json())
+            update_result(self.op_name, asdict(result))
             emit_record_logger(result.to_json())   # unchanged — log channel consumes a string
```

+ `from dataclasses import asdict` import (stdlib section, isort-clean).

## Test

```
$ cd benchmark && CUDA_VISIBLE_DEVICES=7 python3 -m pytest -m "weight_int4pack_mm_with_scales_and_zeros" --level core --record json
1 passed

$ python3 -c "import json; d=json.load(open('benchmark_result.json')); e=d['weight_int4pack_mm_with_scales_and_zeros']['details'][0]; print(type(e).__name__, list(e.keys()))"
dict ['op_name', 'dtype', 'mode', 'level', 'result']   # structured, no escaped inner string
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
