### PR TITLE
docs: define HyV4 MUSA operator validation contract

### DIFF
--- a/docs/content/en/testing/hyv4-musa.md
+++ b/docs/content/en/testing/hyv4-musa.md
@@ -1,0 +1,92 @@
+---
+title: HyV4 MUSA Operator Validation
+weight: 40
+---
+
+<!--
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# HyV4 MUSA Operator Validation
+
+This page defines the evidence required before a FlagGems implementation is
+claimed as covered by a HyV4 MUSA inference path. A model-level blacklist or
+fallback is an observation, not proof that the corresponding FlagGems operator
+is incorrect.
+
+## Operator families
+
+HyV4 exercises the following high-priority families:
+
+| Family | Representative input contract | Validation focus |
+|---|---|---|
+| MXFP8 MoE | hidden 6144, 256 experts, top-k 8, intermediate 2048, group size 128 | scale semantics, quantization, grouped GEMM, routing and accumulation dtype |
+| DSA prefill | paged KV, index top-k 2048 | sparse attention accuracy and page-table transforms |
+| DSA KV gather/dequant | paged FP8 KV, selected indices `[T, 2048]`, BF16 output | index bounds, scale layout and output accuracy |
+| DSA top-k | logits `[T, S]`, k=2048, int64 indices | values, indices and deterministic tie behavior |
+| mHC post | input `[T, 6144]`, residual `[T, 4, 6144]`, post `[T, 4]` | broadcast order and FP32 accumulation |
+| clamped SwiGLU | gate/up `[T, 4096]`, output `[T, 2048]` | clamp, sigmoid and output dtype |
+| non-contiguous BMM | model-derived shapes and strides | stride correctness without forcing a contiguous copy |
+| repeat/index/copy/reduction | dynamic token, expert and page metadata | dispatch ownership, dynamic shapes and integer bounds |
+
+The exact token dimension `T`, strides, dtypes and scale tensors must be
+captured from the effective model runtime. The representative dimensions above
+must not be converted into a synthetic claim that all dynamic shapes work.
+
+## Required issue and pull-request evidence
+
+Every independently fixable operator issue should include:
+
+1. the full FlagGems, compiler, PyTorch and device-stack commits;
+2. a saved real-shape input or a deterministic generator with a checksum;
+3. the actual dispatch owner and kernel name;
+4. expected and actual outputs with maximum and mean error;
+5. eager and compiled-path coverage;
+6. a test that fails before the fix and passes after it;
+7. operator latency and model-level A/B results;
+8. regression coverage for unaffected backends;
+9. a rollback description.
+
+If the effective owner is PyTorch-MUSA, the compiler backend, SGLang or the
+communication library, route the issue to that project instead of adding a
+FlagGems workaround.
+
+## Safe selective enablement
+
+When model integration uses selective operator enablement, retain the runtime
+dispatch record. An empty record must be reported explicitly; it commonly
+means an existing PrivateUse1 implementation owned the call and FlagGems
+skipped duplicate registration.
+
+Do not claim FlagGems model coverage from any of the following alone:
+
+- the operator exists in the source tree;
+- the operator name appears in an allowlist or blacklist;
+- the service returns HTTP 200;
+- a model benchmark passes while the FlagGems dispatch record is empty.
+
+## End-to-end regression gate
+
+After operator-level validation, rerun the same model fingerprint with:
+
+- bounded deterministic generation;
+- repeated and concurrent requests;
+- the selected accuracy workload;
+- profiler-disabled performance measurements;
+- worker, scheduler, OOM, NaN and device-error checks.
+
+Any operator, precision, dispatch, graph or cache change invalidates older
+model-level evidence until these gates are repeated.
+

