### PR TITLE
[QC][Hygon] Add  topk_w8a16_fp8

### DIFF
--- a/benchmark/test_topk_w8a16_fp8.py
+++ b/benchmark/test_topk_w8a16_fp8.py
@@ -20,14 +20,16 @@ import flag_gems
 from . import base
 
 GROUP_SIZE = 128
-FP8_DTYPE = torch.float8_e5m2
+FP8_DTYPE = (
+    torch.float8_e4m3fn if flag_gems.vendor_name == "hygon" else torch.float8_e5m2
+)
 
 
-def _fp8_e5_available():
+def _fp8_available():
     return torch.cuda.is_available() and hasattr(torch, "float8_e5m2")
 
 
-def _quantize_fp8_e5_grouped(x, group_size=GROUP_SIZE):
+def _quantize_fp8_grouped(x, group_size=GROUP_SIZE):
     fp8_info = torch.finfo(FP8_DTYPE)
     *leading, n = x.shape
     padded = (n + group_size - 1) // group_size * group_size
@@ -41,7 +43,7 @@ def _quantize_fp8_e5_grouped(x, group_size=GROUP_SIZE):
     )
 
 
-def _dequant_fp8_e5(x_fp8, x_scale, group_size=GROUP_SIZE):
+def _dequant_fp8(x_fp8, x_scale, group_size=GROUP_SIZE):
     *leading, n = x_fp8.shape
     num_groups = x_scale.shape[-1]
     padded = num_groups * group_size
@@ -53,6 +55,10 @@ def _dequant_fp8_e5(x_fp8, x_scale, group_size=GROUP_SIZE):
 
 def _torch_topk_w8a16(x_fp8, x_scale, k, dequant):
     return torch.topk(dequant, k, dim=-1, largest=True, sorted=True)
+
+
+def _gems_bf16_topk(x_fp8, x_scale, k, dequant):
+    return flag_gems.topk(dequant, k, dim=-1, largest=True, sorted=True)
 
 
 def _gems_topk_w8a16(x_fp8, x_scale, k, dequant):
@@ -77,23 +83,28 @@ class TopKFp8W8A16Benchmark(base.Benchmark):
 
     def get_input_iter(self, dtype):
         for m, n, k in self.shapes:
+            torch.manual_seed(5966)
             x = torch.randn((m, n), dtype=dtype, device=self.device)
-            x_fp8, x_scale = _quantize_fp8_e5_grouped(x)
-            dequant = _dequant_fp8_e5(x_fp8, x_scale)
+            x_fp8, x_scale = _quantize_fp8_grouped(x)
+            dequant = _dequant_fp8(x_fp8, x_scale)
             yield x_fp8, x_scale, k, dequant
 
 
 @pytest.mark.topk_w8a16_fp8
 @pytest.mark.skipif(
-    getattr(flag_gems, "vendor_name", None) != "thead",
-    reason="topk_w8a16_fp8 is a THead/PPU operator",
+    getattr(flag_gems, "vendor_name", None) not in ("thead", "hygon"),
+    reason="topk_w8a16_fp8 requires an implemented backend",
 )
-@pytest.mark.skipif(not _fp8_e5_available(), reason="float8_e5m2 is unavailable")
-def test_topk_w8a16_fp8():
+@pytest.mark.skipif(not _fp8_available(), reason="required FP8 format is unavailable")
+@pytest.mark.parametrize("baseline", ["torch", "flaggems"])
+def test_topk_w8a16_fp8(baseline):
     bench = TopKFp8W8A16Benchmark(
         op_name="topk_w8a16_fp8",
-        torch_op=_torch_topk_w8a16,
+        torch_op=_torch_topk_w8a16 if baseline == "torch" else _gems_bf16_topk,
         dtypes=[torch.bfloat16],
     )
     bench.set_gems(_gems_topk_w8a16)
+    print(
+        f"FP8 format: {FP8_DTYPE}; BF16 baseline: {baseline}; input quantization excluded"
+    )
     bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -14499,7 +14499,7 @@ ops:
   stages:
   - beta: '5.3'
 - id: topk_w8a16_fp8
-  description: 'Returns the k largest (or smallest) elements of a group-wise FP8 E5M2
+  description: 'Returns the k largest (or smallest) elements of a group-wise FP8 E4M3FN/E5M2
     tensor along the last dimension, dequantizing with per-group scales.
 
     '

