### PR TITLE
fix(benchmark): add max_pool3d_with_indices marker to max_pool3d bench

### DIFF
--- a/benchmark/test_max_pool3d.py
+++ b/benchmark/test_max_pool3d.py
@@ -74,6 +74,7 @@ class MaxPool3dBenchmark(base.GenericBenchmark):
 
 
 @pytest.mark.max_pool3d
+@pytest.mark.max_pool3d_with_indices
 def test_perf_max_pool3d():
     bench = MaxPool3dBenchmark(
         input_fn=max_pool3d_input_fn,
@@ -88,6 +89,7 @@ def test_perf_max_pool3d():
 
 
 @pytest.mark.max_pool3d
+@pytest.mark.max_pool3d_backward
 def test_perf_max_pool3d_backward():
     def max_pool3d_backward_input_fn(shape, dtype, device):
         for forward_args in max_pool3d_input_fn(shape, dtype, device):


### PR DESCRIPTION
## Summary

`pytest -m "max_pool3d_with_indices"` (run from `benchmark/`) selected **0 tests** (`1242 deselected`). The operator id in `conf/operators.yaml` is `max_pool3d_with_indices`, but the benchmark that actually exercises `flag_gems.max_pool3d_with_indices` — `benchmark/test_max_pool3d.py::test_perf_max_pool3d` — carried only `@pytest.mark.max_pool3d`, so filtering by the operator id deselected everything.

## Fix

`benchmark/test_max_pool3d.py` (+2 lines): give each pooling benchmark the marker matching the operator it actually benchmarks, alongside the legacy `max_pool3d` marker:

```python
@pytest.mark.max_pool3d
@pytest.mark.max_pool3d_with_indices      # added: this bench runs gems_op=flag_gems.max_pool3d_with_indices
def test_perf_max_pool3d():

@pytest.mark.max_pool3d
@pytest.mark.max_pool3d_backward          # added: this bench runs gems_op=flag_gems.max_pool3d_backward
def test_perf_max_pool3d_backward():
```

`-m "max_pool3d"` / `-m "max_pool3d_with_indices_backward"` behavior is unchanged (the existing markers stay).

## Test

```
$ cd benchmark && CUDA_VISIBLE_DEVICES=7 python3 -m pytest -m "max_pool3d_with_indices" --level core --record json
1 selected, benchmark runs to completion
# fp16/fp32/bf16 core shapes, all SUCCESS, speedups 1.2-3.2 vs torch max_pool3d

$ python3 -m pytest -m "max_pool3d_with_indices_backward" --level core --record json
1 selected, benchmark runs to completion   # fp16/fp32/bf16, 12 rows SUCCESS — marker was already correct and is untouched

# collection matrix after the change (no cross-marker breakage):
# -m max_pool3d                      -> 2 tests   (unchanged)
# -m max_pool3d_with_indices         -> 1 test    (newly selectable)
# -m max_pool3d_backward             -> 1 test    (newly selectable)
# -m max_pool3d_with_indices_backward-> 1 test    (unchanged)
# combined "max_pool3d or max_pool3d_with_indices or max_pool3d_with_indices_backward" -> 3 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
