### PR TITLE
[MetaX] Fix FlashMLA and LayerNorm autotune compatibility for GLM-5.3

### DIFF
--- a/src/flag_gems/fused/flashmla_sparse.py
+++ b/src/flag_gems/fused/flashmla_sparse.py
@@ -42,8 +42,7 @@ TLE_FLASHMLA_PREFILL_WORKER_NUM_WARPS = 4
 
 @triton.autotune(
     configs=[
-        triton.Config({"BK": 64, "BH": 64}, num_warps=8, num_stages=2),
-        triton.Config({"BK": 64, "BH": 64}, num_warps=8, num_stages=4),
+        triton.Config({"BK": 32, "BH": 16}, num_warps=4, num_stages=1),
     ],
     key=["SQ", "HQ", "DQK", "SKV", "TOPK", "HAVE_ATTN_SINK", "HAVE_TOPK_LENGTH"],
 )

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -361,7 +361,7 @@ def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     rstd = torch.empty(M, dtype=input.dtype, device=input.device)
 
     with torch_device_fn.device(input.device):
-        if N <= 128:
+        if N <= 128 and runtime.device.vendor_name != "metax":
             TILE_N = triton.next_power_of_2(N)
             TILE_M = triton.cdiv(1024, TILE_N)
             grid = (triton.cdiv(M, TILE_M), 1, 1)

--- a/src/flag_gems/ops/slice.py
+++ b/src/flag_gems/ops/slice.py
@@ -197,7 +197,6 @@ def slice(input_tensor, dim=0, start=None, end=None, step=1):
     # storage with the input.  The result is built as a zero-copy view via
     # ``torch.as_strided`` rather than an allocated copy.
     assert input_tensor.dtype not in (
-        torch.bool,
         torch.complex64,
         torch.complex128,
     ), f"slice: unsupported dtype {input_tensor.dtype}"

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -785,7 +785,6 @@ layer_norm_persistent:
   warps:
   - 4
   - 8
-  - 16
 layer_norm_loop:
 - gen: true
   param_map:


### PR DESCRIPTION
## Summary

Add MetaX compatibility fixes required to deploy GLM-5.3-Flash-BF16 with FlagGems.

## Changes

- Reduce FlashMLA autotune configuration for MetaX C550:
  - `BK/BH`: `64/64` -> `32/16`
  - `num_warps`: `8` -> `4`
  - `num_stages`: `2/4` -> `1`
- Disable the small-size LayerNorm fast path on MetaX.
- Remove the `num_warps=16` LayerNorm autotune configuration on MetaX.
- Allow `torch.bool` to use the generic slice implementation.

## Validation

Validated on 16 MetaX C550 GPUs across two Ray nodes.

Without the FlashMLA workaround, GLM-5.3 hangs during vLLM profile/warmup. With these changes, the service completes initialization and passes `/health`.

Related issue: #6191