### PR TITLE
[Fix] Record JSON metrics in parallel BLAS benchmarks

### DIFF
--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -21,6 +21,7 @@ import pickle
 import subprocess
 import sys
 import tempfile
+from dataclasses import asdict
 from typing import Generator
 
 import pytest
@@ -32,7 +33,7 @@ import flag_gems
 
 from . import consts
 from .base import Benchmark, GenericBenchmark2DOnly
-from .conftest import Config, emit_record_logger
+from .conftest import Config, emit_record_logger, update_result
 from .consts import (
     COMPLEX_DTYPES,
     DEFAULT_METRICS,
@@ -1046,6 +1047,7 @@ class ParallelBenchmarkMixin:
                 result=metrics,
             )
             print(result)
+            update_result(self.op_name, asdict(result))
             emit_record_logger(result.to_json())
             if os.environ.get(PARALLEL_RESULT_FILE_ENV):
                 with open(os.environ[PARALLEL_RESULT_FILE_ENV], "wb") as result_file:


### PR DESCRIPTION
### PR Category
Benchmark

### Type of Change
Bug Fix

### Description
Record performance details for `ParallelBenchmarkMixin` when `--record json` is
selected, matching the existing `Benchmark.run()` implementation.

The mixin overrides `run()` but only prints results, emits log records, and
optionally writes worker pickle payloads. It never calls `update_result()`. As a
result, tests such as `test_mm_w8a8_fp8` can pass while the JSON report contains
only `result`, `test_case`, and `reason`, without latency or speedup details.
This also affects serial execution through the mixin, not just `--parallel` runs.

Import `asdict` and `update_result`, then register each completed dtype result
after metrics have been collected or merged. `update_result()` already respects
`Config.record_json`, so log-only and non-recording behavior remain unchanged.

Only `benchmark/test_blas_perf_parallel.py` is changed. No kernel, timing,
precision-test, tuning, cost-model, environment-variable, or CI logic is changed.

### Reproduction
From the `benchmark` directory:

```bash
pytest -m mm_w8a8_fp8 --level core --record json \
  --output benchmark_mm_w8a8_fp8.json --continue-on-collection-errors
```

Before this fix, a passing test produces no `details` entry. After the fix,
`mm_w8a8_fp8.details` contains the per-dtype results with `shape_detail`,
`latency_base`, `latency`, and `speedup`. Passing-test stdout capture is independent
of JSON recording; `-s` is not required to populate the JSON report.

### Validation
- Targeted pre-commit checks passed, including Black, isort, and Flake8.
- `git diff --check` passed.
- A temporary reporting-only harness executed the repository's `run()`, result
  dataclasses, and reporting hooks with synthetic metrics. Twelve checks covered
  before/after behavior, serial execution and mocked parallel aggregation, and
  JSON/log/no-record modes, with two dtype results per run. They reproduced the
  missing details before the fix and verified complete serialized metrics after
  it, without changing log/no-record behavior.
- GPU benchmark execution was not rerun for this reporting-only fix. The harness
  timings are synthetic and are not performance measurements.
