### PR TITLE
fix: add missing DSA/__init__.py so non-editable installs include the subpackage

### DIFF
--- a/src/flag_gems/fused/DSA/__init__.py
+++ b/src/flag_gems/fused/DSA/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## Problem

After a non-editable install (`pip install .`), `import flag_gems` crashes:

```
ModuleNotFoundError: No module named 'flag_gems.fused.DSA'
```

## Root cause

`setup.py` uses `find_packages("src")`, which only recognizes directories containing an `__init__.py`. `src/flag_gems/fused/DSA/` has none, so it is silently dropped from the wheel, while `src/flag_gems/fused/__init__.py` unconditionally imports it:

```python
from flag_gems.fused.DSA.bin_topk import bucket_sort_topk
from flag_gems.fused.DSA.sparse_mla import triton_sparse_mla_fwd_interface
```

Editable installs (`pip install -e .`) are unaffected because the source tree is added to `sys.path` directly (Python treats the `__init__.py`-less `DSA/` as a namespace package). That's why this only surfaces with non-editable installs.

## Fix

Add `src/flag_gems/fused/DSA/__init__.py` (Apache 2.0 header, matching the other files in the directory) so `find_packages` picks up the subpackage.

Verified: `pip install . --no-build-isolation && python3 -c "import flag_gems"` succeeds after the fix.

## Related

- #6145

🤖 Generated with [Claude Code](https://claude.com/claude-code)