### PR TITLE
[PPU] Select FlagTree 0.6.2a2+ppu3.6 for asynchronous loads

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -294,6 +294,7 @@ backends:
 
   thead:
     python: "3.12"
+    flagtree: flagtree===0.6.2a2+ppu3.6
     triton: triton==3.5.0+ppu2.0.0.oe
     env_source:
       - /usr/local/PPU_SDK/envsetup.sh


### PR DESCRIPTION
## Summary

Select `flagtree===0.6.2a2+ppu3.6` in the `thead` profile of `src/flag_gems/backends.yaml`, following the published wheel in the [PPU user manual](https://github.com/flagos-ai/FlagTree/wiki/User-manual-for-ppu). This makes the existing setup script choose FlagTree automatically for PPU and supports the asynchronous AIU loads used by [FlagGems-vllm #760](https://github.com/flagos-ai/FlagGems-vllm/pull/760).

This changes only the `thead.flagtree` field. The explicit vendor-Triton option and existing dependency pins are preserved.

## Validation

Installed the published wheel in an isolated Python 3.12 environment on PPU-ZW810E with SDK `2.1.0-a5f865` and PyTorch 2.10.0. Confirmed FlagTree metadata and the imported Triton/TLE modules resolve to that environment, with Triton 3.6.0. Used a fresh Triton compilation cache.

- FlagGems-vllm `tests/test_int8_einsum.py`: **61 passed**, including all 22 upstream shapes, floating routes, strided layouts, empty dimensions and INT8 extremes.
- Existing `benchmark/test_int8_einsum.py --level comprehensive --warmup 20 --iter 100 --record json`: **2 passed**, covering all 22 shapes and both BF16 baselines.
- Parsed the backend YAML and verified that only `thead.flagtree` changes; checked the setup script's compiler selection.
- `git diff --check`: passed.

These runtime checks cover SDK 2.1 / PyTorch 2.10.0. The existing profile's SDK 2.0 / PyTorch 2.9 dependency combination and a clean runner bootstrap have not been validated in this environment.
