### PR TITLE
fix benchmark naming for irshift

### DIFF
--- a/benchmark/test_irshift.py
+++ b/benchmark/test_irshift.py
@@ -4,10 +4,10 @@ import torch
 from . import base, consts
 
 
-@pytest.mark.irshift__
+@pytest.mark.irshift
 def test_irshift__():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="irshift__",
+        op_name="irshift",
         torch_op=torch.ops.aten.__irshift__,
         dtypes=consts.INT_DTYPES,
     )


### PR DESCRIPTION
## Summary

Fix the benchmark naming for `irshift` to align with the corresponding
accuracy test and operator naming.

Changes:
- `@pytest.mark.irshift__` -> `@pytest.mark.irshift`
- `op_name="irshift__"` -> `op_name="irshift"`

The underlying benchmark still uses:

`torch.ops.aten.__irshift__`

so the tested ATen operator is unchanged.