### PR TITLE
fix(ci): stop sort_exports from deleting imports on double __all__

### DIFF
--- a/src/flag_gems/runtime/backend/_enflame/gcu300/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu300/ops/__init__.py
@@ -12,6 +12,236 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ._unsafe_masked_index import _unsafe_masked_index
+from .abs import abs, abs_
+from .add import add, add_
+from .addmm import addmm
+from .addmv import addmv, addmv_out
+from .all import all, all_dim, all_dims
+from .amax import amax
+from .angle import angle
+from .any import any, any_dim, any_dims
+from .arange import arange, arange_start  # noqa: F401
+from .argmax import argmax
+from .argmin import argmin
+from .baddbmm import baddbmm
+from .bincount import bincount
+from .bitwise_and import (
+    bitwise_and_scalar,
+    bitwise_and_scalar_,
+    bitwise_and_scalar_tensor,
+    bitwise_and_tensor,
+    bitwise_and_tensor_,
+)
+from .bitwise_left_shift import bitwise_left_shift, bitwise_left_shift_
+from .bitwise_not import bitwise_not, bitwise_not_  # noqa: F401
+from .bitwise_or import (
+    bitwise_or_scalar,
+    bitwise_or_scalar_,
+    bitwise_or_scalar_tensor,
+    bitwise_or_tensor,
+    bitwise_or_tensor_,
+)
+from .bitwise_right_shift import bitwise_right_shift, bitwise_right_shift_
+from .bitwise_xor import (
+    bitwise_xor_scalar,
+    bitwise_xor_scalar_,
+    bitwise_xor_scalar_tensor,
+    bitwise_xor_tensor,
+    bitwise_xor_tensor_,
+)
+from .bmm import bmm, bmm_out
+from .cat import cat, cat_out
+from .cauchy import cauchy, cauchy_
+from .ceil import ceil, ceil_, ceil_out
+from .celu import celu, celu_
+from .clamp import clamp, clamp_, clamp_tensor, clamp_tensor_
+from .clamp_min import clamp_min, clamp_min_
+from .clip import clip, clip_
+from .concatenate import concatenate
+from .conj_physical import conj_physical
+from .contiguous import contiguous
+from .copy import copy, copy_
+from .cos import cos, cos_
+from .cosh import cosh, cosh_, cosh_out
+from .count_nonzero import count_nonzero
+from .cummax import cummax
+from .cummin import cummin
+from .cumsum import cumsum, cumsum_out, normed_cumsum
+from .diag import diag
+from .diag_embed import diag_embed
+from .diagonal import diagonal_backward
+from .div import (
+    floor_divide,
+    floor_divide_,
+    remainder,
+    remainder_,
+    true_divide,
+    true_divide_,
+    trunc_divide,
+    trunc_divide_,
+)
+from .dropout import dropout
+from .elu import elu
+from .embedding import embedding, embedding_backward
+from .eq import eq, eq_scalar, equal
+from .erf import erf, erf_
+from .exp import exp, exp_, exp_out
+from .exp2 import exp2, exp2_
+from .expm1 import expm1, expm1_, expm1_out
+from .exponential_ import exponential_
+from .eye import eye
+from .eye_m import eye_m
+from .feature_dropout import feature_dropout, feature_dropout_
+from .fill import (
+    fill_scalar,
+    fill_scalar_,
+    fill_scalar_out,
+    fill_tensor,
+    fill_tensor_,
+    fill_tensor_out,
+)
+from .flip import flip
+from .full import full
+from .full_like import full_like
+from .gather import gather, gather_backward
+from .ge import ge, ge_scalar
+from .gelu import gelu, gelu_, gelu_backward
+from .glu import glu
+from .groupnorm import group_norm, group_norm_backward
+from .gt import gt, gt_scalar
+from .hstack import hstack
+from .index import index
+from .index_add import index_add, index_add_
+from .index_put import _index_put_impl_, index_put, index_put_
+from .index_select import index_select
+from .isclose import allclose, isclose
+from .isfinite import isfinite
+from .isin import isin
+from .isinf import isinf
+from .isnan import isnan
+from .kron import kron
+from .layernorm import layer_norm, layer_norm_backward
+from .le import le, le_scalar
+from .lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
+from .linear import linear
+from .linspace import linspace
+from .log import log
+from .log10 import log10, log10_, log10_out
+from .log_sigmoid import log_sigmoid
+from .log_softmax import log_softmax
+from .logaddexp import logaddexp
+from .logical_and import logical_and
+from .logical_not import logical_not
+from .logical_or import logical_or
+from .logical_xor import logical_xor
+from .lt import lt, lt_scalar
+from .masked_fill import masked_fill, masked_fill_
+from .masked_select import masked_select
+from .max import max, max_dim
+from .max_pool2d_with_indices import max_pool2d_backward, max_pool2d_with_indices
+from .max_pool3d_with_indices import max_pool3d_backward, max_pool3d_with_indices
+from .maximum import maximum
+from .mean import mean, mean_dim
+from .min import min, min_dim
+from .minimum import minimum
+from .mm import mm, router_gemm
+from .mul import mul, mul_
+from .multinomial import multinomial
+from .mv import mv
+from .nan_to_num import nan_to_num
+from .nanmedian import nanmedian, nanmedian_dim, nanmedian_dim_values, nanmedian_out
+from .ne import ne, ne_scalar
+from .neg import neg, neg_
+from .nllloss import (
+    nll_loss2d_backward,
+    nll_loss2d_forward,
+    nll_loss_backward,
+    nll_loss_forward,
+)
+from .nonzero import nonzero
+from .nonzero_numpy import nonzero_numpy
+from .normal import (
+    normal_,
+    normal_float_tensor,
+    normal_tensor_float,
+    normal_tensor_tensor,
+)
+from .one_hot import one_hot
+from .ones import ones  # noqa: F401
+from .ones_like import ones_like
+from .outer import outer
+from .pad import pad
+from .per_token_group_quant_fp8 import per_token_group_quant_fp8
+from .poisson import poisson
+from .polar import polar
+from .pow import (
+    pow_scalar,
+    pow_tensor_scalar,
+    pow_tensor_scalar_,
+    pow_tensor_tensor,
+    pow_tensor_tensor_,
+)
+from .prod import prod, prod_dim
+from .rand import rand
+from .rand_like import rand_like
+from .randint_like import randint_like
+from .randn import randn
+from .randn_like import randn_like
+from .randperm import randperm
+from .reciprocal import reciprocal, reciprocal_
+from .relu import relu, relu_
+from .repeat import repeat
+from .repeat_interleave import (
+    repeat_interleave_self_int,
+    repeat_interleave_self_tensor,
+    repeat_interleave_tensor,
+)
+from .replication_pad3d import replication_pad3d
+from .rsqrt import rsqrt, rsqrt_
+from .scatter import scatter, scatter_
+from .scatter_add_ import scatter_add_
+from .scatter_reduce import scatter_reduce, scatter_reduce_, scatter_reduce_out
+from .searchsorted import (
+    searchsorted,
+    searchsorted_out,
+    searchsorted_scalar,
+    searchsorted_scalar_out,
+)
+from .select_scatter import select_scatter
+from .sigmoid import sigmoid, sigmoid_, sigmoid_backward
+from .silu import silu, silu_, silu_backward
+from .sin import sin, sin_
+from .slice_backward import slice_backward
+from .slice_scatter import slice_scatter
+from .softmax import softmax, softmax_backward
+from .softplus import softplus
+from .sort import sort, sort_stable
+from .sqrt import sqrt, sqrt_
+from .sub import sub, sub_
+from .sum import sum, sum_dim, sum_dim_out, sum_out
+from .tanh import tanh, tanh_, tanh_backward
+from .threshold import threshold, threshold_backward
+from .tile import tile
+from .to import to_copy
+from .topk import topk
+from .trace import trace
+from .tril import tril, tril_, tril_out
+from .triu import triu
+from .uniform import uniform_
+from .unique import _unique2, simple_unique_flat, sorted_indices_unique_flat
+from .unique_consecutive import unique_consecutive
+from .unique_dim import unique_dim
+from .upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from .upsample_nearest1d import upsample_nearest1d
+from .upsample_nearest2d import upsample_nearest2d
+from .var_mean import var_mean
+from .vector_norm import vector_norm
+from .vstack import vstack
+from .where import where_scalar_other, where_scalar_self, where_self, where_self_out
+from .zeros import zero_, zeros
+from .zeros_like import zeros_like
+
 __all__ = [
     "_index_put_impl_",
     "_unique2",

--- a/tools/ci_checks/sort_exports.py
+++ b/tools/ci_checks/sort_exports.py
@@ -33,7 +33,6 @@ Usage:
 
 import argparse
 import ast
-import re
 import sys
 from pathlib import Path
 
@@ -61,21 +60,52 @@ def sort_python_all(file_path: Path, fix: bool = False, dry_run: bool = False) -
 
     source = file_path.read_text()
 
-    # Match __all__ = [ ... ]
-    # Use MULTILINE and DOTALL to handle multi-line lists
-    pattern = r"^(__all__\s*=\s*\[)(.*?)(^\])"
-    match = re.search(pattern, source, re.MULTILINE | re.DOTALL)
+    # Locate the module-level `__all__ = [...]` assignment via AST instead of a
+    # regex. A DOTALL regex that looks for the next line-leading "]" can swallow
+    # unrelated code (e.g. all the intervening imports) when a file contains more
+    # than one `__all__` definition, such as an empty `__all__ = []` placeholder
+    # followed later by the real list. Parsing with ast pins the exact node.
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        print(f"❌ {file_path}: cannot parse ({exc})")
+        return False
 
-    if not match:
-        # No __all__ found, that's fine
+    all_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets)
+        and isinstance(node.value, ast.List)
+    ]
+
+    if not all_nodes:
+        # No __all__ list found, that's fine
         return True
 
