### PR TITLE
[QC] Preserve caller FlagTune settings in MM tests

### DIFF
--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -84,14 +84,6 @@ torch_device_object = flag_gems.runtime.backend.gen_torch_device_object()
 DEEPGEMM_N_MULTIPLE = 64
 DEEPGEMM_K_MULTIPLE = 128
 
-
-@pytest.fixture(autouse=True)
-def _disable_implicit_flagtune(monkeypatch):
-    """Avoid remote tuning-model downloads unless tuning was requested."""
-    if "USE_FLAGTUNE" not in os.environ:
-        monkeypatch.setenv("USE_FLAGTUNE", "0")
-
-
 MUL_DEFAULT_SHAPES = [
     ("broadcast", (1, 1), (1, 2048)),
     ("broadcast", (32, 1), (32, 2048)),

--- a/tests/test_mm.py
+++ b/tests/test_mm.py
@@ -24,13 +24,6 @@ import flag_gems
 from . import accuracy_utils as utils
 from .conftest import QUICK_MODE
 
-
-@pytest.fixture(autouse=True)
-def _disable_flagtune_for_mm_unit_tests(monkeypatch):
-    """Keep operator correctness tests independent of remote tuning models."""
-    monkeypatch.setenv("USE_FLAGTUNE", "0")
-
-
 if QUICK_MODE:
     MNK_SHAPES = [
         (1, 1, 32),


### PR DESCRIPTION
### PR Category
OP Test, Benchmark

### Type of Change
Bug Fix

### Description
Remove the two module-wide autouse fixtures that override `USE_FLAGTUNE` in
`benchmark/test_blas_perf_parallel.py` and `tests/test_mm.py`.

The benchmark fixture sets `USE_FLAGTUNE=0` when the variable is unset, overriding
the runtime's automatic tuning-mode selection and preventing eligible operators
from using the cost model. The accuracy-test fixture sets it unconditionally,
even when the caller explicitly enables FlagTune.

With these fixtures removed, both test modules preserve the caller's environment
and the runtime's normal tuning behavior. Offline overrides, when needed, belong
in local test invocations rather than repository test defaults.

This PR changes only those two files (15 deleted lines). It does not modify
kernels, tuning logic, tuning search spaces, CI workflows, test shapes, or the
dedicated `test_mm_w8a8_fp8` entry points.

### Validation
- Targeted pre-commit checks passed for both changed files, including Black,
  isort, and Flake8.
- `git diff --check` passed.
- Python syntax and AST comparison passed: each module is identical to its base
  version after removing only the respective fixture. Both dedicated
  `test_mm_w8a8_fp8` entry points remain present.
- GPU correctness and performance tests were not rerun for this fixture-only
  removal. No claim is made that this fixes runner network access to FlagTune
  model packages; that dependency remains required when cost-model tuning is used.