--- a/src/flag_gems/ops/topk_w8a16_fp8.py
+++ b/src/flag_gems/ops/topk_w8a16_fp8.py
@@ -14,15 +14,14 @@
 
 """Public ``topk_w8a16_fp8`` entry.
 
-The THead / PPU implementation lives in
-``flag_gems.runtime.backend._thead.ops.topk_w8a16_fp8`` and is installed over
-this stub by ``SpecOpRegistrar``. Other vendors should add their own backend
-instead of putting a PPU TLE kernel in the generic tree.
+Hygon (E4M3FN) and THead / PPU (E5M2) implementations live in their
+backend ops packages and are installed over this stub by ``SpecOpRegistrar``.
+Other vendors should add their own backend implementation.
 """
 
 
 def topk_w8a16_fp8(*args, **kwargs):
     raise NotImplementedError(
-        "topk_w8a16_fp8 is implemented for the THead/PPU backend; "
+        "topk_w8a16_fp8 is implemented for the Hygon and THead/PPU backends; "
         "import flag_gems.topk_w8a16_fp8 after the vendor registrar has run"
     )

--- a/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
@@ -115,6 +115,7 @@ from .special_chebyshev_polynomial_w import (
 )
 from .split_with_sizes_copy import split_with_sizes_copy
 from .tile import tile
+from .topk_w8a16_fp8 import topk_w8a16_fp8
 from .unique import _unique2
 from .unique_dim import unique_dim
 from .unsqueeze import unsqueeze, unsqueeze_