-    prefix = match.group(1)  # "__all__ = ["
-    content = match.group(2)  # the items
-    suffix = match.group(3)  # "]"
+    if len(all_nodes) > 1:
+        # Multiple `__all__ = [...]` definitions collapse to whichever runs last
+        # at import time and are almost always a mistake. Refuse to rewrite so we
+        # never guess wrong and clobber code between them.
+        lines_at = ", ".join(str(n.lineno) for n in all_nodes)
+        print(
+            f"❌ {file_path}: found {len(all_nodes)} `__all__` list definitions "
+            f"(lines {lines_at}); expected exactly one. Skipping to avoid data loss."
+        )
+        return False
 
-    # Extract all string items (handles both " and ')
-    items = re.findall(r'["\']([^"\']+)["\']', content)
+    node = all_nodes[0]
+    items = [
+        elt.value
+        for elt in node.value.elts
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+    ]
+
+    # Boundaries of the `__all__ = [ ... ]` statement (1-indexed inclusive).
+    node_start = node.lineno - 1
+    node_end = node.end_lineno - 1
+    prefix = "__all__ = ["
+    suffix = "]"
 
     if not items:
         return True
@@ -119,14 +149,14 @@ def sort_python_all(file_path: Path, fix: bool = False, dry_run: bool = False) -
                 break
         return False
 
