### PR TITLE
Fix benchmark naming for batch_norm_with_update_functional

### DIFF
--- a/benchmark/test_batch_norm_with_update_functional.py
+++ b/benchmark/test_batch_norm_with_update_functional.py
@@ -72,7 +72,7 @@ def test__batch_norm_with_update_functional():
 
     bench = NormBenchmark(
         input_fn=batch_norm_with_update_functional_input_fn_wrapper,
-        op_name="_batch_norm_with_update_functional",
+        op_name="batch_norm_with_update_functional",
         torch_op=torch.ops.aten._batch_norm_with_update_functional,
         dtypes=consts.FLOAT_DTYPES,
     )


### PR DESCRIPTION
### PR Category
Benchmark

### Type of Change
Bug Fix

### Description
Fix the benchmark operator name for `batch_norm_with_update_functional`.

Changed:

```python
op_name="_batch_norm_with_update_functional"
to:

op_name="batch_norm_with_update_functional"