### PR TITLE
[Bug Fix] Enable SQLite WAL mode and busy_timeout to fix "database is locked" (backport to 5.4.0-rc1)

### DIFF
--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -62,6 +62,7 @@ class SQLPersistantModel(PersistantModel):
 
         # Enable WAL mode for SQLite to allow concurrent reads and writes
         if "sqlite" in db_url:
+
             @sqlalchemy.event.listens_for(self.engine, "connect")
             def set_sqlite_pragma(dbapi_conn, connection_record):
                 cursor = dbapi_conn.cursor()

--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import sqlalchemy
+import sqlalchemy.event
 import sqlalchemy.ext.automap
 import sqlalchemy.orm
 import triton
@@ -46,7 +47,28 @@ class SQLPersistantModel(PersistantModel):
 
     def __init__(self, db_url: str, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.engine: Final[sqlalchemy.engine.Engine] = sqlalchemy.create_engine(db_url)
+
+        # Configure engine with SQLite-specific connection args for concurrency
+        engine_kwargs = {}
+        if "sqlite" in db_url:
+            engine_kwargs["connect_args"] = {
+                "timeout": 30.0,  # busy_timeout in seconds
+                "check_same_thread": False,
+            }
+
+        self.engine: Final[sqlalchemy.engine.Engine] = sqlalchemy.create_engine(
+            db_url, **engine_kwargs
+        )
+
+        # Enable WAL mode for SQLite to allow concurrent reads and writes
+        if "sqlite" in db_url:
+            @sqlalchemy.event.listens_for(self.engine, "connect")
+            def set_sqlite_pragma(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA synchronous=NORMAL")
+                cursor.close()
+
         self.sql_model_pool: Dict[str, Type[Base]] = {}
 
     @staticmethod


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

Bug Fix

### Description

Backport to `5.4.0-rc1`. Cherry-picked from the master-targeted PR.

多进程共享同一个 SQLite autotune 缓存库时，并发建表/写入会触发 `sqlite3.OperationalError: database is locked`，导致 worker 进程崩溃退出。根因是 SQLite 默认的 rollback journal 模式对整库加写锁、读写互斥，且默认 `busy_timeout=0`，撞锁即立刻抛错。

本 PR 在 `SQLPersistantModel.__init__` 中对 SQLite 后端做两处配置（仅当 `db_url` 含 `sqlite` 时生效，不影响 PostgreSQL 等其它后端）：

- `busy_timeout=30s`（通过 `connect_args` 的 `timeout`）+ `check_same_thread=False`：撞锁时最多等待 30 秒重试，而非立即失败。
- `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL`（通过 `connect` 事件监听器，每条新连接执行）：WAL 模式让读写可并发、显著缩小写锁竞争窗口。

### Issue

- Resolves #6121

该 issue 最初在摩尔线程后端上报，经排查为跨后端的共性问题。我们已在 NVIDIA 环境上复现：多进程（tp=4）共享同一 SQLite 库跑 autotune，稳定复现 `database is locked` 崩溃，崩溃栈落在 `sql.py` 的 `get_sql_model` -> `conn.execute(CreateTable)`，与 issue 中的栈一致。

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

无性能回退。`synchronous=NORMAL` 在 WAL 模式下是安全档位，写入吞吐相比默认 `FULL` 有提升；WAL 让并发读写不再相互阻塞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