@@ -225,6 +226,7 @@ __all__ = [
     "split_with_sizes_copy",
     "SUPPORTED_FP8_DTYPE",
     "tile",
+    "topk_w8a16_fp8",
     "true_divide",
     "true_divide_",
     "true_divide_out",

--- a/src/flag_gems/runtime/backend/_hygon/ops/topk_w8a16_fp8.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/topk_w8a16_fp8.py
@@ -1,0 +1,321 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Grouped E4M3FN TopK for Hygon, with fused decode and selection."""
+
+import logging
+import math
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _decode(bits):
+    bits = bits.to(tl.uint32)
+    # Decode normal and subnormal E4M3FN without FP32 denormal intermediates.
+    exponent = (bits >> 3) & 15
+    mantissa = bits & 7
+    normal = ((exponent + 120) << 23 | (mantissa << 20)).to(tl.float32, bitcast=True)
+    magnitude = tl.where(exponent == 0, mantissa.to(tl.float32) * 0.001953125, normal)
+    magnitude = tl.where((bits & 127) == 127, float("nan"), magnitude)
+    return tl.where((bits & 128) != 0, -magnitude, magnitude)
+
+
+@triton.jit
+def _pack(value, index, valid, DESC: tl.constexpr, WIDE: tl.constexpr):
+    # Compare the rounded A16 values, matching TopK on a dequantized tensor.
+    bits = value.to(tl.uint16, bitcast=True)
+    bits = tl.where(value == 0, 0, bits).to(tl.uint16)
+    key = bits ^ tl.where((bits & 32768) != 0, 65535, 32768).to(tl.uint16)
+    key = tl.where(value != value, 65535, key).to(tl.uint16)
+    if not DESC:
+        key = key ^ 65535
+    if WIDE:
+        packed = (key.to(tl.uint64) << 32) | (4294967295 - index.to(tl.uint64))
+    else:
+        packed = (key.to(tl.uint32) << 16) | (65535 - index.to(tl.uint32))
+    return tl.where(valid, packed, 0)
+
+
+@triton.jit
+def _store(packed, Y, Indices, offsets, mask, DESC: tl.constexpr, WIDE: tl.constexpr):
+    if WIDE:
+        key = (packed >> 32).to(tl.uint16)
+        index = 4294967295 - (packed & 4294967295)
+    else:
+        key = (packed >> 16).to(tl.uint16)
+        index = 65535 - (packed & 65535)
+    if not DESC:
+        key = key ^ 65535
+    bits = key ^ tl.where((key & 32768) != 0, 32768, 65535).to(tl.uint16)
+    value = bits.to(Y.dtype.element_ty, bitcast=True)
+    tl.store(Y + offsets, value, mask)
+    tl.store(Indices + offsets, index.to(tl.int64), mask)
+
+
+@triton.jit
+def _select(
+    X,
+    S,
+    C,
+    Y,
+    Indices,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    G: tl.constexpr,
+    DESC: tl.constexpr,
+    BLOCK: tl.constexpr,
+    ROWS: tl.constexpr,
+    PARTS: tl.constexpr,
+    FINAL: tl.constexpr,
+    WIDE: tl.constexpr,
+):
+    rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
+    part = tl.program_id(1)
+    col = part * BLOCK + tl.arange(0, BLOCK)
+    valid = (rows[:, None] < M) & (col[None, :] < N)
+    bits = tl.load(X + rows[:, None].to(tl.int64) * N + col[None, :], valid, other=0)
+    scale = tl.load(
+        S + rows[:, None].to(tl.int64) * tl.cdiv(N, G) + col[None, :] // G,
+        valid,
+        other=0,
+    ).to(tl.float32)
+    value = (_decode(bits) * scale).to(Y.dtype.element_ty)
+    packed = _pack(value, col[None, :], valid, DESC, WIDE)
+    packed = tl.sort(packed, descending=True, dim=1)
+    rank = tl.arange(0, BLOCK)
+    mask = (rows[:, None] < M) & (rank[None, :] < K)
+    if FINAL:
+        offsets = rows[:, None].to(tl.int64) * K + rank[None, :]
+        _store(packed, Y, Indices, offsets, mask, DESC, WIDE)
+    else:
+        offsets = (rows[:, None].to(tl.int64) * PARTS + part) * K + rank[None, :]
+        tl.store(C + offsets, packed, mask)
+
+
+@triton.jit
+def _merge(
+    C,
+    D,
+    Y,
+    Indices,
+    COUNT: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK: tl.constexpr,
+    PARTS: tl.constexpr,
+    FINAL: tl.constexpr,
+    DESC: tl.constexpr,
+    WIDE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    part = tl.program_id(1)
+    rank = tl.arange(0, BLOCK)
+    col = part * BLOCK + rank
+    packed = tl.load(C + row * COUNT + col, col < COUNT, other=0)
+    packed = tl.sort(packed, descending=True)
+    if FINAL:
+        _store(packed, Y, Indices, row * K + rank, rank < K, DESC, WIDE)
+    else:
+        tl.store(D + (row * PARTS + part) * K + rank, packed, rank < K)
+
+
+@triton.jit
+def _single_group(
+    X,
+    S,
+    Y,
+    Indices,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK: tl.constexpr,
+    DESC: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    col = tl.arange(0, BLOCK)
+    bits = tl.load(X + row * N + col, col < N, other=0)
+    scale = tl.load(S + row).to(tl.float32)
+    magnitude = tl.abs(scale)
+    # Within these conservative bounds, A16 rounding cannot collapse adjacent
+    # E4M3FN values. Sort byte keys and decode only the selected elements.
+    # Zero, nonfinite and extreme scales use the exact A16-key path below.
+    if Y.dtype.element_ty == tl.bfloat16:
+        regular = (magnitude >= 1.0e-30) & (magnitude <= 1.0e30)
+    else:
+        regular = (magnitude >= 0.03125) & (magnitude <= 100.0)
+    if regular:
+        normalized = tl.where((bits & 127) == 0, 0, bits).to(tl.uint8)
+        key = normalized ^ tl.where((normalized & 128) != 0, 255, 128).to(tl.uint8)
+        key = tl.where(scale < 0, key ^ 255, key).to(tl.uint8)
+        key = tl.where((bits & 127) == 127, 255, key).to(tl.uint8)
+        if not DESC:
+            key = key ^ 255
+        packed = (key.to(tl.uint16) << 8) | (255 - col).to(tl.uint16)
+        packed = tl.where(col < N, packed, 0)
+        packed = tl.sort(packed, descending=True)
+        selected = (255 - (packed & 255)).to(tl.int32)
+        q = tl.load(X + row * N + selected, col < K, other=0)
+        tl.store(Y + row * K + col, _decode(q) * scale, col < K)
+        tl.store(Indices + row * K + col, selected.to(tl.int64), col < K)
+    else:
+        value = (_decode(bits) * scale).to(Y.dtype.element_ty)
+        fallback_packed = _pack(value, col, col < N, DESC, False)
+        fallback_packed = tl.sort(fallback_packed, descending=True)
+        _store(fallback_packed, Y, Indices, row * K + col, col < K, DESC, False)
+
+
+def topk_w8a16_fp8(
+    x_fp8,
+    x_scale,
+    k,
+    dim=-1,
+    largest=True,
+    sorted=True,
+    group_size=128,
+    out_dtype=torch.bfloat16,
+):
+    """TopK of group-wise FP8 values dequantized and rounded to A16.
+
+    Only E4M3FN storage is supported on Hygon. Scales have shape
+    ``x_fp8.shape[:-1] + (ceil(N/group_size),)`` and may be FP16/BF16/FP32.
+    Returns A16 values and INT64 indices along the last dimension. Equal
+    values select lower indices first; NaNs sort above finite values.
+    Noncontiguous inputs are copied on each invocation. ``sorted=False``
+    also returns sorted results. No input contents are cached. Forward only.
+    """
+    logger.debug("GEMS_HYGON TOPK W8A16 FP8")
+    if not isinstance(x_fp8, torch.Tensor) or not isinstance(x_scale, torch.Tensor):
+        raise TypeError("x_fp8 and x_scale must be tensors")
+    if x_fp8.dtype != torch.float8_e4m3fn:
+        raise TypeError("x_fp8 must have dtype float8_e4m3fn")
+    if out_dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError("out_dtype must be float16 or bfloat16")
+    if x_scale.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError("x_scale must have dtype float16, bfloat16 or float32")
+    if x_fp8.device.type != "cuda" or x_scale.device != x_fp8.device:
+        raise ValueError("inputs must be on the same Hygon CUDA device")
+    if x_fp8.ndim == 0:
+        raise ValueError("x_fp8 must have at least one dimension")
+    dim, k, group_size = (
+        operator.index(dim),
+        operator.index(k),
+        operator.index(group_size),
+    )
+    if dim not in (-1, x_fp8.ndim - 1):
+        raise ValueError("only the last dimension is supported")
+    if group_size <= 0:
+        raise ValueError("group_size must be positive")
+    n = x_fp8.shape[-1]
+    if not 0 <= k <= n:
+        raise ValueError("k must satisfy 0 <= k <= N")
+    if n >= 2147483647:
+        raise ValueError("N must be smaller than 2**31-1")
+    if x_scale.shape != x_fp8.shape[:-1] + (triton.cdiv(n, group_size),):
+        raise ValueError(
+            "x_scale shape must match the leading dimensions and ceil(N/group_size)"
+        )
+    m = math.prod(x_fp8.shape[:-1])
+    shape = x_fp8.shape[:-1] + (k,)
+    values = torch.empty(shape, device=x_fp8.device, dtype=out_dtype)
+    indices = torch.empty(shape, device=x_fp8.device, dtype=torch.int64)
+    if k == 0 or m == 0:
+        return values, indices
+    # Use byte storage so E4M3FN decoding is independent of target FP8 casts.
+    x = x_fp8.view(torch.uint8).contiguous()
+    scales = x_scale.contiguous()
+    if n <= 128 and group_size >= n:
+        with torch_device_fn.device(x.device):
+            _single_group[(m,)](
+                x,
+                scales,
+                values,
+                indices,
+                n,
+                k,
+                triton.next_power_of_2(n),
+                largest,
+                num_warps=2,
+                enable_fp_fusion=False,
+            )
+        return values, indices
+    wide = n > 65535
+    block = min(triton.next_power_of_2(n), max(1024, 2 * triton.next_power_of_2(k)))
+    # Avoid sorting a full 1024-element tile for small K on long rows.
+    if n >= 4096 and k <= 64:
+        block = 256 if k <= 32 else 512
+    parts = triton.cdiv(n, block)
+    # One row per program keeps short-row workloads spread across the CUs.
+    rows = 1 if n <= 128 else (4 if n <= 256 else 1)
+    warps = 2 if n <= 128 or (n >= 4096 and k <= 64) else 4
+    candidate_dtype = torch.uint64 if wide else torch.uint32
+    candidates = (
+        torch.empty((m, parts * k), device=x.device, dtype=candidate_dtype)
+        if parts > 1
+        else values
+    )
+    with torch_device_fn.device(x.device):
+        _select[(triton.cdiv(m, rows), parts)](
+            x,
+            scales,
+            candidates,
+            values,
+            indices,
+            m,
+            n,
+            k,
+            group_size,
+            largest,
+            block,
+            rows,
+            parts,
+            parts == 1,
+            wide,
+            num_warps=warps,
+            enable_fp_fusion=False,
+        )
+        count = parts * k
+        while parts > 1:
+            merge_block = min(
+                triton.next_power_of_2(count), max(2048, 2 * triton.next_power_of_2(k))
+            )
+            parts = triton.cdiv(count, merge_block)
+            dest = (
+                torch.empty((m, parts * k), device=x.device, dtype=candidate_dtype)
+                if parts > 1
+                else values
+            )
+            _merge[(m, parts)](
+                candidates,
+                dest,
+                values,
+                indices,
+                count,
+                k,
+                merge_block,
+                parts,
+                parts == 1,
+                largest,
+                wide,
+                num_warps=4,
+            )
+            candidates = dest
+            count = parts * k
+    return values, indices

--- a/tests/test_topk_w8a16_fp8.py
+++ b/tests/test_topk_w8a16_fp8.py
@@ -23,25 +23,25 @@ FP8_DTYPE = torch.float8_e5m2
 FP8_GROUP_SIZE = 128
 
 
-def _fp8_e5_available():
+def _fp8_available():
     return torch.cuda.is_available() and hasattr(torch, "float8_e5m2")
 
 
-def _quantize_fp8_e5_grouped(x, group_size=FP8_GROUP_SIZE):
-    fp8_info = torch.finfo(FP8_DTYPE)
+def _quantize_fp8_grouped(x, group_size=FP8_GROUP_SIZE, fp8_dtype=FP8_DTYPE):
+    fp8_info = torch.finfo(fp8_dtype)
     *leading, n = x.shape
     padded = (n + group_size - 1) // group_size * group_size
     x_pad = torch.nn.functional.pad(x.float(), (0, padded - n))
     grouped = x_pad.reshape(*leading, padded // group_size, group_size)
     scale = (grouped.abs().amax(dim=-1, keepdim=True) / fp8_info.max).clamp(min=1e-8)
-    q = (grouped / scale).clamp(fp8_info.min, fp8_info.max).to(FP8_DTYPE)
+    q = (grouped / scale).clamp(fp8_info.min, fp8_info.max).to(fp8_dtype)
     return (
         q.reshape(*leading, padded)[..., :n].contiguous(),
         scale.squeeze(-1).to(x.dtype).contiguous(),
     )
 
 
-def _dequant_fp8_e5(x_fp8, x_scale, group_size=FP8_GROUP_SIZE):
+def _dequant_fp8(x_fp8, x_scale, group_size=FP8_GROUP_SIZE):
     *leading, n = x_fp8.shape
     num_groups = x_scale.shape[-1]
     padded = num_groups * group_size
@@ -53,10 +53,10 @@ def _dequant_fp8_e5(x_fp8, x_scale, group_size=FP8_GROUP_SIZE):
 
 @pytest.mark.topk_w8a16_fp8
 @pytest.mark.skipif(
-    getattr(flag_gems, "vendor_name", None) != "thead",
-    reason="topk_w8a16_fp8 is a THead/PPU operator",
+    getattr(flag_gems, "vendor_name", None) not in ("thead", "hygon"),
+    reason="topk_w8a16_fp8 requires an implemented backend",
 )
-@pytest.mark.skipif(not _fp8_e5_available(), reason="float8_e5m2 is unavailable")
+@pytest.mark.skipif(not _fp8_available(), reason="required FP8 format is unavailable")
 @pytest.mark.parametrize(
     "shape, k",
     [
@@ -70,11 +70,29 @@ def _dequant_fp8_e5(x_fp8, x_scale, group_size=FP8_GROUP_SIZE):
     ],
 )
 @pytest.mark.parametrize("largest", [True, False])
-def test_topk_w8a16_fp8(shape, k, largest):
+@pytest.mark.parametrize(
+    "fp8_dtype",
+    [
+        pytest.param(
+            torch.float8_e5m2,
+            marks=pytest.mark.skipif(
+                flag_gems.vendor_name == "hygon", reason="Hygon supports E4M3FN only"
+            ),
+        ),
+        pytest.param(
+            torch.float8_e4m3fn,
+            marks=pytest.mark.skipif(
+                flag_gems.vendor_name != "hygon",
+                reason="E4M3FN extension requires Hygon",
+            ),
+        ),
+    ],
+)
+def test_topk_w8a16_fp8(shape, k, largest, fp8_dtype):
     dtype = torch.bfloat16
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    x_fp8, x_scale = _quantize_fp8_e5_grouped(x)
-    dequant = _dequant_fp8_e5(x_fp8, x_scale)
+    x_fp8, x_scale = _quantize_fp8_grouped(x, fp8_dtype=fp8_dtype)
+    dequant = _dequant_fp8(x_fp8, x_scale)
 
     ref_value, ref_index = torch.topk(
         utils.to_reference(dequant), k, dim=-1, largest=largest, sorted=True
@@ -94,3 +112,184 @@ def test_topk_w8a16_fp8(shape, k, largest):
     # FP8 E5M2 quantization creates many ties; index order among equal
     # values may differ from torch.topk. Check the selected values instead.
     utils.gems_assert_close(torch.gather(dequant, -1, res_index), ref_value, dtype)
+
+
+# Backend extensions stay in the shared operator file. PPU retains its original
+# E5M2/BF16 coverage until these additional contracts are supported there.
+HYGON_ONLY = pytest.mark.skipif(
+    flag_gems.vendor_name != "hygon", reason="Hygon FP8 extensions"
+)
+
+
+def _cpu_dequant(q, scale, group_size, out_dtype):
+    cols = torch.arange(q.shape[-1]) // group_size
+    return (q.cpu().float() * scale.cpu().float()[..., cols]).to(out_dtype)
+
+
+def _check_topk(
+    q, scale, k, group_size=128, out_dtype=torch.bfloat16, largest=True, sorted=True
+):
+    ref = _cpu_dequant(q, scale, group_size, out_dtype)
+    values, indices = flag_gems.topk_w8a16_fp8(
+        q,
+        scale,
+        k,
+        group_size=group_size,
+        out_dtype=out_dtype,
+        largest=largest,
+        sorted=sorted,
+    )
+    expected = torch.topk(ref, k, largest=largest, sorted=True).values
+    torch.testing.assert_close(values.cpu(), expected, rtol=0, atol=0, equal_nan=True)
+    assert indices.dtype == torch.int64
+    torch.testing.assert_close(
+        torch.gather(ref, -1, indices.cpu()),
+        values.cpu(),
+        rtol=0,
+        atol=0,
+        equal_nan=True,
+    )
+    if k > 1:
+        assert (indices.cpu().sort().values.diff() != 0).all()
+    return values, indices
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("largest", [False, True])
+@pytest.mark.parametrize(
+    "shape,k,group_size",
+    [
+        ((257,), 257, 33),
+        ((3, 259), 17, 64),
+        ((2, 2, 1025), 33, 128),
+        ((1, 65537), 8, 128),
+    ],
+)
+def test_topk_fp8_edges(shape, k, group_size, largest, out_dtype, fp8_dtype):
+    torch.manual_seed(5966)
+    q = torch.randn(shape, device=flag_gems.device).to(fp8_dtype)
+    scale = torch.randn(
+        shape[:-1] + ((shape[-1] + group_size - 1) // group_size,), device=q.device
+    )
+    _check_topk(q, scale, k, group_size, out_dtype, largest, sorted=False)
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])
+@pytest.mark.parametrize("largest", [True, False])
+@pytest.mark.parametrize("k", [1, 17, 256])
+def test_topk_fp8_all_encodings(fp8_dtype, largest, k):
+    q = (
+        torch.arange(256, dtype=torch.uint8, device=flag_gems.device)
+        .view(fp8_dtype)
+        .reshape(1, 256)
+    )
+    scale = torch.tensor([[1.0, -2.0]], device=q.device)
+    _check_topk(q, scale, k, largest=largest)
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+@pytest.mark.parametrize("shape,k", [((0, 128), 3), ((3, 0), 0), ((2, 128), 0)])
+def test_topk_fp8_empty(shape, k):
+    q = torch.empty(shape, device=flag_gems.device, dtype=torch.float8_e4m3fn)
+    s = torch.ones(shape[:-1] + ((shape[-1] + 127) // 128,), device=q.device)
+    _check_topk(q, s, k)
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+def test_topk_fp8_strides_graph_and_ties():
+    raw = (
+        torch.arange(4 * 514, device=flag_gems.device)
+        .remainder(120)
+        .byte()
+        .reshape(4, 514)
+    )
+    q = raw[::2, ::2].view(torch.float8_e4m3fn)
+    scale = torch.ones((4, 6), device=q.device)[::2, ::2]
+    _check_topk(q, scale, 17)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            flag_gems.topk_w8a16_fp8(q, scale, 17)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        v, i = flag_gems.topk_w8a16_fp8(q, scale, 17)
+    for change in (0, 1, 2):
+        if change == 0:
+            scale.neg_()
+        if change == 1:
+            raw.zero_()
+        if change == 2:
+            scale.zero_()
+        graph.replay()
+        ref = _cpu_dequant(q, scale, 128, torch.bfloat16)
+        torch.testing.assert_close(v.cpu(), torch.topk(ref, 17).values, rtol=0, atol=0)
+        torch.testing.assert_close(
+            torch.gather(ref, -1, i.cpu()), v.cpu(), rtol=0, atol=0
+        )
+        if change > 0:
+            torch.testing.assert_close(
+                i.cpu(), torch.arange(17).expand(2, 17), rtol=0, atol=0
+            )
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+def test_topk_fp8_validation():
+    q = torch.zeros((2, 128), device=flag_gems.device).to(torch.float8_e4m3fn)
+    s = torch.ones((2, 1), device=q.device)
+    for kwargs in (
+        {"k": -1},
+        {"k": 129},
+        {"k": 1, "dim": 0},
+        {"k": 1, "group_size": 0},
+    ):
+        with pytest.raises(ValueError):
+            flag_gems.topk_w8a16_fp8(q, s, **kwargs)
+    with pytest.raises(ValueError):
+        flag_gems.topk_w8a16_fp8(q, s.expand(2, 2), 1)
+    with pytest.raises(TypeError):
+        flag_gems.topk_w8a16_fp8(q.float(), s, 1)
+    with pytest.raises(TypeError, match="float8_e4m3fn"):
+        flag_gems.topk_w8a16_fp8(q.float().to(torch.float8_e5m2), s, 1)
+    with pytest.raises(TypeError):
+        flag_gems.topk_w8a16_fp8(q, s, 1, out_dtype=torch.float32)
+    with pytest.raises(ValueError):
+        flag_gems.topk_w8a16_fp8(q, s.cpu(), 1)
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+@pytest.mark.parametrize("n,k", [(4097, 32), (32769, 256)])
+@pytest.mark.parametrize("largest", [True, False])
+def test_topk_fp8_partition_tails(n, k, largest):
+    torch.manual_seed(5966)
+    q = torch.randn((2, n), device=flag_gems.device).to(torch.float8_e4m3fn)
+    scale = torch.randn((2, (n + 127) // 128), device=q.device, dtype=torch.float16)
+    _check_topk(q, scale, k, largest=largest)
+
+
+@HYGON_ONLY
+@pytest.mark.topk_w8a16_fp8
+@pytest.mark.parametrize(
+    "scale_value",
+    [1.0, -1.0, 0.0, float("nan"), float("inf"), 1e-35, 1e35, 0.03125, 100.0],
+)
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+def test_topk_fp8_single_group_scales(scale_value, out_dtype):
+    q = (
+        torch.arange(256, device=flag_gems.device, dtype=torch.uint8)
+        .reshape(2, 128)
+        .view(torch.float8_e4m3fn)
+    )
+    scale = torch.full((2, 1), scale_value, device=q.device)
+    for largest in (True, False):
+        _check_topk(q, scale, 17, out_dtype=out_dtype, largest=largest)


### PR DESCRIPTION
## Summary
Adds a Hygon backend for `topk_w8a16_fp8`, following #5966. Input is group-wise FP8 E4M3FN activations plus per-group scales (`group_size=128` by default). The operator dequantizes on the fly and returns FP16/BF16 values and int64 indices along the last dimension.

Small single-group rows use packed E4M3 value/index keys when the scale permits exact A16 ordering; other cases use dequantized A16 keys. Longer rows use partitioned local top-k followed by hierarchical merging. Small-K tile sizes and merge sizes reduce sorting work; direct Triton JIT launches reduce Python launch overhead.

The Hygon implementation accepts E4M3FN only and explicitly rejects E5M2. Existing PPU E5M2 support is preserved. The operator is registered through the Hygon backend.

Only the last dimension is supported. `sorted=False` still returns sorted results. Ties prefer the lower index; signed-zero bits and NaN payloads are not guaranteed. This is a forward-only operator.

## Performance

Measured on Hygon BW (gfx936), using E4M3FN input, BF16 output, `group_size=128`, `largest=True`, and `sorted=True`. The seven benchmark shapes match #5966. Results cover Kernel (`do_bench`) and CUDA Graph execution, compared with Torch BF16 and FlagGems BF16.

Input quantization and BF16 baseline preparation are excluded; FP8 decoding, scaling, and selection are included. Both baselines use the same dequantized BF16 values. Latencies are the median of five rounds for each implementation; speedup is the ratio of those medians. Speedup > 1 means FP8 Gems is faster.

All 140 individual comparisons (7 shapes × 2 modes × 2 baselines × 5 rounds) were >= 1x, including one tie at 1.000x. All median speedups exceed 1x. These results apply to the shapes and settings below.

**bfloat16 vs torch `torch.topk` (Kernel):**

| Shape | Torch (ms) | Gems FP8 (ms) | Speedup |
|---|---|---|---|
| 64x128 k=8 | 0.047680 | 0.008160 | 5.843x |
| 256x256 k=8 | 0.053280 | 0.016320 | 3.265x |
| 128x1024 k=16 | 0.065120 | 0.022080 | 2.949x |
| 64x4096 k=32 | 0.072320 | 0.035520 | 2.036x |
| 32x8192 k=64 | 0.093920 | 0.034240 | 2.743x |
| 16x16384 k=128 | 0.105920 | 0.054080 | 1.959x |
| 8x32768 k=256 | 0.183040 | 0.115520 | 1.584x |
| **Arithmetic Mean** | — | — | **2.91x** |

**bfloat16 vs torch `torch.topk` (CUDA Graph):**

| Shape | Torch (ms) | Gems FP8 (ms) | Speedup |
|---|---|---|---|
| 64x128 k=8 | 0.045233 | 0.004097 | 11.041x |
| 256x256 k=8 | 0.051503 | 0.012110 | 4.253x |
| 128x1024 k=16 | 0.063021 | 0.017623 | 3.576x |
| 64x4096 k=32 | 0.069536 | 0.020358 | 3.416x |
| 32x8192 k=64 | 0.091975 | 0.027373 | 3.360x |
| 16x16384 k=128 | 0.102986 | 0.045127 | 2.282x |
| 8x32768 k=256 | 0.167355 | 0.062278 | 2.687x |
| **Arithmetic Mean** | — | — | **4.37x** |

**bfloat16 vs Gems `flag_gems.topk` (Kernel):**

| Shape | Gems BF16 (ms) | Gems FP8 (ms) | Speedup |
|---|---|---|---|
| 64x128 k=8 | 0.010400 | 0.008480 | 1.226x |
| 256x256 k=8 | 0.018400 | 0.015040 | 1.223x |
| 128x1024 k=16 | 0.040160 | 0.020640 | 1.946x |
| 64x4096 k=32 | 0.124640 | 0.038240 | 3.259x |
| 32x8192 k=64 | 0.247039 | 0.037920 | 6.515x |
| 16x16384 k=128 | 0.540799 | 0.053600 | 10.090x |
| 8x32768 k=256 | 1.737279 | 0.114880 | 15.123x |
| **Arithmetic Mean** | — | — | **5.63x** |

**bfloat16 vs Gems `flag_gems.topk` (CUDA Graph):**

| Shape | Gems BF16 (ms) | Gems FP8 (ms) | Speedup |
|---|---|---|---|
| 64x128 k=8 | 0.006067 | 0.004093 | 1.482x |
| 256x256 k=8 | 0.015442 | 0.012165 | 1.269x |
| 128x1024 k=16 | 0.036299 | 0.017624 | 2.060x |
| 64x4096 k=32 | 0.119672 | 0.020375 | 5.874x |
| 32x8192 k=64 | 0.242896 | 0.027757 | 8.751x |
| 16x16384 k=128 | 0.537691 | 0.045447 | 11.831x |
| 8x32768 k=256 | 1.736568 | 0.062152 | 27.941x |
| **Arithmetic Mean** | — | — | **8.46x** |

**Overall Mean Speedup: 2.91x Kernel / 4.37x Graph vs torch (7 cases); 5.63x Kernel / 8.46x Graph vs Gems BF16 (7 cases).**
