### PR TITLE
[CI Test] Trigger MThreads upsample_linear1d_backward validation

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/upsample_linear1d_backward.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/upsample_linear1d_backward.py
@@ -154,6 +154,7 @@ def _last(x):
 def upsample_linear1d_backward(
     grad_output, output_size, input_size, align_corners, scale_factors=None
 ):
+    # CI probe: schedule the Moore Threads backend test job.
     logger.debug("GEMS_MTHREADS UPSAMPLE_LINEAR1D_BACKWARD")
     if (
         not isinstance(grad_output, torch.Tensor)

--- a/tests/test_upsample_linear1d.py
+++ b/tests/test_upsample_linear1d.py
@@ -160,6 +160,7 @@ def upsample_linear1d_backward_call(grad, input_size, align_corners):
     return out.reshape(orig_shape)
 
 
+# CI probe: schedule the upsample_linear1d_backward changed-test path.
 @pytest.mark.upsample_linear1d_backward
 @pytest.mark.parametrize(
     "shape",


### PR DESCRIPTION
## Purpose

CI-only reproduction for #6207: verify that the current MThreads `upsample_linear1d_backward` can pass the device-native reference but fails the quick CPU reference.

## Changes

- Add one comment to `tests/test_upsample_linear1d.py` so changed-test runs the file.
- Add one comment to the MThreads operator file so triage schedules `backend-tests (mthreads-musa520)`.

There are no runtime or test-semantic changes.