--- a/docs/content/zh-cn/testing/hyv4-musa.md
+++ b/docs/content/zh-cn/testing/hyv4-musa.md
@@ -1,0 +1,86 @@
+---
+title: HyV4 MUSA 算子验证
+weight: 40
+---
+
+<!--
+ Copyright 2026 FlagOS Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+# HyV4 MUSA 算子验证
+
+本文定义 FlagGems 实现被认定为覆盖 HyV4 MUSA 推理路径前所需的证据。模型侧
+blacklist 或 fallback 只是观察结果，不能单独证明对应 FlagGems 算子存在错误。
+
+## 算子族
+
+HyV4 涉及以下高优先级算子族：
+
+| 算子族 | 代表性输入契约 | 验证重点 |
+|---|---|---|
+| MXFP8 MoE | hidden 6144、256 experts、top-k 8、intermediate 2048、group size 128 | scale 语义、量化、grouped GEMM、路由和累加 dtype |
+| DSA prefill | paged KV、index top-k 2048 | 稀疏注意力精度和 page-table transform |
+| DSA KV gather/dequant | paged FP8 KV、selected indices `[T, 2048]`、BF16 输出 | 索引边界、scale layout 和输出精度 |
+| DSA top-k | logits `[T, S]`、k=2048、int64 indices | values、indices 和相同值时的确定性 |
+| mHC post | input `[T, 6144]`、residual `[T, 4, 6144]`、post `[T, 4]` | 广播顺序和 FP32 累加 |
+| clamped SwiGLU | gate/up `[T, 4096]`、output `[T, 2048]` | clamp、sigmoid 和输出 dtype |
+| non-contiguous BMM | 从模型提取的真实 shape 和 stride | 不强制 contiguous copy 时的 stride 正确性 |
+| repeat/index/copy/reduction | 动态 token、expert 和 page metadata | dispatch owner、动态 shape 和整数边界 |
+
+精确的 token 维 `T`、stride、dtype 和 scale tensor 必须从有效模型运行时提取。
+上述代表性维度不能被扩展成所有动态 shape 均已支持的结论。
+
+## Issue 和 PR 的必要证据
+
+每个可独立修复的算子问题都应包含：
+
+1. FlagGems、编译器、PyTorch 和设备栈的完整 commit；
+2. 保存的真实 shape 输入，或带 checksum 的确定性生成器；
+3. 实际 dispatch owner 和 kernel 名；
+4. expected/actual，以及最大和平均误差；
+5. eager 与编译路径覆盖；
+6. 修复前失败、修复后通过的测试；
+7. 单算子时延和模型端到端 A/B；
+8. 不受影响后端的回归测试；
+9. 回滚说明。
+
+如果实际 owner 是 PyTorch-MUSA、编译器后端、SGLang 或通信库，应将问题提交到
+对应项目，而不是在 FlagGems 中增加 workaround。
+
+## 安全的选择性启用
+
+模型集成使用选择性算子启用时，应保留运行时 dispatch 记录。记录为空必须明确
+说明；这通常意味着已有 PrivateUse1 实现持有该调用，FlagGems 跳过了重复注册。
+
+以下任一情况都不能单独作为 FlagGems 已覆盖模型的证据：
+
+- 源码树中存在同名算子；
+- 算子名称出现在 allowlist 或 blacklist；
+- 服务返回 HTTP 200；
+- 模型 benchmark 通过，但 FlagGems dispatch 记录为空。
+
+## 端到端回归门禁
+
+算子验证完成后，使用相同模型 fingerprint 重新执行：
+
+- 有界确定性生成；
+- 重复和并发请求；
+- 已选择的精度任务；
+- profiler 关闭的性能测试；
+- worker、scheduler、OOM、NaN 和设备错误检查。
+
+任何算子、精度、dispatch、graph 或 cache 变化都会使旧模型证据失效，必须重新
+通过上述门禁。
+


### PR DESCRIPTION
### PR Category

Model Test / User Experience

### Type of Change

Documentation Update

### Description

Document the validation contract required before a FlagGems operator is claimed as covered by a HyV4 MUSA inference path.

The new English and Chinese pages provide:

- representative contracts for MXFP8 MoE, DSA, mHC, clamped SwiGLU and non-contiguous BMM;
- required real-shape, dispatch-owner, correctness and performance evidence;
- guidance for routing issues to PyTorch-MUSA, the compiler, SGLang or the communication library when FlagGems is not the effective owner;
- explicit rules for interpreting empty dispatch records and selective enablement;
- model-level regression gates after an operator or dispatch change.

This PR does not claim that HyV4 operator kernels are newly implemented or validated. It prevents model blacklists, source-code presence or HTTP success from being used as false coverage evidence.

### Issue

No linked issue. This document was derived from a two-node MUSA TP16 HyV4 adaptation audit.

### Progress

- [ ] Change is properly reviewed.
- [ ] Change is responded to an issue.
- [x] Documentation is provided in English and Chinese.

### Performance

No performance code is changed. Historical model profiles are intentionally excluded from the documentation because they are not current-master performance guarantees.