-    # Detect indent and quote style from existing items
-    lines = content.strip().split("\n")
+    # Detect indent and quote style from the existing __all__ block
+    source_lines = source.split("\n")
+    block_lines = source_lines[node_start : node_end + 1]
     quote = '"'
     indent = 4  # default
-    for line in lines:
+    for line in block_lines[1:]:  # skip the `__all__ = [` line itself
         stripped = line.strip()
-        if stripped:
-            # Use lines with leading whitespace for indent detection
+        if stripped and stripped != "]":
             if line != line.lstrip():
                 indent = len(line) - len(line.lstrip())
             quote = '"' if '"' in stripped else "'"
@@ -134,12 +164,14 @@ def sort_python_all(file_path: Path, fix: bool = False, dry_run: bool = False) -
 
     indent_str = " " * indent
 
-    # Rebuild the __all__ content
-    new_items_lines = [f"{indent_str}{quote}{item}{quote}," for item in sorted_items]
-    new_content = "\n" + "\n".join(new_items_lines) + "\n"
+    # Rebuild only the `__all__ = [ ... ]` statement, replacing it in place by
+    # line range so nothing outside the assignment can be touched.
+    new_block = [prefix]
+    new_block += [f"{indent_str}{quote}{item}{quote}," for item in sorted_items]
+    new_block.append(suffix)
 
-    new_source = (
-        source[: match.start()] + prefix + new_content + suffix + source[match.end() :]
+    new_source = "\n".join(
+        source_lines[:node_start] + new_block + source_lines[node_end + 1 :]
     )
 
     if dry_run:


### PR DESCRIPTION
sort_exports.py located `__all__` with a DOTALL regex `^(__all__\s*=\s*\[)(.*?)(^\])`. When a file has two `__all__` definitions (an empty `__all__ = []` placeholder followed by the real list), the non-greedy match ran from the first `[` to the last line-leading `]`, swallowing every import statement in between and deleting them on --fix.

_enflame/gcu300/ops/__init__.py has exactly this layout, so running --fix wipes all 170 imports while leaving __all__ intact, breaking `import *` and attribute access.

Fixes:
- Locate the module-level `__all__ = [...]` via ast and replace it by line range, so nothing outside the assignment can be touched.
- Refuse to rewrite files with multiple `__all__` list definitions (warn + skip in --fix, fail in --check) to avoid data loss.
- Collapse gcu300's placeholder + real __all__ into a single sorted list, ordered imports then __all__ to match the other backends.
- Drop the now-unused `import re`.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
