### PR TITLE
Fix expression syntax error in unittest.yaml concurrency group

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -31,7 +31,7 @@ jobs:
   preprocess:
     runs-on: ubuntu-latest
     concurrency:
-      group: unit-test-${{ github.event.pull_request.title contains 'KernelGen' && 'kg' || github.run_id }}
+      group: unit-test-${{ (github.event.pull_request && contains(github.event.pull_request.title, 'KernelGen')) && 'kg' || github.run_id }}
       cancel-in-progress: false
     outputs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Summary
Fixes the syntax error in unittest.yaml that was causing all unittest workflow runs to fail immediately with 0s runtime.

## Problem
The concurrency group expression on line 34 had two issues:
1. **Incorrect `contains()` syntax**: Used `github.event.pull_request.title contains 'KernelGen'` instead of the correct function call format `contains(github.event.pull_request.title, 'KernelGen')`
2. **Missing null check**: When the workflow is triggered by push events (PR merges), `github.event.pull_request` is null, causing expression evaluation to fail

This caused unittest workflows to fail at the configuration parsing stage, preventing any tests from running even when PRs had the correct labels (like PR #5602).

## Changes
- Fixed `contains()` function syntax
- Added null check: `github.event.pull_request && contains(...)`

## Test plan
- [x] Verified the expression syntax is correct
- [ ] Confirm unittest workflow runs successfully for pull_request events
- [ ] Confirm unittest workflow runs successfully for push events (after PR merge)

🤖 Generated with Claude Code